### PR TITLE
fix(credits): harden USDC purchase sync and clarify Flow vs Live AI billing

### DIFF
--- a/api/_credit-packs.ts
+++ b/api/_credit-packs.ts
@@ -1,0 +1,34 @@
+/**
+ * Server-side credit pack definitions. Keep in sync with src/config/credits.ts
+ * and contracts/arbitrum/PaymentContract.sol.
+ */
+
+export interface ServerCreditPack {
+  id: number;
+  usdc6: number;
+  credits: number;
+}
+
+/** Must match on-chain PaymentContract pack ids (0, 1, 2). */
+export const SERVER_CREDIT_PACKS: readonly ServerCreditPack[] = [
+  { id: 0, usdc6: 5_000_000, credits: 50 },
+  { id: 1, usdc6: 15_000_000, credits: 175 },
+  { id: 2, usdc6: 40_000_000, credits: 500 },
+] as const;
+
+export function getServerCreditPack(packId: number): ServerCreditPack | undefined {
+  return SERVER_CREDIT_PACKS.find((p) => p.id === packId);
+}
+
+/**
+ * Validates CreditsPurchased event args against known pack config.
+ */
+export function validateCreditPurchaseEvent(
+  packId: number,
+  credits: number,
+  usdcPaid: number
+): boolean {
+  const pack = getServerCreditPack(packId);
+  if (!pack) return false;
+  return pack.credits === credits && pack.usdc6 === usdcPaid;
+}

--- a/api/credits-claim-membership.ts
+++ b/api/credits-claim-membership.ts
@@ -29,6 +29,7 @@ const PIXELS_PREMIUM_LOCK_DEFAULT =
   '0xE91BD97247fdAd39B95221BC26795a4a4A01B332' as `0x${string}`;
 
 const CLAIM_WINDOW_SECONDS = 30 * 24 * 60 * 60;
