### PR TITLE
feat(live-ai): add SD1.5 rendering params and SDXL FaceID support

### DIFF
--- a/src/features/live-ai/api/daydream-update-prompt.ts
+++ b/src/features/live-ai/api/daydream-update-prompt.ts
@@ -3,7 +3,7 @@
  * Uses PATCH /v1/streams/:id (streams.update) per Daydream docs; /beta/streams/:id/prompts returns 404.
  */
 
-import type { LoraDict } from '../types';
+import type { LoraDict, IpAdapterConfig } from '../types';
 
 const DAYDREAM_API_BASE = 'https://api.daydream.live/v1';
 
@@ -18,6 +18,10 @@ export interface UpdatePromptParams {
   guidance_scale?: number;
   /** LoRA path/id -> weight. Updating triggers pipeline reload (~30s). */
   lora_dict?: LoraDict;
+  /** SDXL FaceID: IP adapter configuration. Hot-swappable, no pipeline reload. */
+  ip_adapter?: IpAdapterConfig;
+  /** SDXL FaceID: reference face image URL. */
+  ip_adapter_style_image_url?: string;
 }
 
 /**
@@ -40,6 +44,9 @@ export async function updateDaydreamPrompt(
   if (params.model_id !== undefined) paramsPayload.model_id = params.model_id;
   if (params.guidance_scale != null) paramsPayload.guidance_scale = params.guidance_scale;
   if (params.lora_dict !== undefined) paramsPayload.lora_dict = params.lora_dict;
+  if (params.ip_adapter !== undefined) paramsPayload.ip_adapter = params.ip_adapter;
+  if (params.ip_adapter_style_image_url !== undefined)
+    paramsPayload.ip_adapter_style_image_url = params.ip_adapter_style_image_url;
 
   const body = {
     pipeline: 'streamdiffusion',

--- a/src/features/live-ai/components/live-ai-popover.tsx
+++ b/src/features/live-ai/components/live-ai-popover.tsx
@@ -37,8 +37,10 @@ import {
   getFamilyForModelId,
   getModelLabelForId,
   getTriggerWordsForModelIds,
+  isSD15Model,
+  isSDXLTurboModel,
 } from '../config/curated-loras';
-import type { StreamData, LoraDict } from '../types';
+import type { StreamData, LoraDict, IpAdapterConfig } from '../types';
 
 const MODEL_OPTIONS = [
   { value: 'stabilityai/sd-turbo', label: 'SD 2.1 Turbo' },
@@ -89,6 +91,15 @@ const DEFAULT_STREAM_PARAMS = {
     height: 512,
   },
 };
+
+/** SD1.5-specific stream params per Daydream docs. */
+const SD15_STREAM_PARAMS = {
+  num_inference_steps: 50,
+  t_index_list: [5, 15, 32],
+  use_lcm_lora: true,
+  lcm_lora_id: 'latent-consistency/lcm-lora-sdv1-5',
+  guidance_scale: 1,
+} as const;
 
 const WHIP_PROXY_PREFIX = '/api/whip-proxy';
 
@@ -159,6 +170,10 @@ export function LiveAIPanelContent() {
   const [promptError, setPromptError] = useState<string | null>(null);
   const [loraError, setLoraError] = useState<string | null>(null);
   const [promptApplied, setPromptApplied] = useState(false);
+  const [faceIdEnabled, setFaceIdEnabled] = useState(false);
+  const [faceIdImageUrl, setFaceIdImageUrl] = useState('');
+  const [faceIdUpdating, setFaceIdUpdating] = useState(false);
+  const [faceIdError, setFaceIdError] = useState<string | null>(null);
 
   const daydreamConfigured = isDaydreamConfigured();
   const livepeerConfigured = isLivepeerStudioConfigured();
@@ -200,6 +215,12 @@ export function LiveAIPanelContent() {
         setStreamSource('livepeer');
       } else {
         const lora_dict = loraEntriesToDict(loraEntries);
+        const sd15Extra = isSD15Model(selectedModelId) ? SD15_STREAM_PARAMS : {};
+        const faceIdExtra: Record<string, unknown> = {};
+        if (isSDXLTurboModel(selectedModelId) && faceIdEnabled && faceIdImageUrl.trim()) {
+          faceIdExtra.ip_adapter = { type: 'faceid', scale: 1, enabled: true } satisfies IpAdapterConfig;
+          faceIdExtra.ip_adapter_style_image_url = faceIdImageUrl.trim();
+        }
         const params = {
           ...DEFAULT_STREAM_PARAMS,
           params: {
@@ -207,6 +228,8 @@ export function LiveAIPanelContent() {
             model_id: selectedModelId,
             prompt: prompt.trim() || DEFAULT_STREAM_PARAMS.params.prompt,
             ...(lora_dict && { lora_dict }),
+            ...sd15Extra,
+            ...faceIdExtra,
           },
         };
         data = await createStream(params);
@@ -230,7 +253,7 @@ export function LiveAIPanelContent() {
     } finally {
       setLoading(false);
     }
-  }, [configured, daydreamConfigured, livepeerConfigured, setPermissionsGranted, selectedModelId, prompt, loraEntries]);
+  }, [configured, daydreamConfigured, livepeerConfigured, setPermissionsGranted, selectedModelId, prompt, loraEntries, faceIdEnabled, faceIdImageUrl]);
 
   const handleApplyPrompt = useCallback(async () => {
     if (streamSource !== 'daydream' || !streamData?.id || !prompt.trim()) return;
@@ -269,6 +292,29 @@ export function LiveAIPanelContent() {
       setLoraUpdating(false);
     }
   }, [streamSource, streamData?.id, prompt, loraEntries]);
