### PR TITLE
fix(billing): support ERC-20 gas policies on smart wallet ops

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,12 @@ VITE_DAYDREAM_API_KEY="Your Daydream API Key"
 # Alchemy Account Kit: required for Connect Wallet (embedded wallets, auth modal)
 VITE_ALCHEMY_API_KEY="Your Alchemy API Key"
 VITE_ALCHEMY_POLICY_ID="Your Alchemy Policy ID"
+# Gas policy type. "sponsorship" (default): app sponsors gas. "erc20": the policy
+# above is an Alchemy ERC-20 paymaster policy and users pay gas in USDC — required
+# for ERC-20 policies or Alchemy rejects ops with "erc20 capability is missing".
+# VITE_ALCHEMY_GAS_POLICY_TYPE=erc20
+# Max USDC (6 decimals) spent on gas per operation in erc20 mode. Default 1000000 ($1).
+# VITE_ALCHEMY_GAS_MAX_USDC6=1000000
 # Optional: set to "true" to use mainnet chains (Base, Arbitrum, Story) in dev instead of testnets
 # VITE_USE_MAINNET=true
 # Live AI billing: Arbitrum payment contract and treasury (Phase 1)

--- a/src/config/gas-sponsorship.ts
+++ b/src/config/gas-sponsorship.ts
@@ -1,0 +1,61 @@
+import { toHex } from 'viem';
+import { USDC_ADDRESS_BY_CHAIN_ID } from '@/config/chains';
+
+/**
+ * Gas payment mode for Alchemy smart wallet operations.
+ *
+ * - "sponsorship" (default): the app's gas policy sponsors gas. Nothing extra
+ *   is sent; Account Kit injects the policyId automatically.
+ * - "erc20": the policy in VITE_ALCHEMY_POLICY_ID is an ERC-20 paymaster
+ *   policy (users pay gas in USDC). wallet_prepareCalls must then include the
+ *   `erc20` capability or Alchemy rejects sponsorship with
+ *   "Policy ... is of type ERC20, but erc20 capability is missing".
+ */
+const policyId = import.meta.env.VITE_ALCHEMY_POLICY_ID as string | undefined;
+
+const gasPolicyType = (
+  import.meta.env.VITE_ALCHEMY_GAS_POLICY_TYPE as string | undefined
+)?.toLowerCase();
+
+/** Cap on USDC spent on gas per user operation (6 decimals). Default $1. */
+const DEFAULT_MAX_GAS_USDC6 = 1_000_000n;
+
+function getMaxGasUsdc6(): bigint {
+  const raw = import.meta.env.VITE_ALCHEMY_GAS_MAX_USDC6 as string | undefined;
+  if (raw && /^\d+$/.test(raw)) return BigInt(raw);
+  return DEFAULT_MAX_GAS_USDC6;
+}
+
+export interface Erc20PaymasterCapabilities {
+  paymasterService: {
+    policyId: string;
+    erc20: {
+      tokenAddress: `0x${string}`;
+      maxTokenAmount: `0x${string}`;
+      postOpSettings: { autoApprove: true };
+    };
+  };
+}
+
+/**
+ * Capabilities for wallet_prepareCalls when using an ERC-20 gas policy.
+ * Returns null in sponsorship mode (default) so Account Kit's automatic
+ * policyId injection applies unchanged.
+ */
+export function buildGasPaymasterCapabilities(
+  chainId: number
+): Erc20PaymasterCapabilities | null {
+  if (gasPolicyType !== 'erc20' || !policyId) return null;
+  const tokenAddress = USDC_ADDRESS_BY_CHAIN_ID[chainId];
+  if (!tokenAddress) return null;
+  return {
+    paymasterService: {
+      policyId,
+      erc20: {
+        tokenAddress,
+        maxTokenAmount: toHex(getMaxGasUsdc6()),
+        postOpSettings: { autoApprove: true },
+      },
+    },
+  };
+}

--- a/src/features/credits/hooks/use-credits.ts
+++ b/src/features/credits/hooks/use-credits.ts
@@ -1,12 +1,12 @@
-import { useCallback, useRef } from 'react';
+import { useCallback } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   useAccount,
   useChain,
-  useSendUserOperation,
   useSignMessage,
   useSmartAccountClient,
 } from '@account-kit/react';
+import { useSmartWalletOps } from '@/hooks/use-smart-wallet-ops';
 import { encodeFunctionData, erc20Abi, maxUint256 } from 'viem';
 import { getPaymentContractAddress } from '@/config/billing';
 import { USDC_ADDRESS_BY_CHAIN_ID } from '@/config/chains';