+/** Subscriber bonus Flow credits per claim (not Daydream wholesale capacity). Override via MEMBERSHIP_MONTHLY_CREDITS. */
 const DEFAULT_MONTHLY_CREDITS = 100;
 
 function getLockAddress(): `0x${string}` {

--- a/api/credits-sync-purchase.ts
+++ b/api/credits-sync-purchase.ts
@@ -4,9 +4,16 @@
  * Body: { address, txHash }
  */
 
-import { createPublicClient, decodeEventLog, http, parseAbiItem } from 'viem';
+import {
+  createPublicClient,
+  decodeEventLog,
+  http,
+  parseAbiItem,
+  type Log,
+} from 'viem';
 import { arbitrum } from 'viem/chains';
 import { ADDRESS_REGEX } from './_address';
+import { validateCreditPurchaseEvent } from './_credit-packs';
 import { creditFromPurchase, isCreditStoreConfigured } from './_credit-store';
 
 const CREDITS_PURCHASED = parseAbiItem(
@@ -28,6 +35,29 @@ function getArbitrumRpcUrl(): string {
     process.env.ALCHEMY_API_KEY || process.env.VITE_ALCHEMY_API_KEY;
   if (apiKey) return `https://arb-mainnet.g.alchemy.com/v2/${apiKey}`;
   return 'https://arb1.arbitrum.io/rpc';
+}
+
+function findCreditsPurchasedLog(
+  logs: Log[],
+  contractAddress: string
+): ReturnType<typeof decodeEventLog> | null {
+  const target = contractAddress.toLowerCase();
+  for (const log of logs) {
+    if (log.address.toLowerCase() !== target) continue;
+    try {
+      const decoded = decodeEventLog({
+        abi: [CREDITS_PURCHASED],
+        data: log.data,
+        topics: log.topics,
+      });
+      if (decoded.eventName === 'CreditsPurchased') {
+        return decoded;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return null;
 }
 
 export async function POST(request: Request): Promise<Response> {
@@ -79,23 +109,8 @@ export async function POST(request: Request): Promise<Response> {
       return Response.json({ ok: false, reason: 'tx_failed' }, { status: 400 });
     }
 
-    const log = receipt.logs.find(
-      (l) => l.address.toLowerCase() === contractAddress.toLowerCase()
-    );
-    if (!log) {
-      return Response.json(
-        { ok: false, reason: 'event_not_found' },
-        { status: 400 }
-      );
-    }
-
-    const decoded = decodeEventLog({
-      abi: [CREDITS_PURCHASED],
-      data: log.data,
-      topics: log.topics,
-    });
-
-    if (decoded.eventName !== 'CreditsPurchased') {
+    const decoded = findCreditsPurchasedLog(receipt.logs, contractAddress);
+    if (!decoded || decoded.eventName !== 'CreditsPurchased') {
       return Response.json(
         { ok: false, reason: 'event_not_found' },
         { status: 400 }
@@ -103,11 +118,26 @@ export async function POST(request: Request): Promise<Response> {
     }
 
     const buyer = (decoded.args.buyer as string).toLowerCase();
+    const packId = Number(decoded.args.packId);
     const credits = Number(decoded.args.credits);
+    const usdcPaid = Number(decoded.args.usdcPaid);
 
     if (buyer !== address.toLowerCase()) {
       return Response.json(
         { ok: false, reason: 'buyer_mismatch' },
+        { status: 400 }
+      );
+    }
+
+    if (!validateCreditPurchaseEvent(packId, credits, usdcPaid)) {
+      console.error('credits-sync-purchase pack mismatch', {
+        packId,
+        credits,
+        usdcPaid,
+        txHash,
+      });
+      return Response.json(
+        { ok: false, reason: 'pack_mismatch' },
         { status: 400 }
       );
     }

--- a/docs/internal/billing-economics.md
+++ b/docs/internal/billing-economics.md
@@ -1,0 +1,65 @@
+# Internal billing economics
+
+Private ops reference — not user-facing. Do not expose wholesale Daydream capacity in product UI.
+
+## Wholesale (platform operator / Daydream)
+
+| Plan | Monthly cost | Capacity | Approx. runtime |
+|------|--------------|----------|-----------------|
+| Pro  | $10/mo       | 500 credits | ~7 h real-time AI |
+| Max  | $30/mo       | 1,750 credits | ~23 h real-time AI |
+
+These numbers are **your** Daydream invoice basis. They are not retail prices.
+
+## Retail (user-facing, in app)
+
+| Product | Price | What user gets |
+|---------|-------|----------------|
+| Starter credit pack | $5 USDC | 50 Flow credits |
+| Pro credit pack | $15 USDC | 175 Flow credits |
+| Studio credit pack | $40 USDC | 500 Flow credits |
+| Pixels Premium (Unlock) | $30/mo | Premium Live AI USDC rate ($1.50/hr vs $3/hr retail) |
+| Live AI streaming | USDC via Superfluid | Per-second billing; not credits |
+| Membership bonus | Manual claim | `MEMBERSHIP_MONTHLY_CREDITS` (default **100** Flow credits / 30 days) |
+
+Flow credits pay for **Flow image/video generation** only. Live AI requires **USDC streaming**.
+
+## Margin sanity check
+
+- Studio pack: $40 retail for 500 Flow credits vs ~$10/mo wholesale for 500 capacity → healthy markup on pack sales.
+- Live AI retail $3/hr: ~7 h ≈ $21 vs $10 wholesale → margin on non-premium streaming.
+- Live AI premium $1.50/hr: ~7 h ≈ $10.50 vs $10 wholesale → thin; subscription + volume matters.
+
+Target: annual Daydream cost ÷ (pack revenue + Superfluid inflows + Unlock subscription share) ≥ 1.0 plus profit buffer.
+
+## Production env
+
+```bash
+# Credit ledger (required for purchases)
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
+
+# On-chain credit packs (Arbitrum)
+VITE_ARBITRUM_PAYMENT_CONTRACT=
+ARBITRUM_PAYMENT_CONTRACT=
+
+# Subscriber Flow credit bonus — keep at 50–100, NOT wholesale 500/1750
+MEMBERSHIP_MONTHLY_CREDITS=100
+
+# Live AI USDC streaming
+VITE_SUPERFLUID_RECEIVER=
+
+# Unlock $30/mo subscription lock
+VITE_PIXELS_PREMIUM_LOCK_ADDRESS=
+PIXELS_PREMIUM_LOCK_ADDRESS=
+```
+
+## Pre-launch checklist
+
+1. Redis + payment contract env vars set; on-chain packs match `src/config/credits.ts` and `api/_credit-packs.ts`.
+2. Buy Starter ($5): USDC → treasury, balance +50, re-sync idempotent.
+3. Buy Studio ($40): balance +500.
+4. Flow generation debits quoted credits.
+5. Live AI starts only after Superfluid USDC flow (not credit balance).
+6. Active Unlock key: membership claim once per 30 days; second claim rejected.
+7. Simulate sync failure: retry sync with same txHash credits user without double-charge.

--- a/src/config/credits.test.ts
+++ b/src/config/credits.test.ts
@@ -1,11 +1,19 @@
 import { describe, expect, it } from 'vitest';
 import {
+  CREDIT_PACKS,
   quoteNanobananaCredits,
   quoteSeedanceCredits,
   creditsToLiveAiMinutes,
 } from './credits';
 
 describe('credits config', () => {
+  it('defines retail packs aligned with PaymentContract', () => {
+    expect(CREDIT_PACKS).toHaveLength(3);
+    expect(CREDIT_PACKS[0]).toMatchObject({ id: 0, usdc6: 5_000_000, credits: 50 });
+    expect(CREDIT_PACKS[1]).toMatchObject({ id: 1, usdc6: 15_000_000, credits: 175 });
+    expect(CREDIT_PACKS[2]).toMatchObject({ id: 2, usdc6: 40_000_000, credits: 500 });
+  });
+
   it('quotes seedance with quality multiplier', () => {
     const low = quoteSeedanceCredits({
       duration: 5,

--- a/src/config/credits.ts
+++ b/src/config/credits.ts
@@ -7,7 +7,7 @@ import type {
 /** Milli-credits (3 decimal places) for fractional Live AI debits. 1000 milli = 1 credit. */
 export const MILLI_CREDITS_PER_CREDIT = 1000;
 
-/** ~1.11 credits/min → 50 credits ≈ 45 min Live AI. */
+/** ~1.11 credits/min reference rate (legacy Live AI equivalence; Live AI bills USDC via Superfluid). */
 export const LIVE_AI_MILLI_CREDITS_PER_MINUTE = 1110;
 
 /** Debit interval while Live AI is streaming (ms). */
@@ -32,21 +32,21 @@ export const CREDIT_PACKS: readonly CreditPackDefinition[] = [
     name: 'Starter',
     usdc6: 5_000_000,
     credits: 50,
-    description: '~45 min Live AI',
+    description: '~10 Flow image gens',
   },
   {
     id: 1,
     name: 'Pro',
     usdc6: 15_000_000,
     credits: 175,
-    description: '~2.6 hr Live AI',
+    description: '~35 Flow image gens',
   },
   {
     id: 2,
     name: 'Studio',
     usdc6: 40_000_000,
     credits: 500,
-    description: '~7.5 hr Live AI',
+    description: '~100 Flow image gens',
   },
 ] as const;
 
@@ -54,7 +54,7 @@ export function getCreditPack(packId: number): CreditPackDefinition | undefined 
   return CREDIT_PACKS.find((p) => p.id === packId);
 }
 
-/** Estimated Live AI minutes remaining from credit balance. */
+/** Estimated minutes at legacy Live AI credit rate (informational only). */
 export function creditsToLiveAiMinutes(credits: number): number {
   if (credits <= 0) return 0;
   const milli = credits * MILLI_CREDITS_PER_CREDIT;

--- a/src/features/credits/api/sync-purchase.test.ts
+++ b/src/features/credits/api/sync-purchase.test.ts
@@ -71,4 +71,21 @@ describe('syncPurchaseCredits', () => {
     expect(fetch).toHaveBeenCalledTimes(3);
     vi.useRealTimers();
   });
+
+  it('does not mark syncPending for terminal errors', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: false, reason: 'pack_mismatch' }), {
+        status: 400,
+      })
+    );
+
+    const result = await syncPurchaseCredits(
+      '0x1234567890123456789012345678901234567890',
+      '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.syncPending).toBe(false);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/features/credits/api/sync-purchase.test.ts
+++ b/src/features/credits/api/sync-purchase.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { syncPurchaseCredits } from './sync-purchase';
+
+describe('syncPurchaseCredits', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns success on first ok response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ ok: true, creditsAdded: 50, balance: 50 }),
+        { status: 200 }
+      )
+    );
+
+    const result = await syncPurchaseCredits(
+      '0x1234567890123456789012345678901234567890',
+      '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.creditsAdded).toBe(50);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on 500 then succeeds', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: false, reason: 'error' }), {
+          status: 500,
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ ok: true, creditsAdded: 50, balance: 50 }),
+          { status: 200 }
+        )
+      );
+
+    const promise = syncPurchaseCredits(
+      '0x1234567890123456789012345678901234567890',
+      '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+    );
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.ok).toBe(true);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it('marks syncPending after exhausted retries', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ ok: false, reason: 'error' }), {
+        status: 500,
+      })
+    );
+
+    const promise = syncPurchaseCredits(
+      '0x1234567890123456789012345678901234567890',
+      '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+    );
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.ok).toBe(false);
+    expect(result.syncPending).toBe(true);
+    expect(fetch).toHaveBeenCalledTimes(3);
+    vi.useRealTimers();
+  });
+});