+
+  const handleApplyFaceId = useCallback(async () => {
+    if (streamSource !== 'daydream' || !streamData?.id) return;
+    if (faceIdEnabled && !faceIdImageUrl.trim()) {
+      setFaceIdError('Provide a reference face image URL.');
+      return;
+    }
+    setFaceIdError(null);
+    setFaceIdUpdating(true);
+    try {
+      await updateDaydreamPrompt(streamData.id, {
+        prompt: (prompt.trim() || DEFAULT_STREAM_PARAMS.params.prompt) ?? '',
+        ip_adapter: { type: 'faceid', scale: 1, enabled: faceIdEnabled },
+        ...(faceIdEnabled && faceIdImageUrl.trim()
+          ? { ip_adapter_style_image_url: faceIdImageUrl.trim() }
+          : {}),
+      });
+    } catch (e) {
+      setFaceIdError(e instanceof Error ? e.message : 'Failed to update FaceID');
+    } finally {
+      setFaceIdUpdating(false);
+    }
+  }, [streamSource, streamData?.id, prompt, faceIdEnabled, faceIdImageUrl]);
 
   const addLoraPreset = useCallback((preset: CuratedLoraPreset) => {
     setLoraEntries((prev) => [...prev, { id: nextLoraId(), path: preset.modelId, scale: preset.defaultScale }]);
@@ -487,6 +533,41 @@ export function LiveAIPanelContent() {
                   <p className="text-xs text-muted-foreground">Trigger words: {triggerHints.join(', ')}</p>
                 )}
               </div>
+              {isSDXLTurboModel(selectedModelId) && (
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <Switch
+                      id="live-ai-faceid"
+                      checked={faceIdEnabled}
+                      onCheckedChange={setFaceIdEnabled}
+                    />
+                    <Label htmlFor="live-ai-faceid" className="text-xs cursor-pointer">
+                      FaceID (IP Adapter)
+                    </Label>
+                  </div>
+                  {faceIdEnabled && (
+                    <>
+                      <input
+                        type="url"
+                        value={faceIdImageUrl}
+                        onChange={(e) => setFaceIdImageUrl(e.target.value)}
+                        placeholder="Reference face image URL"
+                        className="w-full rounded border border-input bg-background px-2 py-1 text-xs"
+                      />
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        className="h-7 text-xs"
+                        onClick={handleApplyFaceId}
+                        disabled={faceIdUpdating || !faceIdImageUrl.trim()}
+                      >
+                        {faceIdUpdating ? 'Applying…' : 'Apply FaceID'}
+                      </Button>
+                      {faceIdError && <p className="text-xs text-destructive">{faceIdError}</p>}
+                    </>
+                  )}
+                </div>
+              )}
             </>
           )}
         </div>

--- a/src/features/live-ai/config/curated-loras.ts
+++ b/src/features/live-ai/config/curated-loras.ts
@@ -177,3 +177,11 @@ export function getTriggerWordsForModelIds(modelIds: string[]): string[] {
     .map((p) => p.triggerWord)
     .filter(Boolean);
 }
+
+export function isSD15Model(modelId: string): boolean {
+  return getFamilyForModelId(modelId) === 'SD1.5';
+}
+
+export function isSDXLTurboModel(modelId: string): boolean {
+  return modelId === 'stabilityai/sdxl-turbo';
+}

--- a/src/features/live-ai/types.ts
+++ b/src/features/live-ai/types.ts
@@ -8,6 +8,13 @@ export type LoraDict = Record<string, number> | null;
  * Params for creating a Daydream stream (MVP: streamdiffusion).
  * See Daydream API / stream create body.
  */
+/** IP adapter config for FaceID (SDXL Turbo). Hot-swappable, no pipeline reload. */
+export interface IpAdapterConfig {
+  type: 'faceid';
+  scale: number;
+  enabled: boolean;
+}
+
 export interface CreateStreamParams {
   pipeline: 'streamdiffusion';
   params: {
@@ -19,6 +26,18 @@ export interface CreateStreamParams {
     height?: number;
     /** LoRA path/id -> weight. Optional; omitted or null = no LoRAs. */
     lora_dict?: LoraDict;
+    /** SD1.5-specific: number of inference steps. */
+    num_inference_steps?: number;
+    /** SD1.5-specific: timestep index list for StreamDiffusion. */
+    t_index_list?: number[];
+    /** SD1.5-specific: enable LCM LoRA acceleration. */
+    use_lcm_lora?: boolean;
+    /** SD1.5-specific: HuggingFace id for LCM LoRA. */
+    lcm_lora_id?: string;
+    /** SDXL FaceID: IP adapter configuration. */
+    ip_adapter?: IpAdapterConfig;
+    /** SDXL FaceID: reference face image URL. */
+    ip_adapter_style_image_url?: string;
   };
 }
 


### PR DESCRIPTION
SD1.5 models (Dreamshaper 8, Open Journey v4) now send required model-specific params (num_inference_steps, t_index_list, use_lcm_lora, lcm_lora_id, guidance_scale) so streams actually render output instead of staying blank.

SDXL Turbo model now shows a FaceID toggle in settings that lets users enable IP adapter with a reference face image URL, sent in both stream create and update calls.