@@ -92,30 +92,7 @@ export function useCredits(): UseCreditsResult {
   const paymentContract = getPaymentContractAddress();
   const usdcAddress = USDC_ADDRESS_BY_CHAIN_ID[ARBITRUM_ONE_CHAIN_ID];
 
-  const pendingPurchaseRef = useRef<{
-    resolve: (hash: string) => void;
-    reject: (error: Error) => void;
-  } | null>(null);
-
-  const { sendUserOperation } = useSendUserOperation({
-    client,
-    waitForTxn: true,
-    onSuccess: (data) => {
-      const hash = data?.hash;
-      if (pendingPurchaseRef.current && hash) {
-        pendingPurchaseRef.current.resolve(hash);
-        pendingPurchaseRef.current = null;
-      }
-    },
-    onError: (err) => {
-      if (pendingPurchaseRef.current) {
-        pendingPurchaseRef.current.reject(
-          err instanceof Error ? err : new Error(String(err))
-        );
-        pendingPurchaseRef.current = null;
-      }
-    },
-  });
+  const { sendOps } = useSmartWalletOps(client ?? undefined);
 
   const { data, isLoading } = useQuery({
     queryKey: ['credits-balance', address],
@@ -162,15 +139,10 @@ export function useCredits(): UseCreditsResult {
           args: [paymentContract, maxUint256],
         });
 
-        const txHash = await new Promise<string>((resolve, reject) => {
-          pendingPurchaseRef.current = { resolve, reject };
-          sendUserOperation({
-            uo: [
-              { target: usdcAddress, data: approveData, value: 0n },
-              { target: paymentContract, data: buyData, value: 0n },
-            ],
-          });
-        });
+        const { txHash } = await sendOps([
+          { target: usdcAddress, data: approveData, value: 0n },
+          { target: paymentContract, data: buyData, value: 0n },
+        ]);
 
         const syncRes = await fetch('/api/credits-sync-purchase', {
           method: 'POST',
@@ -194,7 +166,7 @@ export function useCredits(): UseCreditsResult {
       client,
       paymentContract,
       refreshBalance,
-      sendUserOperation,
+      sendOps,
       usdcAddress,
     ]
   );

--- a/src/features/live-ai/hooks/use-superfluid-billing.ts
+++ b/src/features/live-ai/hooks/use-superfluid-billing.ts
@@ -2,10 +2,10 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   useAccount,
   useChain,
-  useSendUserOperation,
   useSmartAccountClient,
 } from '@account-kit/react';
 import { arbitrum } from 'viem/chains';
+import { useSmartWalletOps } from '@/hooks/use-smart-wallet-ops';
 import {
   getSuperfluidReceiverAddress,
   intervalCostUsdc6ToFlowRate,
@@ -76,25 +76,7 @@ export function useSuperfluidBilling() {
   const flowRateRef = useRef(intervalCostUsdc6ToFlowRate(intervalCostUsdc6));
   flowRateRef.current = intervalCostUsdc6ToFlowRate(intervalCostUsdc6);
 
-  const pendingOpRef = useRef<{
-    resolve: () => void;
-    reject: (error: Error) => void;
-  } | null>(null);
-
-  const { sendUserOperation } = useSendUserOperation({
-    client,
-    waitForTxn: true,
-    onSuccess: () => {
-      pendingOpRef.current?.resolve();
-      pendingOpRef.current = null;
-    },
-    onError: (err) => {
-      pendingOpRef.current?.reject(
-        err instanceof Error ? err : new Error(String(err))
-      );
-      pendingOpRef.current = null;
-    },
-  });
+  const { sendOps } = useSmartWalletOps(client ?? undefined);
 
   const sendOpsRef = useRef<
     (
@@ -104,10 +86,7 @@ export function useSuperfluidBilling() {
 
   sendOpsRef.current = async (uo) => {
     if (!client) throw new Error('Wallet not ready');
-    await new Promise<void>((resolve, reject) => {
-      pendingOpRef.current = { resolve, reject };
-      sendUserOperation({ uo });
-    });
+    await sendOps(uo);
   };
 
   const ensureArbitrum = useCallback(async () => {

--- a/src/hooks/use-smart-wallet-ops.ts
+++ b/src/hooks/use-smart-wallet-ops.ts
@@ -1,0 +1,110 @@
+import { useCallback } from 'react';
+import { useSmartWalletClient } from '@account-kit/react';
+import { toHex } from 'viem';
+import type { Address, Hex } from 'viem';
+import { buildGasPaymasterCapabilities } from '@/config/gas-sponsorship';
+import { createLogger } from '@/shared/logging/logger';
+
+const log = createLogger('smart-wallet-ops');
+
+export interface SmartWalletOp {
+  target: Address;
+  data: Hex;
+  value: bigint;
+}
+
+export interface SendOpsResult {
+  /** Mined transaction hash containing the user operation. */
+  txHash: Hex;
+}
+
+interface ClientWithAccount {
+  account: { address: Address };
+}
+
+type SmartWalletClient = NonNullable<ReturnType<typeof useSmartWalletClient>>;
+type PreparedCalls = Awaited<ReturnType<SmartWalletClient['prepareCalls']>>;
+
+interface PrepareCallsRequest {
+  calls: Array<{ to: Address; data?: Hex; value?: Hex }>;
+  capabilities?: unknown;
+  paymasterPermitSignature?: unknown;
+}
+
+/**
+ * prepareCalls is generic over whether the client is account-bound, which makes
+ * its params type unrepresentable here; the request shape matches the
+ * wallet_prepareCalls wire format documented by Alchemy.
+ */
+function callPrepareCalls(
+  client: { prepareCalls: (params: never) => Promise<PreparedCalls> },
+  request: PrepareCallsRequest
+): Promise<PreparedCalls> {
+  return client.prepareCalls(request as never);
+}
+
+/**
+ * Sends batched calls through the Alchemy Smart Wallets API
+ * (wallet_prepareCalls → sign → wallet_sendPreparedCalls) and waits for the
+ * mined transaction.
+ *
+ * Unlike useSendUserOperation, this passes explicit paymaster capabilities so
+ * ERC-20 gas policies work: Account Kit's default path only injects the
+ * policyId and Alchemy rejects ERC-20 policies with "erc20 capability is
+ * missing". It also handles the paymaster permit round-trip when the gas
+ * policy operates in pre-op (permit) mode.
+ */
+export function useSmartWalletOps(client: ClientWithAccount | undefined) {
+  const smartWalletClient = useSmartWalletClient({
+    account: client?.account.address,
+  });
+
+  const sendOps = useCallback(
+    async (ops: SmartWalletOp[]): Promise<SendOpsResult> => {
+      if (!smartWalletClient) throw new Error('Wallet not ready');
+
+      const capabilities = buildGasPaymasterCapabilities(
+        smartWalletClient.chain.id
+      );
+
+      let prepared = await callPrepareCalls(smartWalletClient, {
+        calls: ops.map((op) => ({
+          to: op.target,
+          data: op.data,
+          value: op.value ? toHex(op.value) : undefined,
+        })),
+        ...(capabilities ? { capabilities } : {}),
+      });
+
+      // ERC-20 gas policies in pre-op mode return a permit signature request
+      // that must be signed and folded back into a second prepareCalls.
+      if (prepared.type === 'paymaster-permit') {
+        log.warn('Paymaster requested ERC-20 permit; signing and re-preparing');
+        const signature = await smartWalletClient.signSignatureRequest(
+          prepared.signatureRequest
+        );
+        prepared = await callPrepareCalls(smartWalletClient, {
+          calls: prepared.modifiedRequest.calls as PrepareCallsRequest['calls'],
+          capabilities: prepared.modifiedRequest.capabilities,
+          paymasterPermitSignature: signature,
+        });
+      }
+
+      const signed = await smartWalletClient.signPreparedCalls(prepared);
+      const { id } = await smartWalletClient.sendPreparedCalls(signed);
+
+      const status = await smartWalletClient.waitForCallsStatus({ id });
+      if (status.status !== 'success') {
+        throw new Error(
+          `Transaction failed (status ${String(status.statusCode)})`
+        );
+      }
+      const txHash = status.receipts?.[0]?.transactionHash;
+      if (!txHash) throw new Error('Transaction confirmed without a receipt');
+      return { txHash };
+    },
+    [smartWalletClient]
+  );
+
+  return { sendOps, ready: Boolean(smartWalletClient) };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Account Kit's `useSendUserOperation` routes through `wallet_prepareCalls` but only injects the `policyId`, so ERC-20 type gas policies fail every operation (credit pack purchases, Superfluid flow start/stop) with "Policy is of type ERC20, but erc20 capability is missing"
- Adds `useSmartWalletOps`: `prepareCalls → sign → sendPreparedCalls → waitForCallsStatus`, passing explicit paymaster capabilities and handling the pre-op paymaster permit round-trip; returns the mined tx hash (needed by credit purchase sync)
- `buildGasPaymasterCapabilities` includes the `erc20` capability (USDC gas token, post-op `autoApprove`, $1 default cap via `VITE_ALCHEMY_GAS_MAX_USDC6`) when `VITE_ALCHEMY_GAS_POLICY_TYPE=erc20`
- Credit pack purchase (`use-credits.ts`) and Superfluid flow ops (`use-superfluid-billing.ts`) now use the new hook

With a regular sponsorship policy (the current setup), behavior is unchanged — the env flag stays unset and Account Kit injects the policy ID as before. This keeps the ERC-20 option available if users should pay their own gas in USDC later.

## Test plan
- [ ] With sponsorship policy (no `VITE_ALCHEMY_GAS_POLICY_TYPE`): buy a credit pack → approve + buyCredits batch lands, credits sync
- [ ] Start/stop a Live AI session → Superfluid flow ops confirm on-chain
- [ ] (Optional) With an ERC-20 policy + `VITE_ALCHEMY_GAS_POLICY_TYPE=erc20`: purchase succeeds with gas paid in USDC
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-74b98123-f89b-4647-9f1c-456ef213ce67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74b98123-f89b-4647-9f1c-456ef213ce67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