--- a/src/features/credits/api/sync-purchase.ts
+++ b/src/features/credits/api/sync-purchase.ts
@@ -21,6 +21,35 @@ function isSyncSuccess(body: SyncPurchaseResponse): boolean {
   return body.ok || body.reason === 'already_processed';
 }
 
+/** Errors where retry will never succeed — do not show sync-pending UX. */
+const TERMINAL_SYNC_REASONS = new Set([
+  'buyer_mismatch',
+  'pack_mismatch',
+  'tx_failed',
+]);
+
+function isRetryableSyncFailure(
+  reason: string | undefined,
+  status: number
+): boolean {
+  if (reason && TERMINAL_SYNC_REASONS.has(reason)) return false;
+  return (
+    reason === 'error' ||
+    reason === 'disabled' ||
+    reason === 'event_not_found' ||
+    reason === 'network_error' ||
+    status >= 500
+  );
+}
+
+function shouldMarkSyncPending(
+  reason: string | undefined,
+  status: number
+): boolean {
+  if (reason && TERMINAL_SYNC_REASONS.has(reason)) return false;
+  return isRetryableSyncFailure(reason, status);
+}
+
 /**
  * Idempotently sync credits from an on-chain buyCredits tx. Retries transient failures.
  */
@@ -48,13 +77,13 @@ export async function syncPurchaseCredits(
         return { ...lastBody, ok: true };
       }
 
