### PR TITLE
fix(credits): resolve serverless crash and improve USDC purchase UX

### DIFF
--- a/api/_address.ts
+++ b/api/_address.ts
@@ -1,0 +1,5 @@
+/** Wallet address validation — no viem or other heavy deps (safe for lightweight serverless routes). */
+
+export const ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
+export const HEX_SIG_REGEX = /^0x[a-fA-F0-9]+$/;
+export const MAX_SIG_AGE_MS = 5 * 60 * 1000;

--- a/api/_credit-store.ts
+++ b/api/_credit-store.ts
@@ -13,7 +13,7 @@ function processedTxKey(txHash: string): string {
 }
 
 export async function getCreditBalance(address: string): Promise<number> {
-  const redis = getRedis();
+  const redis = await getRedis();
   if (!redis) return 0;
   const raw = await redis.get<number>(balanceKey(address));
   if (typeof raw !== 'number' || !Number.isFinite(raw)) return 0;
@@ -35,7 +35,7 @@ export async function creditFromPurchase(
   txHash: string,
   credits: number
 ): Promise<CreditPurchaseResult> {
-  const redis = getRedis();
+  const redis = await getRedis();
   if (!redis) {
     return { ok: false, creditsAdded: 0, balance: 0, reason: 'disabled' };
   }
@@ -77,7 +77,7 @@ export async function addCredits(
   address: string,
   credits: number
 ): Promise<number> {
-  const redis = getRedis();
+  const redis = await getRedis();
   if (!redis || credits <= 0) return await getCreditBalance(address);
   await redis.incrby(balanceKey(address), credits);
   return await getCreditBalance(address);
@@ -91,7 +91,7 @@ export async function debitCredits(
   amount: number,
   idempotencyKey?: string
 ): Promise<DebitResult> {
-  const redis = getRedis();
+  const redis = await getRedis();
   if (!redis) {
     return { ok: false, balance: 0, debited: 0, reason: 'disabled' };
   }

--- a/api/_credit-store.ts
+++ b/api/_credit-store.ts
@@ -44,24 +44,15 @@ export async function creditFromPurchase(
   }
 
   const txKey = processedTxKey(txHash);
-  const already = await redis.get<string>(txKey);
-  if (already) {
-    const balance = await getCreditBalance(address);
-    return { ok: true, creditsAdded: 0, balance, reason: 'already_processed' };
-  }
-
   const balKey = balanceKey(address);
-  const pipeline = redis.pipeline();
-  pipeline.setnx(txKey, '1');
-  pipeline.incrby(balKey, credits);
-  const results = await pipeline.exec();
 
-  const setOk = results[0] === 1;
+  const setOk = await redis.set(txKey, '1', { nx: true });
   if (!setOk) {
     const balance = await getCreditBalance(address);
     return { ok: true, creditsAdded: 0, balance, reason: 'already_processed' };
   }
 
+  await redis.incrby(balKey, credits);
   const balance = await getCreditBalance(address);
   return { ok: true, creditsAdded: credits, balance };
 }

--- a/api/_promo-store.ts
+++ b/api/_promo-store.ts
@@ -33,7 +33,7 @@ export async function createPromoCode(
   code: string,
   meta: PromoCodeMeta
 ): Promise<boolean> {
-  const redis = getRedis();
+  const redis = await getRedis();
   if (!redis) return false;
   const normalized = code.toUpperCase();
   await redis.set(promoMetaKey(normalized), JSON.stringify(meta));
@@ -57,7 +57,7 @@ export async function redeemPromoCode(
   code: string,
   address: string
 ): Promise<RedeemPromoResult> {
-  const redis = getRedis();
+  const redis = await getRedis();
   if (!redis) {
     return { ok: false, creditsGranted: 0, balance: 0, reason: 'disabled' };
   }

--- a/api/_redis-client.ts
+++ b/api/_redis-client.ts
@@ -1,7 +1,6 @@
 type RedisClient = import('@upstash/redis').Redis;
 
 let redisClient: RedisClient | null = null;
-let redisInitAttempted = false;
 let redisInitPromise: Promise<RedisClient | null> | null = null;
 
 /**
@@ -46,11 +45,14 @@ export function isRedisConfigured(): boolean {
 
 /** Shared Redis client for credit ledger, promo codes, etc. Lazy-loads @upstash/redis. */
 export async function getRedis(): Promise<RedisClient | null> {
-  if (redisInitAttempted) return redisClient;
+  if (redisClient) return redisClient;
   if (!redisInitPromise) {
     redisInitPromise = initRedis().then((client) => {
-      redisInitAttempted = true;
-      redisClient = client;
+      if (client) {
+        redisClient = client;
+      } else {
+        redisInitPromise = null;
+      }
       return client;
     });
   }

--- a/api/_redis-client.ts
+++ b/api/_redis-client.ts
@@ -1,7 +1,8 @@
-import { Redis } from '@upstash/redis';
+type RedisClient = import('@upstash/redis').Redis;
 
-let redisClient: Redis | null = null;
+let redisClient: RedisClient | null = null;
 let redisInitAttempted = false;
+let redisInitPromise: Promise<RedisClient | null> | null = null;
 
 /**
  * Resolve Upstash/Vercel KV credentials.
@@ -21,25 +22,37 @@ function resolveRedisCredentials(): { url: string; token: string } | null {
   return { url, token };
 }
 
-/** Shared Redis client for credit ledger, promo codes, etc. */
-export function getRedis(): Redis | null {
-  if (redisInitAttempted) return redisClient;
-  redisInitAttempted = true;
-
+async function initRedis(): Promise<RedisClient | null> {
   const creds = resolveRedisCredentials();
-  if (!creds) {
-    redisClient = null;
-    return null;
-  }
+  if (!creds) return null;
 
   try {
-    redisClient = new Redis({ url: creds.url, token: creds.token });
-  } catch {
-    redisClient = null;
+    const { Redis } = await import('@upstash/redis');
+    try {
+      return Redis.fromEnv();
+    } catch {
+      return new Redis({ url: creds.url, token: creds.token });
+    }
+  } catch (e) {
+    console.error('redis init failed', e);
+    return null;
   }
-  return redisClient;
 }
 
+/** Whether Redis credentials are present (does not load @upstash/redis). */
 export function isRedisConfigured(): boolean {
-  return getRedis() !== null;
+  return resolveRedisCredentials() !== null;
+}
+
+/** Shared Redis client for credit ledger, promo codes, etc. Lazy-loads @upstash/redis. */
+export async function getRedis(): Promise<RedisClient | null> {
+  if (redisInitAttempted) return redisClient;
+  if (!redisInitPromise) {
+    redisInitPromise = initRedis().then((client) => {
+      redisInitAttempted = true;
+      redisClient = client;
+      return client;
+    });
+  }
+  return redisInitPromise;
 }

--- a/api/_wallet-auth.ts
+++ b/api/_wallet-auth.ts
@@ -1,9 +1,11 @@
-import { createPublicClient, http } from 'viem';
-import { arbitrum } from 'viem/chains';
+import type { PublicClient } from 'viem';
+import {
+  ADDRESS_REGEX,
+  HEX_SIG_REGEX,
+  MAX_SIG_AGE_MS,
+} from './_address';
 
-export const ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
-export const HEX_SIG_REGEX = /^0x[a-fA-F0-9]+$/;
-export const MAX_SIG_AGE_MS = 5 * 60 * 1000;
+export { ADDRESS_REGEX, HEX_SIG_REGEX, MAX_SIG_AGE_MS };
 
 function getArbitrumRpcUrl(): string {
   const apiKey =
@@ -12,10 +14,12 @@ function getArbitrumRpcUrl(): string {
   return 'https://arb1.arbitrum.io/rpc';
 }
 
-let publicClient: ReturnType<typeof createPublicClient> | null = null;
+let publicClient: PublicClient | null = null;
 
-function getPublicClient() {
+async function getPublicClient(): Promise<PublicClient> {
   if (!publicClient) {
+    const { createPublicClient, http } = await import('viem');
+    const { arbitrum } = await import('viem/chains');
     publicClient = createPublicClient({
       chain: arbitrum,
       transport: http(getArbitrumRpcUrl()),
@@ -52,7 +56,8 @@ export async function verifyWalletMessage(
   signature: string
 ): Promise<boolean> {
   try {
-    return await getPublicClient().verifyMessage({
+    const client = await getPublicClient();
+    return await client.verifyMessage({
       address: address as `0x${string}`,
       message,
       signature: signature as `0x${string}`,

--- a/api/credits-balance.ts
+++ b/api/credits-balance.ts
@@ -28,7 +28,7 @@ export async function GET(request: Request): Promise<Response> {
     console.error('credits-balance error', e);
     return Response.json(
       { balance: 0, configured: false, degraded: true },
-      { status: 200 }
+      { status: 503 }
     );
   }
 }

--- a/api/credits-balance.ts
+++ b/api/credits-balance.ts
@@ -3,29 +3,32 @@
  * Returns credit balance for a wallet.
  */
 
-import { ADDRESS_REGEX } from './_wallet-auth';
+import { ADDRESS_REGEX } from './_address';
 import { getCreditBalance, isCreditStoreConfigured } from './_credit-store';
 
 export async function GET(request: Request): Promise<Response> {
-  const url = new URL(request.url);
-  const address = url.searchParams.get('address')?.trim() ?? '';
-
-  if (!ADDRESS_REGEX.test(address)) {
-    return Response.json({ error: 'invalid address' }, { status: 400 });
-  }
-
-  if (!isCreditStoreConfigured()) {
-    return Response.json(
-      { balance: 0, configured: false },
-      { status: 200 }
-    );
-  }
-
   try {
+    const url = new URL(request.url);
+    const address = url.searchParams.get('address')?.trim() ?? '';
+
+    if (!ADDRESS_REGEX.test(address)) {
+      return Response.json({ error: 'invalid address' }, { status: 400 });
+    }
+
+    if (!isCreditStoreConfigured()) {
+      return Response.json(
+        { balance: 0, configured: false },
+        { status: 200 }
+      );
+    }
+
     const balance = await getCreditBalance(address);
     return Response.json({ balance, configured: true }, { status: 200 });
   } catch (e) {
     console.error('credits-balance error', e);
-    return Response.json({ error: 'server error' }, { status: 500 });
+    return Response.json(
+      { balance: 0, configured: false, degraded: true },
+      { status: 200 }
+    );
   }
 }

--- a/api/credits-claim-membership.ts
+++ b/api/credits-claim-membership.ts
@@ -104,7 +104,7 @@ export async function POST(request: Request): Promise<Response> {
       );
     }
 
-    const redis = getRedis();
+    const redis = await getRedis();
     if (!redis) {
       return Response.json({ ok: false, reason: 'disabled' }, { status: 503 });
     }

--- a/api/credits-health.ts
+++ b/api/credits-health.ts
@@ -30,13 +30,15 @@ export async function GET(): Promise<Response> {
     console.error('credits-health viem import failed', e);
   }
 
+  const ok = redisConnected || !redisConfigured ? viemOk : false;
+
   return Response.json(
     {
       redisConfigured,
       redisConnected,
       viemOk,
-      ok: redisConnected || !redisConfigured ? viemOk : false,
+      ok,
     },
-    { status: 200 }
+    { status: ok ? 200 : 503 }
   );
 }

--- a/api/credits-health.ts
+++ b/api/credits-health.ts
@@ -1,0 +1,42 @@
+/**
+ * GET /api/credits-health
+ * Diagnostic probe for credits API dependencies (Redis + viem).
+ */
+
+import { isRedisConfigured, getRedis } from './_redis-client';
+
+export async function GET(): Promise<Response> {
+  const redisConfigured = isRedisConfigured();
+  let redisConnected = false;
+  let viemOk = false;
+
+  if (redisConfigured) {
+    try {
+      const redis = await getRedis();
+      if (redis) {
+        await redis.ping();
+        redisConnected = true;
+      }
+    } catch (e) {
+      console.error('credits-health redis ping failed', e);
+    }
+  }
+
+  try {
+    await import('viem');
+    await import('viem/chains');
+    viemOk = true;
+  } catch (e) {
+    console.error('credits-health viem import failed', e);
+  }
+
+  return Response.json(
+    {
+      redisConfigured,
+      redisConnected,
+      viemOk,
+      ok: redisConnected || !redisConfigured ? viemOk : false,
+    },
+    { status: 200 }
+  );
+}

--- a/api/credits-sync-purchase.ts
+++ b/api/credits-sync-purchase.ts
@@ -6,7 +6,7 @@
 
 import { createPublicClient, decodeEventLog, http, parseAbiItem } from 'viem';
 import { arbitrum } from 'viem/chains';
-import { ADDRESS_REGEX } from './_wallet-auth';
+import { ADDRESS_REGEX } from './_address';
 import { creditFromPurchase, isCreditStoreConfigured } from './_credit-store';
 
 const CREDITS_PURCHASED = parseAbiItem(

--- a/src/config/gas-sponsorship.ts
+++ b/src/config/gas-sponsorship.ts
@@ -18,12 +18,19 @@ const gasPolicyType = (
 )?.toLowerCase();
 
 /** Cap on USDC spent on gas per user operation (6 decimals). Default $1. */
-const DEFAULT_MAX_GAS_USDC6 = 1_000_000n;
+export const DEFAULT_MAX_GAS_USDC6 = 1_000_000;
 
 function getMaxGasUsdc6(): bigint {
   const raw = import.meta.env.VITE_ALCHEMY_GAS_MAX_USDC6 as string | undefined;
   if (raw && /^\d+$/.test(raw)) return BigInt(raw);
-  return DEFAULT_MAX_GAS_USDC6;
+  return BigInt(DEFAULT_MAX_GAS_USDC6);
+}
+
+/** Extra USDC (6 decimals) to reserve for ERC-20 gas when buying credit packs. */
+export function getPurchaseGasBufferUsdc6(chainId: number): number {
+  if (gasPolicyType !== 'erc20' || !policyId) return 0;
+  if (!(chainId in USDC_ADDRESS_BY_CHAIN_ID)) return 0;
+  return Number(getMaxGasUsdc6());
 }
 
 export interface Erc20PaymasterCapabilities {

--- a/src/features/credits/components/buy-credits-modal.tsx
+++ b/src/features/credits/components/buy-credits-modal.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { Coins, Loader2 } from 'lucide-react';
+import { useAccount, useChain } from '@account-kit/react';
+import { Coins, DollarSign, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import {
@@ -11,8 +12,35 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { CREDIT_PACKS, useCredits } from '@/features/credits/hooks/use-credits';
-import { formatLiveAiTimeFromCredits } from '@/config/credits';
+import {
+  CREDIT_PACKS,
+  useCredits,
+} from '@/features/credits/hooks/use-credits';
+import {
+  formatLiveAiTimeFromCredits,
+  type CreditPackDefinition,
+} from '@/config/credits';
+import { getPurchaseGasBufferUsdc6 } from '@/config/gas-sponsorship';
+import { useBuyUsdcOnramp } from '@/hooks/use-buy-usdc-onramp';
+import { useUsdcBalance } from '@/hooks/use-usdc-balance';
+
+const ARBITRUM_ONE_CHAIN_ID = 42_161;
+
+function packUsdcRequiredUsdc6(pack: CreditPackDefinition): number {
+  return pack.usdc6 + getPurchaseGasBufferUsdc6(ARBITRUM_ONE_CHAIN_ID);
+}
+
+function hasEnoughUsdc(
+  usdcBalance: string | null,
+  pack: CreditPackDefinition
+): boolean {
+  if (usdcBalance === null) return true;
+  return Number(usdcBalance) * 1_000_000 >= packUsdcRequiredUsdc6(pack);
+}
+
+function formatUsdcRequired(pack: CreditPackDefinition): string {
+  return (packUsdcRequiredUsdc6(pack) / 1_000_000).toFixed(2);
+}
 
 interface BuyCreditsModalProps {
   open: boolean;
@@ -20,12 +48,37 @@ interface BuyCreditsModalProps {
 }
 
 export function BuyCreditsModal({ open, onOpenChange }: BuyCreditsModalProps) {
+  const { address } = useAccount({ type: 'LightAccount' });
+  const { chain } = useChain();
   const { purchasePack } = useCredits();
+  const { balance: usdcBalance, formatted: usdcFormatted } = useUsdcBalance(
+    chain,
+    address as `0x${string}` | undefined
+  );
+  const { openBuyUsdc, isLoading: isOnrampLoading } = useBuyUsdcOnramp();
   const [purchasingId, setPurchasingId] = useState<number | null>(null);
+
+  const onArbitrum = chain?.id === ARBITRUM_ONE_CHAIN_ID;
+  const anyPackUnaffordable =
+    usdcBalance !== null &&
+    CREDIT_PACKS.some((pack) => !hasEnoughUsdc(usdcBalance, pack));
 
   const handleBuy = async (packId: number) => {
     const pack = CREDIT_PACKS.find((p) => p.id === packId);
     if (!pack) return;
+
+    if (!onArbitrum) {
+      toast.error('Switch to Arbitrum to buy credits');
+      return;
+    }
+
+    if (!hasEnoughUsdc(usdcBalance, pack)) {
+      toast.error('Insufficient USDC', {
+        description: `Need ~$${formatUsdcRequired(pack)} USDC on Arbitrum (includes gas). Use Buy USDC first.`,
+      });
+      return;
+    }
+
     setPurchasingId(packId);
     try {
       const result = await purchasePack(pack);
@@ -40,6 +93,10 @@ export function BuyCreditsModal({ open, onOpenChange }: BuyCreditsModalProps) {
     }
   };
 
+  const handleBuyUsdc = () => {
+    void openBuyUsdc({ address: address ?? undefined });
+  };
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
@@ -50,29 +107,70 @@ export function BuyCreditsModal({ open, onOpenChange }: BuyCreditsModalProps) {
           </DialogTitle>
           <DialogDescription>
             Pay with USDC on Arbitrum. Credits unlock Live AI and Flow generation.
+            {usdcBalance !== null && (
+              <span className="mt-1 block tabular-nums">
+                Wallet USDC: {usdcFormatted}
+              </span>
+            )}
           </DialogDescription>
         </DialogHeader>
-        <div className="flex flex-col gap-2">
-          {CREDIT_PACKS.map((pack) => (
+        {!onArbitrum && (
+          <p className="text-xs text-amber-600">
+            Connect on Arbitrum One to purchase credit packs.
+          </p>
+        )}
+        {anyPackUnaffordable && onArbitrum && (
+          <div className="flex items-center justify-between gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs">
+            <span className="text-muted-foreground">
+              Top up USDC before buying — packs need pack price plus gas.
+            </span>
             <Button
-              key={pack.id}
+              type="button"
+              size="sm"
               variant="outline"
-              className="h-auto flex-col items-start gap-0.5 py-3 text-left"
-              disabled={purchasingId !== null}
-              onClick={() => void handleBuy(pack.id)}
+              className="shrink-0 text-xs"
+              disabled={isOnrampLoading}
+              onClick={handleBuyUsdc}
             >
-              <span className="flex w-full items-center justify-between font-medium">
-                {pack.name}
-                <span>${(pack.usdc6 / 1_000_000).toFixed(0)} USDC</span>
-              </span>
-              <span className="text-xs text-muted-foreground">
-                {pack.credits} credits · {pack.description}
-              </span>
-              {purchasingId === pack.id && (
-                <Loader2 className="absolute right-3 h-4 w-4 animate-spin" aria-hidden />
-              )}
+              <DollarSign className="h-3.5 w-3.5" aria-hidden />
+              {isOnrampLoading ? 'Opening…' : 'Buy USDC'}
             </Button>
-          ))}
+          </div>
+        )}
+        <div className="flex flex-col gap-2">
+          {CREDIT_PACKS.map((pack) => {
+            const affordable = hasEnoughUsdc(usdcBalance, pack);
+            return (
+              <Button
+                key={pack.id}
+                variant="outline"
+                className="relative h-auto flex-col items-start gap-0.5 py-3 text-left"
+                disabled={
+                  purchasingId !== null || !onArbitrum || !affordable
+                }
+                onClick={() => void handleBuy(pack.id)}
+              >
+                <span className="flex w-full items-center justify-between font-medium">
+                  {pack.name}
+                  <span>${(pack.usdc6 / 1_000_000).toFixed(0)} USDC</span>
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {pack.credits} credits · {pack.description}
+                </span>
+                {usdcBalance !== null && !affordable && onArbitrum && (
+                  <span className="text-xs text-amber-600">
+                    Need ~${formatUsdcRequired(pack)} USDC total
+                  </span>
+                )}
+                {purchasingId === pack.id && (
+                  <Loader2
+                    className="absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin"
+                    aria-hidden
+                  />
+                )}
+              </Button>
+            );
+          })}
         </div>
       </DialogContent>
     </Dialog>
@@ -85,7 +183,9 @@ interface CreditBalanceBadgeProps {
 }
 
 export function CreditBalanceBadge({ onClick, className }: CreditBalanceBadgeProps) {
-  const { balance, isLoading } = useCredits();
+  const { balance, isLoading, isDegraded } = useCredits();
+
+  const label = isLoading ? '…' : isDegraded ? `${balance} cr?` : `${balance} cr`;
 
   return (
     <button
@@ -95,10 +195,15 @@ export function CreditBalanceBadge({ onClick, className }: CreditBalanceBadgePro
         className ??
         'inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs font-medium tabular-nums hover:bg-muted/50'
       }
-      aria-label="Credit balance"
+      aria-label={
+        isDegraded
+          ? 'Credit balance unavailable — service may be degraded'
+          : 'Credit balance'
+      }
+      title={isDegraded ? 'Credits balance temporarily unavailable' : undefined}
     >
       <Coins className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden />
-      {isLoading ? '…' : `${balance} cr`}
+      {label}
     </button>
   );
 }

--- a/src/features/credits/components/buy-credits-modal.tsx
+++ b/src/features/credits/components/buy-credits-modal.tsx
@@ -34,7 +34,7 @@ function hasEnoughUsdc(
   usdcBalance: string | null,
   pack: CreditPackDefinition
 ): boolean {
-  if (usdcBalance === null) return true;
+  if (usdcBalance === null) return false;
   return Number(usdcBalance) * 1_000_000 >= packUsdcRequiredUsdc6(pack);
 }
 

--- a/src/features/credits/hooks/use-credits.ts
+++ b/src/features/credits/hooks/use-credits.ts
@@ -16,6 +16,7 @@ import {
 } from '@/config/credits';
 import {
   buildBuyCreditsCalldata,
+  classifyPayFailure,
 } from '@/features/credits/api/buy-credits';
 import {
   buildCreditsAuthMessage,
@@ -27,6 +28,7 @@ const ARBITRUM_ONE_CHAIN_ID = 42_161;
 interface BalanceResponse {
   balance: number;
   configured: boolean;
+  degraded?: boolean;
 }
 
 interface DebitResponse {
@@ -60,15 +62,33 @@ interface ClaimMembershipResponse {
 async function fetchBalance(address: `0x${string}`): Promise<BalanceResponse> {
   const url = new URL('/api/credits-balance', window.location.origin);
   url.searchParams.set('address', address);
-  const res = await fetch(url.toString());
-  if (!res.ok) return { balance: 0, configured: false };
-  return (await res.json()) as BalanceResponse;
+  try {
+    const res = await fetch(url.toString());
+    if (!res.ok) {
+      return { balance: 0, configured: false, degraded: true };
+    }
+    return (await res.json()) as BalanceResponse;
+  } catch {
+    return { balance: 0, configured: false, degraded: true };
+  }
+}
+
+function formatPurchaseError(error: unknown): string {
+  const reason = classifyPayFailure(error);
+  if (reason === 'insufficient_balance') {
+    return 'Insufficient USDC on Arbitrum. Use Buy USDC to top up first.';
+  }
+  if (reason === 'session_limit_exceeded') {
+    return 'Session spending limit exceeded. Try again later.';
+  }
+  return error instanceof Error ? error.message : 'Purchase failed';
 }
 
 export interface UseCreditsResult {
   balance: number;
   configured: boolean;
   isLoading: boolean;
+  isDegraded: boolean;
   hasCredits: boolean;
   refreshBalance: () => void;
   purchasePack: (pack: CreditPackDefinition) => Promise<{ ok: boolean; error?: string }>;
@@ -156,8 +176,7 @@ export function useCredits(): UseCreditsResult {
         }
         return { ok: true };
       } catch (e) {
-        const msg = e instanceof Error ? e.message : 'Purchase failed';
-        return { ok: false, error: msg };
+        return { ok: false, error: formatPurchaseError(e) };
       }
     },
     [
@@ -236,11 +255,13 @@ export function useCredits(): UseCreditsResult {
   );
 
   const balance = data?.balance ?? 0;
+  const isDegraded = data?.degraded === true;
 
   return {
     balance,
     configured: data?.configured ?? false,
     isLoading,
+    isDegraded,
     hasCredits: balance > 0,
     refreshBalance,
     purchasePack,


### PR DESCRIPTION
## Summary
- Fix `FUNCTION_INVOCATION_FAILED` on `/api/credits-balance` by removing heavy top-level imports: split address constants into `api/_address.ts`, lazy-load viem in `_wallet-auth.ts`, and lazy-load `@upstash/redis` in `_redis-client.ts`.
- Harden `credits-balance` with full try/catch and a degraded `{ balance: 0, configured: false, degraded: true }` fallback instead of crashing.
- Add `GET /api/credits-health` diagnostic endpoint for post-deploy verification.
- Improve buy-credits UX: USDC pre-flight checks (pack + gas buffer), disabled buttons when underfunded, Buy USDC CTA, and friendly errors via `classifyPayFailure`.

## Test plan
- [ ] Deploy preview/production and confirm `GET /api/credits-health` returns `{ redisConfigured, redisConnected, viemOk, ok }`
- [ ] Confirm `GET /api/credits-balance?address=0x…` returns 200 JSON (not `FUNCTION_INVOCATION_FAILED`)
- [ ] Verify Redis env vars are set in Vercel Production (`UPSTASH_REDIS_REST_*` or `KV_REST_API_*`)
- [ ] Open Buy credits modal with low USDC — packs disabled with "Need ~$X USDC" hint and Buy USDC button
- [ ] Fund wallet via Buy USDC, purchase Starter pack, confirm balance updates after sync


Made with [Cursor](https://cursor.com)