### PR TITLE
feat(payments): unify currency labels and reorder wallet menu

### DIFF
--- a/src/components/subscribe-button.tsx
+++ b/src/components/subscribe-button.tsx
@@ -5,6 +5,7 @@ import { Sparkles, Settings2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { usePremiumMembership } from '@/features/live-ai/hooks/use-premium-membership';
 import { useUnlockCheckout } from '@/hooks/use-unlock-checkout';
+import { formatSubscribeCta } from '@/shared/utils/currency-display';
 
 interface SubscribeButtonProps {
   variant?: 'default' | 'outline' | 'ghost' | 'secondary';
@@ -57,7 +58,7 @@ export function SubscribeButton({
       onClick={openSubscribeCheckout}
     >
       <Sparkles className="h-4 w-4 shrink-0" />
-      <span>Subscribe $30/mo</span>
+      <span>{formatSubscribeCta()}</span>
     </Button>
   );
 }

--- a/src/components/subscription-renewal-watcher.tsx
+++ b/src/components/subscription-renewal-watcher.tsx
@@ -11,10 +11,15 @@ import {
 } from '@/infrastructure/unlock/membership';
 import { useUsdcBalance } from '@/hooks/use-usdc-balance';
 import { useUnlockCheckout } from '@/hooks/use-unlock-checkout';
+import {
+  formatUsdRate,
+  LIVE_AI_PREMIUM_HOURLY_USD,
+  PIXELS_PREMIUM_MONTHLY_USD,
+} from '@/shared/utils/currency-display';
 
 const DAY_SECONDS = 86_400;
 const RENEWAL_WINDOW_DAYS = 3;
-const LOW_BALANCE_THRESHOLD_USDC = 30;
+const LOW_BALANCE_THRESHOLD_USDC = PIXELS_PREMIUM_MONTHLY_USD;
 
 interface SubStatus {
   hasValidKey: boolean;
@@ -72,8 +77,7 @@ export function SubscriptionRenewalWatcher() {
     if (keyHadExpired && !shownExpiredRef.current) {
       shownExpiredRef.current = true;
       toast.error('Pixels Premium expired', {
-        description:
-          'Renew to restore the $1.50/hr rate and credit discounts.',
+        description: `Renew to restore the ${formatUsdRate(LIVE_AI_PREMIUM_HOURLY_USD, 'hr')} rate and credit discounts.`,
         action: { label: 'Renew', onClick: openSubscribeCheckout },
         duration: 12_000,
       });

--- a/src/components/wallet-connect-button.tsx
+++ b/src/components/wallet-connect-button.tsx
@@ -41,6 +41,8 @@ import { canAffordAnyCreditPack } from '@/features/credits/usdc-for-purchase';
 import { formatSubscribeCta } from '@/shared/utils/currency-display';
 import { useUsdcBalance } from '@/hooks/use-usdc-balance';
 
+const ARBITRUM_ONE_CHAIN_ID = 42_161;
+
 function truncateAddress(address: string): string {
   if (address.length <= 10) return address;
   return `${address.slice(0, 6)}…${address.slice(-4)}`;
@@ -185,7 +187,8 @@ function WalletConnectButtonInner({
   }
 
   const displayText = address ? truncateAddress(address) : 'Connected';
-  const canBuyCredits = canAffordAnyCreditPack(usdcBalance);
+  const onArbitrum = chain?.id === ARBITRUM_ONE_CHAIN_ID;
+  const canBuyCredits = !onArbitrum || canAffordAnyCreditPack(usdcBalance);
 
   return (
     <>

--- a/src/components/wallet-connect-button.tsx
+++ b/src/components/wallet-connect-button.tsx
@@ -37,6 +37,8 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { alchemyConfig, SWITCHABLE_CHAINS } from '@/config/alchemy';
+import { canAffordAnyCreditPack } from '@/features/credits/usdc-for-purchase';
+import { formatSubscribeCta } from '@/shared/utils/currency-display';
 import { useUsdcBalance } from '@/hooks/use-usdc-balance';
 
 function truncateAddress(address: string): string {
@@ -89,7 +91,7 @@ function WalletConnectButtonInner({
   const { logout } = useLogout();
   const { address } = useAccount({ type: 'LightAccount' });
   const { chain, setChain, isSettingChain } = useChain();
-  const { formatted: usdcFormatted } = useUsdcBalance(
+  const { balance: usdcBalance, formatted: usdcFormatted } = useUsdcBalance(
     chain,
     address as `0x${string}` | undefined
   );
@@ -183,6 +185,7 @@ function WalletConnectButtonInner({
   }
 
   const displayText = address ? truncateAddress(address) : 'Connected';
+  const canBuyCredits = canAffordAnyCreditPack(usdcBalance);
 
   return (
     <>
@@ -210,10 +213,34 @@ function WalletConnectButtonInner({
             </DropdownMenuItem>
           )}
           <DropdownMenuItem disabled className="text-muted-foreground">
+            USDC: {usdcFormatted}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={handleBuyUsdc}
+            disabled={isOnrampLoading}
+            className="flex cursor-pointer items-center gap-2"
+            aria-label="Buy USDC"
+          >
+            <DollarSign className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden />
+            {isOnrampLoading ? 'Opening…' : 'Buy USDC'}
+          </DropdownMenuItem>
+          {isUnlockConfigured && !isPremiumMember && (
+            <DropdownMenuItem
+              onClick={openSubscribeCheckout}
+              className="flex cursor-pointer items-center gap-2"
+              aria-label="Subscribe to Pixels Premium"
+            >
+              <Sparkles className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden />
+              {formatSubscribeCta()}
+            </DropdownMenuItem>
+          )}
+          <DropdownMenuItem disabled className="text-muted-foreground">
             Credits: {creditsLoading ? '…' : `${balance} cr`}
           </DropdownMenuItem>
           <DropdownMenuItem
             onClick={() => setBuyCreditsOpen(true)}
+            disabled={!canBuyCredits}
+            title={canBuyCredits ? undefined : 'Top up USDC on Arbitrum first'}
             className="flex cursor-pointer items-center gap-2"
           >
             <Sparkles className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden />
@@ -226,18 +253,6 @@ function WalletConnectButtonInner({
             <Gift className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden />
             Redeem code
           </DropdownMenuItem>
-          <DropdownMenuItem disabled className="text-muted-foreground">
-            USDC: {usdcFormatted}
-          </DropdownMenuItem>
-        <DropdownMenuItem
-          onClick={handleBuyUsdc}
-          disabled={isOnrampLoading}
-          className="flex cursor-pointer items-center gap-2"
-          aria-label="Buy USDC"
-        >
-          <DollarSign className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden />
-          {isOnrampLoading ? 'Opening…' : 'Buy USDC'}
-        </DropdownMenuItem>
         {isUnlockConfigured && isPaidSubscriber && (
           <DropdownMenuItem
             onClick={() => void handleClaimMembershipCredits()}
@@ -257,16 +272,6 @@ function WalletConnectButtonInner({
           >
             <Settings2 className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden />
             Manage subscription
-          </DropdownMenuItem>
-        )}
-        {isUnlockConfigured && !isPremiumMember && (
-          <DropdownMenuItem
-            onClick={openSubscribeCheckout}
-            className="flex cursor-pointer items-center gap-2"
-            aria-label="Subscribe to Pixels Premium"
-          >
-            <Sparkles className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden />
-            Subscribe $30/mo
           </DropdownMenuItem>
         )}
         <DropdownMenuSeparator />

--- a/src/features/credits/components/buy-credits-modal.tsx
+++ b/src/features/credits/components/buy-credits-modal.tsx
@@ -22,7 +22,7 @@ import {
 } from '@/shared/utils/currency-display';
 import {
   canAffordAnyCreditPack,
-  formatUsdcRequiredForPack,
+  getUsdcRequiredForPack,
   hasEnoughUsdcForPack,
   packUsdcAmount,
 } from '@/features/credits/usdc-for-purchase';
@@ -98,9 +98,9 @@ export function BuyCreditsModal({ open, onOpenChange }: BuyCreditsModalProps) {
     }
 
     if (!hasEnoughUsdcForPack(usdcBalance, pack)) {
-      const required = formatUsdcRequiredForPack(pack);
+      const required = getUsdcRequiredForPack(pack);
       toast.error('Insufficient USDC', {
-        description: `Need ${formatUsdcRequiredApprox(Number(required))} on Arbitrum (includes gas). Use Buy USDC first.`,
+        description: `Need ${formatUsdcRequiredApprox(required)} on Arbitrum (includes gas). Use Buy USDC first.`,
       });
       return;
     }
@@ -222,7 +222,7 @@ export function BuyCreditsModal({ open, onOpenChange }: BuyCreditsModalProps) {
                 </span>
                 {usdcBalance !== null && !affordable && onArbitrum && (
                   <span className="text-xs text-amber-600">
-                    Need {formatUsdcRequiredApprox(Number(formatUsdcRequiredForPack(pack)))}{' '}
+                    Need {formatUsdcRequiredApprox(getUsdcRequiredForPack(pack))}{' '}
                     total
                   </span>
                 )}

--- a/src/features/credits/components/buy-credits-modal.tsx
+++ b/src/features/credits/components/buy-credits-modal.tsx
@@ -18,29 +18,21 @@ import {
 } from '@/features/credits/hooks/use-credits';
 import {
   formatLiveAiTimeFromCredits,
-  type CreditPackDefinition,
 } from '@/config/credits';
-import { getPurchaseGasBufferUsdc6 } from '@/config/gas-sponsorship';
+import {
+  formatUsdcCheckout,
+  formatUsdcRequiredApprox,
+} from '@/shared/utils/currency-display';
+import {
+  canAffordAnyCreditPack,
+  formatUsdcRequiredForPack,
+  hasEnoughUsdcForPack,
+  packUsdcAmount,
+} from '@/features/credits/usdc-for-purchase';
 import { useBuyUsdcOnramp } from '@/hooks/use-buy-usdc-onramp';
 import { useUsdcBalance } from '@/hooks/use-usdc-balance';
 
 const ARBITRUM_ONE_CHAIN_ID = 42_161;
-
-function packUsdcRequiredUsdc6(pack: CreditPackDefinition): number {
-  return pack.usdc6 + getPurchaseGasBufferUsdc6(ARBITRUM_ONE_CHAIN_ID);
-}
-
-function hasEnoughUsdc(
-  usdcBalance: string | null,
-  pack: CreditPackDefinition
-): boolean {
-  if (usdcBalance === null) return false;
-  return Number(usdcBalance) * 1_000_000 >= packUsdcRequiredUsdc6(pack);
-}
-
-function formatUsdcRequired(pack: CreditPackDefinition): string {
-  return (packUsdcRequiredUsdc6(pack) / 1_000_000).toFixed(2);
-}
 
 interface BuyCreditsModalProps {
   open: boolean;
@@ -60,8 +52,7 @@ export function BuyCreditsModal({ open, onOpenChange }: BuyCreditsModalProps) {
 
   const onArbitrum = chain?.id === ARBITRUM_ONE_CHAIN_ID;
   const anyPackUnaffordable =
-    usdcBalance !== null &&
-    CREDIT_PACKS.some((pack) => !hasEnoughUsdc(usdcBalance, pack));
+    usdcBalance !== null && !canAffordAnyCreditPack(usdcBalance);
 
   const handleBuy = async (packId: number) => {
     const pack = CREDIT_PACKS.find((p) => p.id === packId);
@@ -72,9 +63,10 @@ export function BuyCreditsModal({ open, onOpenChange }: BuyCreditsModalProps) {
       return;
     }
 
-    if (!hasEnoughUsdc(usdcBalance, pack)) {
+    if (!hasEnoughUsdcForPack(usdcBalance, pack)) {
+      const required = formatUsdcRequiredForPack(pack);
       toast.error('Insufficient USDC', {
-        description: `Need ~$${formatUsdcRequired(pack)} USDC on Arbitrum (includes gas). Use Buy USDC first.`,
+        description: `Need ${formatUsdcRequiredApprox(Number(required))} on Arbitrum (includes gas). Use Buy USDC first.`,
       });
       return;
     }
@@ -139,7 +131,7 @@ export function BuyCreditsModal({ open, onOpenChange }: BuyCreditsModalProps) {
         )}
         <div className="flex flex-col gap-2">
           {CREDIT_PACKS.map((pack) => {
-            const affordable = hasEnoughUsdc(usdcBalance, pack);
+            const affordable = hasEnoughUsdcForPack(usdcBalance, pack);
             return (
               <Button
                 key={pack.id}
@@ -152,14 +144,15 @@ export function BuyCreditsModal({ open, onOpenChange }: BuyCreditsModalProps) {
               >
                 <span className="flex w-full items-center justify-between font-medium">
                   {pack.name}
-                  <span>${(pack.usdc6 / 1_000_000).toFixed(0)} USDC</span>
+                  <span>{formatUsdcCheckout(packUsdcAmount(pack))}</span>
                 </span>
                 <span className="text-xs text-muted-foreground">
                   {pack.credits} credits · {pack.description}
                 </span>
                 {usdcBalance !== null && !affordable && onArbitrum && (
                   <span className="text-xs text-amber-600">
-                    Need ~${formatUsdcRequired(pack)} USDC total
+                    Need {formatUsdcRequiredApprox(Number(formatUsdcRequiredForPack(pack)))}{' '}
+                    total
                   </span>
                 )}
                 {purchasingId === pack.id && (

--- a/src/features/credits/usdc-for-purchase.ts
+++ b/src/features/credits/usdc-for-purchase.ts
@@ -1,0 +1,30 @@
+import type { CreditPackDefinition } from '@/config/credits';
+import { CREDIT_PACKS } from '@/config/credits';
+import { getPurchaseGasBufferUsdc6 } from '@/config/gas-sponsorship';
+
+const ARBITRUM_ONE_CHAIN_ID = 42_161;
+
+export function packUsdcRequiredUsdc6(pack: CreditPackDefinition): number {
+  return pack.usdc6 + getPurchaseGasBufferUsdc6(ARBITRUM_ONE_CHAIN_ID);
+}
+
+export function hasEnoughUsdcForPack(
+  usdcBalance: string | null,
+  pack: CreditPackDefinition
+): boolean {
+  if (usdcBalance === null) return false;
+  return Number(usdcBalance) * 1_000_000 >= packUsdcRequiredUsdc6(pack);
+}
+
+export function canAffordAnyCreditPack(usdcBalance: string | null): boolean {
+  if (usdcBalance === null) return false;
+  return CREDIT_PACKS.some((pack) => hasEnoughUsdcForPack(usdcBalance, pack));
+}
+
+export function formatUsdcRequiredForPack(pack: CreditPackDefinition): string {
+  return (packUsdcRequiredUsdc6(pack) / 1_000_000).toFixed(2);
+}
+
+export function packUsdcAmount(pack: CreditPackDefinition): number {
+  return pack.usdc6 / 1_000_000;
+}

--- a/src/features/credits/usdc-for-purchase.ts
+++ b/src/features/credits/usdc-for-purchase.ts
@@ -21,8 +21,8 @@ export function canAffordAnyCreditPack(usdcBalance: string | null): boolean {
   return CREDIT_PACKS.some((pack) => hasEnoughUsdcForPack(usdcBalance, pack));
 }
 
-export function formatUsdcRequiredForPack(pack: CreditPackDefinition): string {
-  return (packUsdcRequiredUsdc6(pack) / 1_000_000).toFixed(2);
+export function getUsdcRequiredForPack(pack: CreditPackDefinition): number {
+  return packUsdcRequiredUsdc6(pack) / 1_000_000;
 }
 
 export function packUsdcAmount(pack: CreditPackDefinition): number {

--- a/src/features/live-ai/components/insufficient-balance-paywall.tsx
+++ b/src/features/live-ai/components/insufficient-balance-paywall.tsx
@@ -5,6 +5,11 @@ import { DollarSign, Sparkles } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useBuyUsdcOnramp } from '@/hooks/use-buy-usdc-onramp';
 import { useUnlockCheckout } from '@/hooks/use-unlock-checkout';
+import {
+  formatSubscribeCta,
+  formatUsdRate,
+  LIVE_AI_PREMIUM_HOURLY_USD,
+} from '@/shared/utils/currency-display';
 import { usePremiumMembership } from '../hooks/use-premium-membership';
 
 /**
@@ -30,7 +35,8 @@ export function InsufficientBalancePaywall() {
       <p className="font-medium">Top up USDC on Arbitrum to continue.</p>
       {showSubscribe && (
         <p className="text-muted-foreground">
-          Or subscribe to lock in the $1.50/hr rate — 50% off retail.
+          Or subscribe to lock in the {formatUsdRate(LIVE_AI_PREMIUM_HOURLY_USD, 'hr')}{' '}
+          rate — 50% off retail.
         </p>
       )}
       <div className="flex flex-wrap gap-2">
@@ -51,7 +57,7 @@ export function InsufficientBalancePaywall() {
             onClick={openSubscribeCheckout}
           >
             <Sparkles className="h-3.5 w-3.5" aria-hidden />
-            Subscribe $30/mo
+            {formatSubscribeCta()}
           </Button>
         )}
       </div>

--- a/src/features/live-ai/components/live-ai-popover.tsx
+++ b/src/features/live-ai/components/live-ai-popover.tsx
@@ -43,6 +43,11 @@ import { isSuperfluidConfigured } from '@/config/superfluid';
 import { useLiveAiFunding } from '../hooks/use-live-ai-funding';
 import { useSuperfluidBilling } from '../hooks/use-superfluid-billing';
 import { UsageMeter } from './usage-meter';
+import {
+  formatUsdPrice,
+  formatUsdRate,
+  LIVE_AI_DAILY_SPEND_CAP_USD,
+} from '@/shared/utils/currency-display';
 import type { StreamData, LoraDict, IpAdapterConfig } from '../types';
 
 // Dreamshaper 8 and Open Journey v4 are temporarily hidden: they fail to cold-start reliably.
@@ -535,7 +540,7 @@ export function LiveAIPanelContent() {
               <p className="text-xs text-muted-foreground mb-2">
                 Camera will be used for AI generation. Live AI bills USDC per second via Superfluid
                 {hourlyUsdc > 0 && !fundingLoading
-                  ? ` (~$${hourlyUsdc.toFixed(2)}/hr${isPremiumMember ? ', premium rate' : ''}).`
+                  ? ` (~${formatUsdRate(hourlyUsdc, 'hr')}${isPremiumMember ? ', premium rate' : ''}).`
                   : '.'}{' '}
                 The payment stream is confirmed on-chain first; the AI session
                 starts only after that.
@@ -1173,8 +1178,8 @@ function LiveAISessionWithBroadcastCore({
         <div className="mb-2 p-2 rounded-md bg-destructive/10 border border-destructive/20 text-xs">
           {billingError === 'session_limit_exceeded' && (
             <p>
-              You&apos;ve hit the $50 daily spend cap. Re-authorize your session
-              key to continue, or wait until the cap resets.
+              You&apos;ve hit the {formatUsdPrice(LIVE_AI_DAILY_SPEND_CAP_USD)} daily spend
+              cap. Re-authorize your session key to continue, or wait until the cap resets.
             </p>
           )}
           {billingError === 'rpc_or_unknown' && (

--- a/src/features/live-ai/components/usage-meter.tsx
+++ b/src/features/live-ai/components/usage-meter.tsx
@@ -6,19 +6,16 @@ import { useLiveSessionStore } from '../stores/live-session-store';
 import { usePremiumMembership } from '../hooks/use-premium-membership';
 import { useAccount } from '@account-kit/react';
 import { hourlyUsdcFromInterval } from '@/config/superfluid';
+import {
+  formatUsdRate,
+  formatUsdStreamedInUsdc,
+} from '@/shared/utils/currency-display';
 
 function formatElapsed(ms: number): string {
   const totalSec = Math.floor(ms / 1000);
   const m = Math.floor(totalSec / 60);
   const s = totalSec % 60;
   return `${m}:${String(s).padStart(2, '0')}`;
-}
-
-function formatUsd(amount: number): string {
-  return amount.toLocaleString(undefined, {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  });
 }
 
 /**
@@ -61,12 +58,12 @@ export function UsageMeter() {
           <DollarSign className="h-3 w-3" aria-hidden />
           {isLoading
             ? '…'
-            : `$${formatUsd(hourlyRate)}/hr${isPremiumMember ? ' · premium' : ''}`}
+            : `${formatUsdRate(hourlyRate, 'hr')}${isPremiumMember ? ' · premium' : ''}`}
         </span>
       </div>
       {!isLoading && (
         <p className="text-muted-foreground">
-          ~${formatUsd(estimatedSpent)} streamed via Superfluid
+          {formatUsdStreamedInUsdc(estimatedSpent)}
         </p>
       )}
     </div>

--- a/src/shared/utils/currency-display.ts
+++ b/src/shared/utils/currency-display.ts
@@ -31,8 +31,9 @@ function formatUsdNumber(
   amount: number,
   options?: { minimumFractionDigits?: number; maximumFractionDigits?: number }
 ): string {
-  return amount.toLocaleString(undefined, {
-    minimumFractionDigits: options?.minimumFractionDigits ?? 0,
+  return amount.toLocaleString('en-US', {
+    minimumFractionDigits:
+      options?.minimumFractionDigits ?? (Number.isInteger(amount) ? 0 : 2),
     maximumFractionDigits: options?.maximumFractionDigits ?? 2,
   });
 }

--- a/src/shared/utils/currency-display.ts
+++ b/src/shared/utils/currency-display.ts
@@ -1,0 +1,78 @@
+/**
+ * Pixels payment UI — layered currency labeling:
+ *
+ * Layer 1 (pricing): `$` for rates, subscriptions, marketing — e.g. `$30/mo`, `$3/hr`
+ * Layer 2 (wallet): `USDC` label for balances — e.g. `USDC: 12.50`
+ * Layer 3 (actions): `USDC` in CTA labels — e.g. `Buy USDC`, `Buy credits`
+ * Layer 4 (checkout): USDC amount with optional peg hint — e.g. `5 USDC (~$5)`
+ *
+ * Never combine as `$5 USDC` (redundant). Pick one layer per surface.
+ */
+
+import {
+  DAILY_SPEND_LIMIT_USDC6,
+  INTERVAL_COST_PREMIUM_USDC6,
+  INTERVAL_COST_RETAIL_USDC6,
+} from '@/config/billing';
+import { hourlyUsdcFromInterval } from '@/config/superfluid';
+
+/** Pixels Premium subscription (Unlock checkout — USDC or card). */
+export const PIXELS_PREMIUM_MONTHLY_USD = 30;
+
+export const LIVE_AI_PREMIUM_HOURLY_USD = hourlyUsdcFromInterval(
+  INTERVAL_COST_PREMIUM_USDC6
+);
+export const LIVE_AI_RETAIL_HOURLY_USD = hourlyUsdcFromInterval(
+  INTERVAL_COST_RETAIL_USDC6
+);
+export const LIVE_AI_DAILY_SPEND_CAP_USD = DAILY_SPEND_LIMIT_USDC6 / 1_000_000;
+
+function formatUsdNumber(
+  amount: number,
+  options?: { minimumFractionDigits?: number; maximumFractionDigits?: number }
+): string {
+  return amount.toLocaleString(undefined, {
+    minimumFractionDigits: options?.minimumFractionDigits ?? 0,
+    maximumFractionDigits: options?.maximumFractionDigits ?? 2,
+  });
+}
+
+/** Layer 1 — familiar dollar price anchor. */
+export function formatUsdPrice(amount: number): string {
+  return `$${formatUsdNumber(amount)}`;
+}
+
+/** Layer 1 — rate with unit suffix. */
+export function formatUsdRate(amount: number, unit: string): string {
+  return `${formatUsdPrice(amount)}/${unit}`;
+}
+
+/** Layer 1 — subscription CTA label. */
+export function formatSubscribeCta(
+  amountUsd = PIXELS_PREMIUM_MONTHLY_USD
+): string {
+  return `Subscribe ${formatUsdRate(amountUsd, 'mo')}`;
+}
+
+/** Layer 2/4 — on-chain token amount. */
+export function formatUsdcAmount(amount: number): string {
+  return `${formatUsdNumber(amount, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  })} USDC`;
+}
+
+/** Layer 4 — checkout confirmation with USD peg hint. */
+export function formatUsdcCheckout(amount: number): string {
+  return `${formatUsdcAmount(amount)} (~${formatUsdPrice(amount)})`;
+}
+
+/** Layer 4 — approximate USDC required (includes gas buffer). */
+export function formatUsdcRequiredApprox(amount: number): string {
+  return `~${formatUsdcAmount(amount)}`;
+}
+
+/** Layer 4 — streamed spend with USDC settlement context. */
+export function formatUsdStreamedInUsdc(amount: number): string {
+  return `~${formatUsdPrice(amount)} streamed in USDC`;
+}


### PR DESCRIPTION
## Summary
- Add layered `$` / USDC display helpers and shared credit-pack affordability checks.
- Reorder the wallet dropdown so USDC balance, Buy USDC, and Subscribe sit above Credits.
- Gate Buy credits until the user has enough USDC for at least one pack; update checkout copy to `5 USDC (~$5)` and clarify streamed spend as USDC.

## Test plan
- [ ] Open `/projects` wallet menu: verify USDC block is above Credits and Buy credits is disabled at 0 USDC
- [ ] Top up USDC (or mock balance) and confirm Buy credits enables and opens the modal
- [ ] Buy credits modal shows `5 USDC (~$5)` pack labels and USDC-only insufficient messages
- [ ] Subscribe CTAs still show `$30/mo`; Live AI rates still show `$X/hr`
- [ ] Usage meter during Live AI shows `~$X streamed in USDC`


Made with [Cursor](https://cursor.com)