### PR TITLE
fix(generative): prevent stale file reference errors in Flow screen

### DIFF
--- a/src/features/generative/components/node-end.tsx
+++ b/src/features/generative/components/node-end.tsx
@@ -14,15 +14,16 @@ export const NodeEnd = memo(function NodeEnd() {
   const handleFile = useCallback(
     async (file: File) => {
       if (!file.type.startsWith('image/')) return;
-      if (endImage?.type === 'file') {
-        URL.revokeObjectURL(endImage.objectUrl);
-      }
       try {
         // Read file data into memory immediately to prevent stale file handle references.
         // Raw File objects can become unreadable when the browser tab goes inactive.
         const buffer = await file.arrayBuffer();
         const blob = new Blob([buffer], { type: file.type });
         const objectUrl = URL.createObjectURL(blob);
+        // Revoke the old URL only after the new one is ready to avoid a broken-image flash.
+        if (endImage?.type === 'file') {
+          URL.revokeObjectURL(endImage.objectUrl);
+        }
         setEndImage({ type: 'file', blob, objectUrl });
       } catch {
         toast.error('Could not read the selected image. Please try again.');

--- a/src/features/generative/components/node-end.tsx
+++ b/src/features/generative/components/node-end.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState, memo } from 'react';
 import { ImagePlus, X } from 'lucide-react';
+import { toast } from 'sonner';
 import { useGenerativeStore } from '../stores/generative-store';
 import { ImageGenDialog } from './image-gen-dialog';
 import type { ImageSource } from '../types';
@@ -11,13 +12,21 @@ export const NodeEnd = memo(function NodeEnd() {
   const [dragOver, setDragOver] = useState(false);
 
   const handleFile = useCallback(
-    (file: File) => {
+    async (file: File) => {
       if (!file.type.startsWith('image/')) return;
       if (endImage?.type === 'file') {
         URL.revokeObjectURL(endImage.objectUrl);
       }
-      const objectUrl = URL.createObjectURL(file);
-      setEndImage({ type: 'file', blob: file, objectUrl });
+      try {
+        // Read file data into memory immediately to prevent stale file handle references.
+        // Raw File objects can become unreadable when the browser tab goes inactive.
+        const buffer = await file.arrayBuffer();
+        const blob = new Blob([buffer], { type: file.type });
+        const objectUrl = URL.createObjectURL(blob);
+        setEndImage({ type: 'file', blob, objectUrl });
+      } catch {
+        toast.error('Could not read the selected image. Please try again.');
+      }
     },
     [setEndImage, endImage],
   );
@@ -79,6 +88,10 @@ export const NodeEnd = memo(function NodeEnd() {
               src={previewUrl}
               alt="End"
               className="h-full w-full rounded-lg object-cover"
+              onError={() => {
+                handleClear();
+                toast.error('Image preview expired. Please re-add the image.');
+              }}
             />
             <button
               onClick={(e) => {

--- a/src/features/generative/components/node-start.tsx
+++ b/src/features/generative/components/node-start.tsx
@@ -19,15 +19,16 @@ export const NodeStart = memo(function NodeStart() {
   const handleFile = useCallback(
     async (file: File) => {
       if (!file.type.startsWith('image/')) return;
-      if (startImage?.type === 'file') {
-        URL.revokeObjectURL(startImage.objectUrl);
-      }
       try {
         // Read file data into memory immediately to prevent stale file handle references.
         // Raw File objects can become unreadable when the browser tab goes inactive.
         const buffer = await file.arrayBuffer();
         const blob = new Blob([buffer], { type: file.type });
         const objectUrl = URL.createObjectURL(blob);
+        // Revoke the old URL only after the new one is ready to avoid a broken-image flash.
+        if (startImage?.type === 'file') {
+          URL.revokeObjectURL(startImage.objectUrl);
+        }
         setStartImage({ type: 'file', blob, objectUrl });
       } catch {
         toast.error('Could not read the selected image. Please try again.');

--- a/src/features/generative/components/node-start.tsx
+++ b/src/features/generative/components/node-start.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useRef, useState, memo } from 'react';
 import { ImagePlus, X } from 'lucide-react';
+import { toast } from 'sonner';
 import { useGenerativeStore } from '../stores/generative-store';
 import { ImageGenDialog } from './image-gen-dialog';
 import type { ImageSource } from '../types';
@@ -16,13 +17,21 @@ export const NodeStart = memo(function NodeStart() {
   const [dragOver, setDragOver] = useState(false);
 
   const handleFile = useCallback(
-    (file: File) => {
+    async (file: File) => {
       if (!file.type.startsWith('image/')) return;
       if (startImage?.type === 'file') {
         URL.revokeObjectURL(startImage.objectUrl);
       }
-      const objectUrl = URL.createObjectURL(file);
-      setStartImage({ type: 'file', blob: file, objectUrl });
+      try {
+        // Read file data into memory immediately to prevent stale file handle references.
+        // Raw File objects can become unreadable when the browser tab goes inactive.
+        const buffer = await file.arrayBuffer();
+        const blob = new Blob([buffer], { type: file.type });
+        const objectUrl = URL.createObjectURL(blob);
+        setStartImage({ type: 'file', blob, objectUrl });
+      } catch {
+        toast.error('Could not read the selected image. Please try again.');
+      }
     },
     [setStartImage, startImage],
   );
@@ -84,6 +93,10 @@ export const NodeStart = memo(function NodeStart() {
               src={previewUrl}
               alt="Start"
               className="h-full w-full rounded-lg object-cover"
+              onError={() => {
+                handleClear();
+                toast.error('Image preview expired. Please re-add the image.');
+              }}
             />
             <button
               onClick={(e) => {

--- a/src/features/generative/components/video-result-player.tsx
+++ b/src/features/generative/components/video-result-player.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react';
+import { toast } from 'sonner';
 
 interface VideoResultPlayerProps {
   url: string;
@@ -15,6 +16,7 @@ export const VideoResultPlayer = memo(function VideoResultPlayer({
       autoPlay
       loop
       playsInline
+      onError={() => toast.error('Failed to load the generated video.')}
     />
   );
 });

--- a/src/features/generative/services/image-upload-service.ts
+++ b/src/features/generative/services/image-upload-service.ts
@@ -25,7 +25,8 @@ function blobToDataUri(blob: Blob): Promise<string> {
         reject(new Error('FileReader did not return a string'));
       }
     };
-    reader.onerror = () => reject(reader.error ?? new Error('FileReader error'));
+    reader.onerror = () =>
+      reject(new Error('The image file could not be read. It may have expired — please re-add the image.'));
     reader.readAsDataURL(blob);
   });
 }


### PR DESCRIPTION
Read image file data into memory immediately on selection via arrayBuffer() instead of storing raw File objects that can become unreadable when the browser tab goes inactive. Add onError handlers to img/video elements for defense-in-depth.

https://claude.ai/code/session_01KCte8YW5xnQJX4jDLuP2yg