### PR TITLE
fix(generative): make flow screen responsive on mobile

### DIFF
--- a/src/features/generative/components/generative-flow.tsx
+++ b/src/features/generative/components/generative-flow.tsx
@@ -25,41 +25,31 @@ export const FlowStage = memo(function FlowStage() {
   const configured = isEvolinkConfigured();
 
   return (
-    <div className="flex h-full w-full flex-col items-center justify-center gap-6 bg-background p-4">
+    <div className="flex h-full w-full flex-col items-center justify-center gap-4 overflow-y-auto bg-background p-3 sm:gap-6 sm:p-4">
       {!configured && <ApiKeyInput />}
 
-      {/* Three-node horizontal layout */}
-      <div className="flex items-center gap-4">
+      {/* Three-node layout: vertical on mobile, horizontal on desktop */}
+      <div className="flex flex-col items-center gap-3 sm:flex-row sm:gap-4">
         {/* Node A: Start Image */}
         <NodeStart />
 
-        {/* Connector arrow */}
-        <svg width="40" height="2" className="text-border">
-          <line
-            x1="0"
-            y1="1"
-            x2="40"
-            y2="1"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeDasharray="4 4"
-          />
+        {/* Connector: horizontal on desktop, vertical on mobile */}
+        <svg width="40" height="2" className="hidden text-border sm:block">
+          <line x1="0" y1="1" x2="40" y2="1" stroke="currentColor" strokeWidth="2" strokeDasharray="4 4" />
+        </svg>
+        <svg width="2" height="24" className="block text-border sm:hidden">
+          <line x1="1" y1="0" x2="1" y2="24" stroke="currentColor" strokeWidth="2" strokeDasharray="4 4" />
         </svg>
 
         {/* Node B: Video Generation */}
         <NodeBridge onCancelVideo={handleCancelVideo} />
 
-        {/* Connector arrow */}
-        <svg width="40" height="2" className="text-border">
-          <line
-            x1="0"
-            y1="1"
-            x2="40"
-            y2="1"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeDasharray="4 4"
-          />
+        {/* Connector: horizontal on desktop, vertical on mobile */}
+        <svg width="40" height="2" className="hidden text-border sm:block">
+          <line x1="0" y1="1" x2="40" y2="1" stroke="currentColor" strokeWidth="2" strokeDasharray="4 4" />
+        </svg>
+        <svg width="2" height="24" className="block text-border sm:hidden">
+          <line x1="1" y1="0" x2="1" y2="24" stroke="currentColor" strokeWidth="2" strokeDasharray="4 4" />
         </svg>
 
         {/* Node C: End Image (Optional) */}

--- a/src/features/generative/components/generative-flow.tsx
+++ b/src/features/generative/components/generative-flow.tsx
@@ -25,7 +25,7 @@ export const FlowStage = memo(function FlowStage() {
   const configured = isEvolinkConfigured();
 
   return (
-    <div className="flex h-full w-full flex-col items-center justify-center gap-4 overflow-y-auto bg-background p-3 sm:gap-6 sm:p-4">
+    <div className="flex h-full w-full flex-col items-center justify-start gap-4 overflow-y-auto bg-background p-3 sm:justify-center sm:gap-6 sm:p-4">
       {!configured && <ApiKeyInput />}
 
       {/* Three-node layout: vertical on mobile, horizontal on desktop */}
@@ -34,10 +34,10 @@ export const FlowStage = memo(function FlowStage() {
         <NodeStart />
 
         {/* Connector: horizontal on desktop, vertical on mobile */}
-        <svg width="40" height="2" className="hidden text-border sm:block">
+        <svg width="40" height="2" className="hidden text-border sm:block" aria-hidden="true">
           <line x1="0" y1="1" x2="40" y2="1" stroke="currentColor" strokeWidth="2" strokeDasharray="4 4" />
         </svg>
-        <svg width="2" height="24" className="block text-border sm:hidden">
+        <svg width="2" height="24" className="block text-border sm:hidden" aria-hidden="true">
           <line x1="1" y1="0" x2="1" y2="24" stroke="currentColor" strokeWidth="2" strokeDasharray="4 4" />
         </svg>
 
@@ -45,10 +45,10 @@ export const FlowStage = memo(function FlowStage() {
         <NodeBridge onCancelVideo={handleCancelVideo} />
 
         {/* Connector: horizontal on desktop, vertical on mobile */}
-        <svg width="40" height="2" className="hidden text-border sm:block">
+        <svg width="40" height="2" className="hidden text-border sm:block" aria-hidden="true">
           <line x1="0" y1="1" x2="40" y2="1" stroke="currentColor" strokeWidth="2" strokeDasharray="4 4" />
         </svg>
-        <svg width="2" height="24" className="block text-border sm:hidden">
+        <svg width="2" height="24" className="block text-border sm:hidden" aria-hidden="true">
           <line x1="1" y1="0" x2="1" y2="24" stroke="currentColor" strokeWidth="2" strokeDasharray="4 4" />
         </svg>
 

--- a/src/features/generative/components/node-bridge.tsx
+++ b/src/features/generative/components/node-bridge.tsx
@@ -21,7 +21,7 @@ export const NodeBridge = memo(function NodeBridge({ onCancelVideo }: NodeBridge
   return (
     <div className="flex flex-col items-center gap-2">
       <span className="text-xs font-medium text-muted-foreground">Generated Video</span>
-      <div className="relative flex h-40 w-64 items-center justify-center overflow-hidden rounded-lg border border-border bg-black">
+      <div className="relative flex h-28 w-48 items-center justify-center overflow-hidden rounded-lg border border-border bg-black sm:h-40 sm:w-64">
         {resultVideoUrl ? (
           <VideoResultPlayer url={resultVideoUrl} />
         ) : isGenerating ? (
@@ -40,7 +40,7 @@ export const NodeBridge = memo(function NodeBridge({ onCancelVideo }: NodeBridge
         )}
       </div>
 
-      <div className="flex w-64 flex-col gap-1">
+      <div className="flex w-48 flex-col gap-1 sm:w-64">
         <Label htmlFor="video-prompt" className="text-xs">
           Prompt
         </Label>

--- a/src/features/generative/components/node-end.tsx
+++ b/src/features/generative/components/node-end.tsx
@@ -60,7 +60,7 @@ export const NodeEnd = memo(function NodeEnd() {
     <div className="flex flex-col items-center gap-2">
       <span className="text-xs font-medium text-muted-foreground">End Image (Optional)</span>
       <div
-        className={`relative flex h-40 w-40 items-center justify-center rounded-lg border-2 border-dashed transition-colors ${
+        className={`relative flex h-28 w-28 items-center justify-center rounded-lg border-2 border-dashed transition-colors sm:h-40 sm:w-40 ${
           dragOver
             ? 'border-primary bg-primary/10'
             : 'border-border bg-muted/30 hover:border-primary/50'

--- a/src/features/generative/components/node-start.tsx
+++ b/src/features/generative/components/node-start.tsx
@@ -65,7 +65,7 @@ export const NodeStart = memo(function NodeStart() {
     <div className="flex flex-col items-center gap-2">
       <span className="text-xs font-medium text-muted-foreground">Start Image</span>
       <div
-        className={`relative flex h-40 w-40 items-center justify-center rounded-lg border-2 border-dashed transition-colors ${
+        className={`relative flex h-28 w-28 items-center justify-center rounded-lg border-2 border-dashed transition-colors sm:h-40 sm:w-40 ${
           dragOver
             ? 'border-primary bg-primary/10'
             : 'border-border bg-muted/30 hover:border-primary/50'

--- a/src/features/generative/components/render-controls.tsx
+++ b/src/features/generative/components/render-controls.tsx
@@ -107,7 +107,7 @@ export const RenderControls = memo(function RenderControls() {
   return (
     <div className="flex flex-col items-center gap-4">
       {/* Settings row */}
-      <div className="flex flex-wrap items-end justify-center gap-3">
+      <div className="flex w-full flex-wrap items-end justify-center gap-3 px-2 sm:w-auto sm:px-0">
         {/* Speed */}
         <div className="flex flex-col gap-1">
           <Label className="text-xs">Speed</Label>
@@ -199,7 +199,7 @@ export const RenderControls = memo(function RenderControls() {
         onClick={isGenerating ? cancel : handleGenerate}
         disabled={!isGenerating && !canGenerate}
         variant={isGenerating ? 'destructive' : 'default'}
-        className="min-w-[160px]"
+        className="min-w-[140px] sm:min-w-[160px]"
       >
         {isGenerating ? (
           <>


### PR DESCRIPTION
## Summary
- Nodes stack vertically on mobile (below 640px) instead of overflowing horizontally
- SVG connectors switch from horizontal to vertical dashed lines on mobile
- Image nodes shrink from 160x160 to 112x112, video node from 160x256 to 112x192
- Render controls get full-width padding and slightly narrower generate button on mobile
- Outer container scrolls vertically when content exceeds viewport

## Test plan
- [ ] Open flow screen on desktop — layout should be unchanged (horizontal 3-node)
- [ ] Resize to < 640px or use DevTools mobile preset — nodes stack vertically with vertical connectors
- [ ] Verify all controls (dropdowns, slider, switch, generate button) remain usable at 375px width
- [ ] Test drag-and-drop on image nodes still works at mobile size

🤖 Generated with [Claude Code](https://claude.com/claude-code)