-      const retryable =
-        lastBody.reason === 'error' ||
-        lastBody.reason === 'disabled' ||
-        res.status >= 500;
+      const retryable = isRetryableSyncFailure(lastBody.reason, res.status);
 
       if (!retryable || attempt === SYNC_MAX_ATTEMPTS - 1) {
-        return { ...lastBody, syncPending: true };
+        return {
+          ...lastBody,
+          syncPending: shouldMarkSyncPending(lastBody.reason, res.status),
+        };
       }
     } catch {
       if (attempt === SYNC_MAX_ATTEMPTS - 1) {
@@ -71,5 +100,5 @@ export async function syncPurchaseCredits(
     await sleep(SYNC_BACKOFF_MS[attempt] ?? 4_000);
   }
 
-  return { ...lastBody, syncPending: true };
+  return { ...lastBody, syncPending: shouldMarkSyncPending(lastBody.reason, 0) };
 }

--- a/src/features/credits/api/sync-purchase.ts
+++ b/src/features/credits/api/sync-purchase.ts
@@ -1,0 +1,75 @@
+export interface SyncPurchaseResponse {
+  ok: boolean;
+  creditsAdded: number;
+  balance: number;
+  reason?: string;
+}
+
+export interface SyncPurchaseResult extends SyncPurchaseResponse {
+  /** True when on-chain payment succeeded but credits are not yet in Redis. */
+  syncPending?: boolean;
+}
+
+const SYNC_MAX_ATTEMPTS = 3;
+const SYNC_BACKOFF_MS = [1_000, 2_000, 4_000] as const;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isSyncSuccess(body: SyncPurchaseResponse): boolean {
+  return body.ok || body.reason === 'already_processed';
+}
+
+/**
+ * Idempotently sync credits from an on-chain buyCredits tx. Retries transient failures.
+ */
+export async function syncPurchaseCredits(
+  address: `0x${string}`,
+  txHash: `0x${string}`
+): Promise<SyncPurchaseResult> {
+  let lastBody: SyncPurchaseResponse = {
+    ok: false,
+    creditsAdded: 0,
+    balance: 0,
+    reason: 'network_error',
+  };
+
+  for (let attempt = 0; attempt < SYNC_MAX_ATTEMPTS; attempt++) {
+    try {
+      const res = await fetch('/api/credits-sync-purchase', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ address, txHash }),
+      });
+      lastBody = (await res.json()) as SyncPurchaseResponse;
+
+      if (isSyncSuccess(lastBody)) {
+        return { ...lastBody, ok: true };
+      }
+
+      const retryable =
+        lastBody.reason === 'error' ||
+        lastBody.reason === 'disabled' ||
+        res.status >= 500;
+
+      if (!retryable || attempt === SYNC_MAX_ATTEMPTS - 1) {
+        return { ...lastBody, syncPending: true };
+      }
+    } catch {
+      if (attempt === SYNC_MAX_ATTEMPTS - 1) {
+        return {
+          ok: false,
+          creditsAdded: 0,
+          balance: 0,
+          reason: 'network_error',
+          syncPending: true,
+        };
+      }
+    }
+
+    await sleep(SYNC_BACKOFF_MS[attempt] ?? 4_000);
+  }
+
+  return { ...lastBody, syncPending: true };
+}

--- a/src/features/credits/components/buy-credits-modal.tsx
+++ b/src/features/credits/components/buy-credits-modal.tsx
@@ -64,7 +64,6 @@ export function BuyCreditsModal({ open, onOpenChange }: BuyCreditsModalProps) {
 
   useEffect(() => {
     if (!open) {
-      setPendingSync(null);
       setRetryingSync(false);
     }
   }, [open]);
@@ -85,8 +84,13 @@ export function BuyCreditsModal({ open, onOpenChange }: BuyCreditsModalProps) {
         onOpenChange(false);
       } else {
         toast.error(result.error ?? 'Sync failed', {
-          description: 'Your USDC payment was received. Try syncing again.',
+          description: result.syncPending
+            ? 'Your USDC payment was received. Try syncing again.'
+            : 'A terminal error occurred. Please contact support.',
         });
+        if (!result.syncPending) {
+          setPendingSync(null);
+        }
       }
     } finally {
       setRetryingSync(false);
@@ -209,7 +213,11 @@ export function BuyCreditsModal({ open, onOpenChange }: BuyCreditsModalProps) {
                 variant="outline"
                 className="relative h-auto flex-col items-start gap-0.5 py-3 text-left"
                 disabled={
-                  purchasingId !== null || retryingSync || !onArbitrum || !affordable
+                  purchasingId !== null ||
+                  pendingSync !== null ||
+                  retryingSync ||
+                  !onArbitrum ||
+                  !affordable
                 }
                 onClick={() => void handleBuy(pack.id)}
               >

--- a/src/features/credits/components/buy-credits-modal.tsx
+++ b/src/features/credits/components/buy-credits-modal.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useAccount, useChain } from '@account-kit/react';
-import { Coins, DollarSign, Loader2 } from 'lucide-react';
+import { Coins, DollarSign, Loader2, RefreshCw } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import {
@@ -16,15 +16,17 @@ import {
   CREDIT_PACKS,
   useCredits,
 } from '@/features/credits/hooks/use-credits';
-import {
-  formatLiveAiTimeFromCredits,
-  type CreditPackDefinition,
-} from '@/config/credits';
+import { type CreditPackDefinition } from '@/config/credits';
 import { getPurchaseGasBufferUsdc6 } from '@/config/gas-sponsorship';
 import { useBuyUsdcOnramp } from '@/hooks/use-buy-usdc-onramp';
 import { useUsdcBalance } from '@/hooks/use-usdc-balance';
 
 const ARBITRUM_ONE_CHAIN_ID = 42_161;
+
+interface PendingSync {
+  txHash: `0x${string}`;
+  credits: number;
+}
 
 function packUsdcRequiredUsdc6(pack: CreditPackDefinition): number {
   return pack.usdc6 + getPurchaseGasBufferUsdc6(ARBITRUM_ONE_CHAIN_ID);
@@ -50,18 +52,46 @@ interface BuyCreditsModalProps {
 export function BuyCreditsModal({ open, onOpenChange }: BuyCreditsModalProps) {
   const { address } = useAccount({ type: 'LightAccount' });
   const { chain } = useChain();
-  const { purchasePack } = useCredits();
+  const { purchasePack, syncPurchase } = useCredits();
   const { balance: usdcBalance, formatted: usdcFormatted } = useUsdcBalance(
     chain,
     address as `0x${string}` | undefined
   );
   const { openBuyUsdc, isLoading: isOnrampLoading } = useBuyUsdcOnramp();
   const [purchasingId, setPurchasingId] = useState<number | null>(null);
+  const [pendingSync, setPendingSync] = useState<PendingSync | null>(null);
+  const [retryingSync, setRetryingSync] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      setPendingSync(null);
+      setRetryingSync(false);
+    }
+  }, [open]);
 
   const onArbitrum = chain?.id === ARBITRUM_ONE_CHAIN_ID;
   const anyPackUnaffordable =
     usdcBalance !== null &&
     CREDIT_PACKS.some((pack) => !hasEnoughUsdc(usdcBalance, pack));
+
+  const handleRetrySync = async () => {
+    if (!pendingSync) return;
+    setRetryingSync(true);
+    try {
+      const result = await syncPurchase(pendingSync.txHash);
+      if (result.ok) {
+        toast.success(`Added ${pendingSync.credits} credits`);
+        setPendingSync(null);
+        onOpenChange(false);
+      } else {
+        toast.error(result.error ?? 'Sync failed', {
+          description: 'Your USDC payment was received. Try syncing again.',
+        });
+      }
+    } finally {
+      setRetryingSync(false);
+    }
+  };
 
   const handleBuy = async (packId: number) => {
     const pack = CREDIT_PACKS.find((p) => p.id === packId);
@@ -80,11 +110,17 @@ export function BuyCreditsModal({ open, onOpenChange }: BuyCreditsModalProps) {
     }
 
     setPurchasingId(packId);
+    setPendingSync(null);
     try {
       const result = await purchasePack(pack);
       if (result.ok) {
         toast.success(`Added ${pack.credits} credits`);
         onOpenChange(false);
+      } else if (result.syncPending && result.txHash) {
+        setPendingSync({ txHash: result.txHash, credits: pack.credits });
+        toast.warning('Payment received — syncing credits', {
+          description: 'Use Retry sync if credits do not appear shortly.',
+        });
       } else {
         toast.error(result.error ?? 'Purchase failed');
       }
@@ -106,7 +142,8 @@ export function BuyCreditsModal({ open, onOpenChange }: BuyCreditsModalProps) {
             Buy credits
           </DialogTitle>
           <DialogDescription>
-            Pay with USDC on Arbitrum. Credits unlock Live AI and Flow generation.
+            Pay with USDC on Arbitrum for Flow image and video generation. Live AI
+            streams USDC separately — use Buy USDC or Subscribe for streaming.
             {usdcBalance !== null && (
               <span className="mt-1 block tabular-nums">
                 Wallet USDC: {usdcFormatted}
@@ -114,6 +151,32 @@ export function BuyCreditsModal({ open, onOpenChange }: BuyCreditsModalProps) {
             )}
           </DialogDescription>
         </DialogHeader>
+        {pendingSync && (
+          <div className="flex flex-col gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs">
+            <p className="font-medium text-amber-800 dark:text-amber-200">
+              Payment received — credits syncing
+            </p>
+            <p className="text-muted-foreground">
+              Your purchase of {pendingSync.credits} credits is being applied.
+              This is safe to retry — you will not be charged twice.
+            </p>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              className="w-fit text-xs"
+              disabled={retryingSync}
+              onClick={() => void handleRetrySync()}
+            >
+              {retryingSync ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+              ) : (
+                <RefreshCw className="h-3.5 w-3.5" aria-hidden />
+              )}
+              {retryingSync ? 'Syncing…' : 'Retry sync'}
+            </Button>
+          </div>
+        )}
         {!onArbitrum && (
           <p className="text-xs text-amber-600">
             Connect on Arbitrum One to purchase credit packs.
@@ -146,7 +209,7 @@ export function BuyCreditsModal({ open, onOpenChange }: BuyCreditsModalProps) {
                 variant="outline"
                 className="relative h-auto flex-col items-start gap-0.5 py-3 text-left"
                 disabled={
-                  purchasingId !== null || !onArbitrum || !affordable
+                  purchasingId !== null || retryingSync || !onArbitrum || !affordable
                 }
                 onClick={() => void handleBuy(pack.id)}
               >
@@ -209,5 +272,5 @@ export function CreditBalanceBadge({ onClick, className }: CreditBalanceBadgePro
 }
 
 export function formatCreditsSummary(credits: number): string {
-  return `${credits} credits (${formatLiveAiTimeFromCredits(credits)} Live AI)`;
+  return `${credits} Flow credits`;
 }

--- a/src/features/credits/components/insufficient-credits-paywall.tsx
+++ b/src/features/credits/components/insufficient-credits-paywall.tsx
@@ -5,7 +5,6 @@ import { Coins, Gift } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { BuyCreditsModal } from '@/features/credits/components/buy-credits-modal';
 import { RedeemPromoModal } from '@/features/credits/components/redeem-promo-modal';
-import { formatLiveAiTimeFromCredits } from '@/config/credits';
 
 interface InsufficientCreditsPaywallProps {
   /** Optional override message */
@@ -13,10 +12,11 @@ interface InsufficientCreditsPaywallProps {
 }
 
 /**
- * Shown when AI features require credits and balance is zero.
+ * Shown when Flow generation requires credits and balance is zero.
+ * Live AI uses USDC streaming (Superfluid), not credits.
  */
 export function InsufficientCreditsPaywall({
-  message = 'Buy credits or redeem a promo code to use AI features.',
+  message = 'Buy credits or redeem a promo code for Flow image and video generation.',
 }: InsufficientCreditsPaywallProps) {
   const [buyOpen, setBuyOpen] = useState(false);
   const [redeemOpen, setRedeemOpen] = useState(false);
@@ -24,7 +24,7 @@ export function InsufficientCreditsPaywall({
   return (
     <>
       <div className="mb-2 space-y-2 rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-xs">
-        <p className="font-medium">Credits required</p>
+        <p className="font-medium">Flow credits required</p>
         <p className="text-muted-foreground">{message}</p>
         <div className="flex flex-wrap gap-2">
           <Button
@@ -55,7 +55,7 @@ export function InsufficientCreditsPaywall({
 export function CreditsRequiredHint({ creditsNeeded }: { creditsNeeded: number }) {
   return (
     <p className="text-xs text-muted-foreground">
-      Requires {creditsNeeded} credits ({formatLiveAiTimeFromCredits(creditsNeeded)} Live AI equiv.)
+      Requires {creditsNeeded} Flow credits
     </p>
   );
 }

--- a/src/features/credits/hooks/use-credits.ts
+++ b/src/features/credits/hooks/use-credits.ts
@@ -194,7 +194,7 @@ export function useCredits(): UseCreditsResult {
           return {
             ...syncResult,
             txHash,
-            syncPending: syncResult.syncPending ?? true,
+            syncPending: syncResult.syncPending === true,
           };
         }
         return { ok: true, txHash };

--- a/src/features/credits/hooks/use-credits.ts
+++ b/src/features/credits/hooks/use-credits.ts
@@ -18,6 +18,7 @@ import {
   buildBuyCreditsCalldata,
   classifyPayFailure,
 } from '@/features/credits/api/buy-credits';
+import { syncPurchaseCredits } from '@/features/credits/api/sync-purchase';
 import {
   buildCreditsAuthMessage,
   generateCreditsNonce,
@@ -45,11 +46,11 @@ interface RedeemResponse {
   reason?: string;
 }
 
-interface SyncPurchaseResponse {
+export interface PurchasePackResult {
   ok: boolean;
-  creditsAdded: number;
-  balance: number;
-  reason?: string;
+  error?: string;
+  txHash?: `0x${string}`;
+  syncPending?: boolean;
 }
 
 interface ClaimMembershipResponse {
@@ -91,7 +92,9 @@ export interface UseCreditsResult {
   isDegraded: boolean;
   hasCredits: boolean;
   refreshBalance: () => void;
-  purchasePack: (pack: CreditPackDefinition) => Promise<{ ok: boolean; error?: string }>;
+  purchasePack: (pack: CreditPackDefinition) => Promise<PurchasePackResult>;
+  /** Re-sync credits from a completed on-chain buyCredits tx (idempotent). */
+  syncPurchase: (txHash: `0x${string}`) => Promise<PurchasePackResult>;
   debitCredits: (
     amount: number,
     reason: 'live_ai' | 'flow_video' | 'flow_image',
@@ -140,8 +143,30 @@ export function useCredits(): UseCreditsResult {
     [address, client, signMessageAsync]
   );
 
+  const syncPurchase = useCallback(
+    async (txHash: `0x${string}`): Promise<PurchasePackResult> => {
+      if (!address) {
+        return { ok: false, error: 'Connect wallet on Arbitrum' };
+      }
+      const syncBody = await syncPurchaseCredits(address, txHash);
+      refreshBalance();
+      if (syncBody.ok) {
+        return { ok: true, txHash };
+      }
+      return {
+        ok: false,
+        txHash,
+        syncPending: syncBody.syncPending,
+        error: syncBody.syncPending
+          ? 'Payment received — credits are still syncing. Retry in a moment.'
+          : (syncBody.reason ?? 'Sync failed'),
+      };
+    },
+    [address, refreshBalance]
+  );
+
   const purchasePack = useCallback(
-    async (pack: CreditPackDefinition): Promise<{ ok: boolean; error?: string }> => {
+    async (pack: CreditPackDefinition): Promise<PurchasePackResult> => {
       if (!client || !address || chain?.id !== ARBITRUM_ONE_CHAIN_ID) {
         return { ok: false, error: 'Connect wallet on Arbitrum' };
       }
@@ -164,17 +189,15 @@ export function useCredits(): UseCreditsResult {
           { target: paymentContract, data: buyData, value: 0n },
         ]);
 
-        const syncRes = await fetch('/api/credits-sync-purchase', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ address, txHash }),
-        });
-        const syncBody = (await syncRes.json()) as SyncPurchaseResponse;
-        refreshBalance();
-        if (!syncBody.ok) {
-          return { ok: false, error: syncBody.reason ?? 'Sync failed' };
+        const syncResult = await syncPurchase(txHash);
+        if (!syncResult.ok) {
+          return {
+            ...syncResult,
+            txHash,
+            syncPending: syncResult.syncPending ?? true,
+          };
         }
-        return { ok: true };
+        return { ok: true, txHash };
       } catch (e) {
         return { ok: false, error: formatPurchaseError(e) };
       }
@@ -184,8 +207,8 @@ export function useCredits(): UseCreditsResult {
       chain?.id,
       client,
       paymentContract,
-      refreshBalance,
       sendOps,
+      syncPurchase,
       usdcAddress,
     ]
   );
@@ -265,6 +288,7 @@ export function useCredits(): UseCreditsResult {
     hasCredits: balance > 0,
     refreshBalance,
     purchasePack,
+    syncPurchase,
     debitCredits,
     redeemPromo,
     claimMembershipCredits,


### PR DESCRIPTION
## Summary
- Adds automatic retry (3 attempts with backoff) and manual "Retry sync" UX after on-chain credit pack purchases, so USDC payments are not lost when Redis/RPC sync fails.
- Validates `CreditsPurchased` event args server-side against known pack config and scans all contract logs for the event.
- Updates user-facing copy so credits are clearly for Flow image/video generation; Live AI remains USDC streaming via Superfluid.
- Documents internal wholesale vs retail billing economics in `docs/internal/billing-economics.md`.

## Test plan
- [ ] Buy Starter ($5) pack on Arbitrum — confirm +50 credits and idempotent re-sync
- [ ] Simulate sync failure — confirm "Payment received — credits syncing" banner and Retry sync succeeds without double charge
- [ ] Confirm buy modal and paywalls no longer imply credits unlock Live AI
- [ ] Confirm Live AI still requires Superfluid USDC stream before session start
- [ ] Run `npm run test:run -- src/features/credits src/config/credits.test.ts`


Made with [Cursor](https://cursor.com)