### PR TITLE
fix(billing): align wallet address and gate Live AI on smart wallet readiness

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "routes": "tsr generate",
     "test": "vitest",
     "test:run": "vitest run",
+    "check:billing-env": "node scripts/check-billing-env.mjs",
     "test:preview-sync": "vitest run src/features/preview/components/video-preview.sync.test.tsx",
     "test:preview-sync:stress": "node scripts/preview-sync-stress.mjs --runs 20",
     "test:coverage": "vitest run --coverage",

--- a/scripts/check-billing-env.mjs
+++ b/scripts/check-billing-env.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+/**
+ * Validates billing-related environment variables for production.
+ * Run locally with .env loaded, or in CI against Vercel env exports.
+ *
+ * Usage: node scripts/check-billing-env.mjs
+ */
+
+const REQUIRED_CLIENT = [
+  { key: 'VITE_ALCHEMY_API_KEY', pattern: /^.{8,}$/ },
+  { key: 'VITE_ARBITRUM_PAYMENT_CONTRACT', pattern: /^0x[a-fA-F0-9]{40}$/ },
+  { key: 'VITE_SUPERFLUID_RECEIVER', pattern: /^0x[a-fA-F0-9]{40}$/ },
+];
+
+const REQUIRED_SERVER = [
+  {
+    keys: ['UPSTASH_REDIS_REST_URL', 'KV_REST_API_URL'],
+    pattern: /^https:\/\/.+/,
+    label: 'Redis URL (UPSTASH_REDIS_REST_URL or KV_REST_API_URL)',
+  },
+  {
+    keys: ['UPSTASH_REDIS_REST_TOKEN', 'KV_REST_API_TOKEN'],
+    pattern: /^.{8,}$/,
+    label: 'Redis token (UPSTASH_REDIS_REST_TOKEN or KV_REST_API_TOKEN)',
+  },
+];
+
+const RECOMMENDED = [
+  { key: 'VITE_ALCHEMY_POLICY_ID', pattern: /^.{4,}$/ },
+  { key: 'VITE_ALCHEMY_GAS_POLICY_TYPE', pattern: /^(sponsorship|erc20)$/i },
+  { key: 'VITE_PIXELS_PREMIUM_LOCK_ADDRESS', pattern: /^0x[a-fA-F0-9]{40}$/ },
+];
+
+function check(entries) {
+  const results = [];
+  for (const entry of entries) {
+    const keys = entry.keys ?? [entry.key];
+    const value =
+      keys.map((k) => process.env[k]?.trim()).find((v) => v && v.length > 0) ?? '';
+    const ok = value.length > 0 && entry.pattern.test(value);
+    const label = entry.label ?? keys.join(' | ');
+    results.push({
+      key: label,
+      ok,
+      value: value ? `${value.slice(0, 12)}…` : '(missing)',
+    });
+  }
+  return results;
+}
+
+const client = check(REQUIRED_CLIENT);
+const server = check(REQUIRED_SERVER);
+const recommended = check(RECOMMENDED);
+
+function printSection(title, rows) {
+  console.log(`\n${title}`);
+  for (const row of rows) {
+    console.log(`  ${row.ok ? '✓' : '✗'} ${row.key}${row.ok ? '' : ` — ${row.value}`}`);
+  }
+}
+
+printSection('Required (client / VITE_*)', client);
+printSection('Required (server / API)', server);
+printSection('Recommended', recommended);
+
+const failed = [...client, ...server].filter((r) => !r.ok);
+if (failed.length > 0) {
+  console.error(`\n${failed.length} required billing env var(s) missing or invalid.`);
+  console.error('See docs/internal/billing-economics.md for the full checklist.');
+  process.exit(1);
+}
+
+console.log('\nAll required billing environment variables are set.');

--- a/src/features/credits/components/buy-credits-modal.test.tsx
+++ b/src/features/credits/components/buy-credits-modal.test.tsx
@@ -1,27 +1,125 @@
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { useAccount } from '@account-kit/react';
+import { useUsdcBalance } from '@/hooks/use-usdc-balance';
+import { BuyCreditsModal } from './buy-credits-modal';
 
-/**
- * Regression: buy-credits modal must use LightAccount (same as wallet menu and
- * useCredits) so USDC balance matches the connected smart wallet.
- */
-describe('BuyCreditsModal account type', () => {
-  it('uses LightAccount for wallet address (not sca)', () => {
-    const source = readFileSync(
-      resolve(import.meta.dirname, 'buy-credits-modal.tsx'),
-      'utf8'
+const LIGHT_ACCOUNT_ADDRESS =
+  '0x429A000000000000000000000000000000751d' as `0x${string}`;
+const ARBITRUM_ONE_CHAIN_ID = 42_161;
+
+let mockUsdcBalance: {
+  balance: string | null;
+  formatted: string;
+  isLoading: boolean;
+  isError: boolean;
+};
+
+vi.mock('@account-kit/react', () => ({
+  useAccount: vi.fn(() => ({ address: LIGHT_ACCOUNT_ADDRESS })),
+  useChain: vi.fn(() => ({
+    chain: { id: ARBITRUM_ONE_CHAIN_ID, name: 'Arbitrum One' },
+  })),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const labels: Record<string, string> = {
+        'credits.buyTitle': 'Buy credits',
+        'credits.buyDescription':
+          'Pay with USDC on Arbitrum for Flow image and video generation.',
+      };
+      return labels[key] ?? key;
+    },
+  }),
+}));
+
+vi.mock('@/hooks/use-usdc-balance', () => ({
+  useUsdcBalance: vi.fn(() => mockUsdcBalance),
+}));
+
+vi.mock('@/features/credits/hooks/use-credits', () => ({
+  CREDIT_PACKS: [
+    {
+      id: 0,
+      name: 'Starter',
+      usdc6: 5_000_000,
+      credits: 50,
+      description: '~10 Flow image gens',
+    },
+    {
+      id: 1,
+      name: 'Pro',
+      usdc6: 15_000_000,
+      credits: 175,
+      description: '~35 Flow image gens',
+    },
+    {
+      id: 2,
+      name: 'Studio',
+      usdc6: 40_000_000,
+      credits: 500,
+      description: '~100 Flow image gens',
+    },
+  ],
+  useCredits: () => ({
+    purchasePack: vi.fn(),
+    syncPurchase: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/use-buy-usdc-onramp', () => ({
+  useBuyUsdcOnramp: () => ({
+    openBuyUsdc: vi.fn(),
+    isLoading: false,
+  }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
+}));
+
+describe('BuyCreditsModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUsdcBalance = {
+      balance: null,
+      formatted: '—',
+      isLoading: true,
+      isError: false,
+    };
+  });
+
+  it('reads wallet address from LightAccount', () => {
+    render(<BuyCreditsModal open onOpenChange={vi.fn()} />);
+
+    expect(vi.mocked(useAccount)).toHaveBeenCalledWith({ type: 'LightAccount' });
+    expect(vi.mocked(useUsdcBalance)).toHaveBeenCalledWith(
+      expect.objectContaining({ id: ARBITRUM_ONE_CHAIN_ID }),
+      LIGHT_ACCOUNT_ADDRESS
     );
-    expect(source).toContain("useAccount({ type: 'LightAccount' })");
-    expect(source).not.toContain("useAccount({ type: 'sca' })");
   });
 
   it('shows balance loading state while USDC is fetched', () => {
-    const source = readFileSync(
-      resolve(import.meta.dirname, 'buy-credits-modal.tsx'),
-      'utf8'
-    );
-    expect(source).toContain('Checking USDC balance');
-    expect(source).toContain('isBalanceLoading');
+    render(<BuyCreditsModal open onOpenChange={vi.fn()} />);
+
+    expect(screen.getByText('Checking USDC balance…')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Starter/i })).toBeDisabled();
+  });
+
+  it('enables affordable packs when balance is loaded', () => {
+    mockUsdcBalance = {
+      balance: '11.52',
+      formatted: '11.52',
+      isLoading: false,
+      isError: false,
+    };
+
+    render(<BuyCreditsModal open onOpenChange={vi.fn()} />);
+
+    expect(screen.getByText('Wallet USDC: 11.52')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Starter/i })).toBeEnabled();
+    expect(screen.getByRole('button', { name: /Studio/i })).toBeDisabled();
   });
 });

--- a/src/features/credits/components/buy-credits-modal.test.tsx
+++ b/src/features/credits/components/buy-credits-modal.test.tsx
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Regression: buy-credits modal must use LightAccount (same as wallet menu and
+ * useCredits) so USDC balance matches the connected smart wallet.
+ */
+describe('BuyCreditsModal account type', () => {
+  it('uses LightAccount for wallet address (not sca)', () => {
+    const source = readFileSync(
+      resolve(import.meta.dirname, 'buy-credits-modal.tsx'),
+      'utf8'
+    );
+    expect(source).toContain("useAccount({ type: 'LightAccount' })");
+    expect(source).not.toContain("useAccount({ type: 'sca' })");
+  });
+
+  it('shows balance loading state while USDC is fetched', () => {
+    const source = readFileSync(
+      resolve(import.meta.dirname, 'buy-credits-modal.tsx'),
+      'utf8'
+    );
+    expect(source).toContain('Checking USDC balance');
+    expect(source).toContain('isBalanceLoading');
+  });
+});

--- a/src/features/credits/components/buy-credits-modal.tsx
+++ b/src/features/credits/components/buy-credits-modal.tsx
@@ -44,13 +44,14 @@ interface BuyCreditsModalProps {
 
 export function BuyCreditsModal({ open, onOpenChange }: BuyCreditsModalProps) {
   const { t } = useTranslation();
-  const { address } = useAccount({ type: 'sca' });
+  const { address } = useAccount({ type: 'LightAccount' });
   const { chain } = useChain();
   const { purchasePack, syncPurchase } = useCredits();
-  const { balance: usdcBalance, formatted: usdcFormatted } = useUsdcBalance(
-    chain,
-    address as `0x${string}` | undefined
-  );
+  const {
+    balance: usdcBalance,
+    formatted: usdcFormatted,
+    isLoading: isBalanceLoading,
+  } = useUsdcBalance(chain, address as `0x${string}` | undefined);
   const { openBuyUsdc, isLoading: isOnrampLoading } = useBuyUsdcOnramp();
   const [purchasingId, setPurchasingId] = useState<number | null>(null);
   const [pendingSync, setPendingSync] = useState<PendingSync | null>(null);
@@ -141,7 +142,13 @@ export function BuyCreditsModal({ open, onOpenChange }: BuyCreditsModalProps) {
           </DialogTitle>
           <DialogDescription>
             {t('credits.buyDescription')}
-            {usdcBalance !== null && (
+            {isBalanceLoading && (
+              <span className="mt-1 flex items-center gap-1.5 text-muted-foreground">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+                Checking USDC balance…
+              </span>
+            )}
+            {!isBalanceLoading && usdcBalance !== null && (
               <span className="mt-1 block tabular-nums">
                 Wallet USDC: {usdcFormatted}
               </span>
@@ -210,6 +217,7 @@ export function BuyCreditsModal({ open, onOpenChange }: BuyCreditsModalProps) {
                   pendingSync !== null ||
                   retryingSync ||
                   !onArbitrum ||
+                  isBalanceLoading ||
                   !affordable
                 }
                 onClick={() => void handleBuy(pack.id)}

--- a/src/features/credits/usdc-for-purchase.test.ts
+++ b/src/features/credits/usdc-for-purchase.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { CREDIT_PACKS } from '@/config/credits';
+import {
+  canAffordAnyCreditPack,
+  hasEnoughUsdcForPack,
+} from '@/features/credits/usdc-for-purchase';
+
+describe('usdc-for-purchase', () => {
+  const starterPack = CREDIT_PACKS[0]!;
+
+  it('affirms Starter pack affordable at 11.52 USDC', () => {
+    expect(hasEnoughUsdcForPack('11.52', starterPack)).toBe(true);
+    expect(canAffordAnyCreditPack('11.52')).toBe(true);
+  });
+
+  it('rejects packs when balance is null (loading)', () => {
+    expect(hasEnoughUsdcForPack(null, starterPack)).toBe(false);
+    expect(canAffordAnyCreditPack(null)).toBe(false);
+  });
+
+  it('rejects Starter when balance is below pack price', () => {
+    expect(hasEnoughUsdcForPack('4.99', starterPack)).toBe(false);
+    expect(canAffordAnyCreditPack('4.99')).toBe(false);
+  });
+
+  it('affirms all packs at 50 USDC', () => {
+    for (const pack of CREDIT_PACKS) {
+      expect(hasEnoughUsdcForPack('50', pack)).toBe(true);
+    }
+  });
+});

--- a/src/features/live-ai/components/live-ai-popover.tsx
+++ b/src/features/live-ai/components/live-ai-popover.tsx
@@ -49,6 +49,7 @@ import {
   LIVE_AI_DAILY_SPEND_CAP_USD,
 } from '@/shared/utils/currency-display';
 import type { StreamData, LoraDict, IpAdapterConfig } from '../types';
+import { getStartFlowErrorMessage } from '../lib/start-flow-error';
 
 // Dreamshaper 8 and Open Journey v4 are temporarily hidden: they fail to cold-start reliably.
 const MODEL_OPTIONS = [
@@ -153,6 +154,7 @@ interface BillingControls {
   startFlow: () => Promise<boolean>;
   stopFlow: () => Promise<boolean>;
   setOnPause: (fn: (() => void) | null) => void;
+  walletReady: boolean;
 }
 
 /**
@@ -164,11 +166,11 @@ function SuperfluidBillingBridge({
 }: {
   onControls: (controls: BillingControls | null) => void;
 }) {
-  const { startFlow, stopFlow, setOnPause } = useSuperfluidBilling();
+  const { startFlow, stopFlow, setOnPause, walletReady } = useSuperfluidBilling();
   useEffect(() => {
-    onControls({ startFlow, stopFlow, setOnPause });
+    onControls({ startFlow, stopFlow, setOnPause, walletReady });
     return () => onControls(null);
-  }, [onControls, startFlow, stopFlow, setOnPause]);
+  }, [onControls, startFlow, stopFlow, setOnPause, walletReady]);
   return null;
 }
 
@@ -303,6 +305,10 @@ export function LiveAIPanelContent() {
         setError('Billing is unavailable. Reload the page and try again.');
         return;
       }
+      if (!billingControls.walletReady) {
+        setError('Wallet initializing — try again in a moment.');
+        return;
+      }
     }
     if (daydreamConfigured) {
       const validationErr = validateLoraEntries(loraEntries);
@@ -323,7 +329,8 @@ export function LiveAIPanelContent() {
         setStartPhase('payment');
         const flowOk = await billingControls.startFlow();
         if (!flowOk) {
-          setError('Could not start the USDC payment stream. Live AI was not started.');
+          const billingError = useLiveSessionStore.getState().billingError;
+          setError(getStartFlowErrorMessage(billingError));
           return;
         }
         flowStarted = true;
@@ -560,6 +567,11 @@ export function LiveAIPanelContent() {
                 be set up before the session can start.
               </p>
             )}
+            {superfluidConfigured && address && billingControls && !billingControls.walletReady && (
+              <p className="mb-2 text-xs text-muted-foreground">
+                Wallet initializing — payment controls will be ready shortly.
+              </p>
+            )}
             {superfluidConfigured && address && billingUnavailable && (
               <p className="mb-2 text-xs text-destructive">
                 Billing is unavailable. Reload the page and try again.
@@ -576,7 +588,8 @@ export function LiveAIPanelContent() {
                 !address ||
                 !hasFunding ||
                 billingUnavailable ||
-                !billingControls
+                !billingControls ||
+                !billingControls.walletReady
               }
               size="sm"
               className="w-full"
@@ -1181,6 +1194,9 @@ function LiveAISessionWithBroadcastCore({
               You&apos;ve hit the {formatUsdPrice(LIVE_AI_DAILY_SPEND_CAP_USD)} daily spend
               cap. Re-authorize your session key to continue, or wait until the cap resets.
             </p>
+          )}
+          {billingError === 'wallet_not_ready' && (
+            <p>Wallet initializing — try again in a moment.</p>
           )}
           {billingError === 'rpc_or_unknown' && (
             <p>Billing failed. Check connection and try again.</p>

--- a/src/features/live-ai/hooks/use-superfluid-billing.ts
+++ b/src/features/live-ai/hooks/use-superfluid-billing.ts
@@ -76,7 +76,7 @@ export function useSuperfluidBilling() {
   const flowRateRef = useRef(intervalCostUsdc6ToFlowRate(intervalCostUsdc6));
   flowRateRef.current = intervalCostUsdc6ToFlowRate(intervalCostUsdc6);
 
-  const { sendOps } = useSmartWalletOps(client ?? undefined);
+  const { sendOps, ready: walletReady } = useSmartWalletOps(client ?? undefined);
 
   const sendOpsRef = useRef<
     (
@@ -138,6 +138,14 @@ export function useSuperfluidBilling() {
     if (!address || !receiver || !configured) return false;
     if (flowActiveRef.current) return true;
     if (startInFlightRef.current) return false;
+    if (!client || !walletReady) {
+      log.warn('Cannot start Superfluid flow: smart wallet not ready', {
+        hasClient: Boolean(client),
+        walletReady,
+      });
+      setBillingError('wallet_not_ready');
+      return false;
+    }
 
     startInFlightRef.current = true;
     setBillingError(null);
@@ -184,7 +192,16 @@ export function useSuperfluidBilling() {
     } finally {
       startInFlightRef.current = false;
     }
-  }, [address, configured, ensureArbitrum, markFlowActive, receiver, setBillingError]);
+  }, [
+    address,
+    client,
+    configured,
+    ensureArbitrum,
+    markFlowActive,
+    receiver,
+    setBillingError,
+    walletReady,
+  ]);
 
   // Stop the flow when the stream ends. If the flow is active but the stream
   // never goes live (broadcast failure), stop it after a grace period so the
@@ -253,5 +270,6 @@ export function useSuperfluidBilling() {
     startFlow,
     stopFlow,
     flowActive,
+    walletReady: Boolean(client && walletReady),
   };
 }

--- a/src/features/live-ai/lib/start-flow-error.test.ts
+++ b/src/features/live-ai/lib/start-flow-error.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { getStartFlowErrorMessage } from './start-flow-error';
+
+describe('getStartFlowErrorMessage', () => {
+  it('maps wallet_not_ready to initializing message', () => {
+    expect(getStartFlowErrorMessage('wallet_not_ready')).toContain('initializing');
+  });
+
+  it('maps insufficient_balance to top-up message', () => {
+    expect(getStartFlowErrorMessage('insufficient_balance')).toContain('USDC');
+  });
+
+  it('maps rpc_or_unknown to connection message', () => {
+    expect(getStartFlowErrorMessage('rpc_or_unknown')).toContain('connection');
+  });
+
+  it('falls back for null billing error', () => {
+    expect(getStartFlowErrorMessage(null)).toContain('Could not start');
+  });
+});

--- a/src/features/live-ai/lib/start-flow-error.ts
+++ b/src/features/live-ai/lib/start-flow-error.ts
@@ -1,0 +1,28 @@
+import {
+  formatUsdPrice,
+  LIVE_AI_DAILY_SPEND_CAP_USD,
+} from '@/shared/utils/currency-display';
+
+export type StartFlowBillingError =
+  | 'insufficient_balance'
+  | 'session_limit_exceeded'
+  | 'rpc_or_unknown'
+  | 'wallet_not_ready'
+  | null;
+
+export function getStartFlowErrorMessage(
+  billingError: StartFlowBillingError
+): string {
+  switch (billingError) {
+    case 'insufficient_balance':
+      return 'Not enough USDC on Arbitrum to start the payment stream. Top up USDC and try again.';
+    case 'wallet_not_ready':
+      return 'Wallet initializing — try again in a moment.';
+    case 'session_limit_exceeded':
+      return `Daily spend cap reached (${formatUsdPrice(LIVE_AI_DAILY_SPEND_CAP_USD)}). Re-authorize your session key or wait for reset.`;
+    case 'rpc_or_unknown':
+      return 'Billing failed. Check your connection and try again.';
+    default:
+      return 'Could not start the USDC payment stream. Live AI was not started.';
+  }
+}

--- a/src/features/live-ai/stores/live-session-store.ts
+++ b/src/features/live-ai/stores/live-session-store.ts
@@ -19,7 +19,12 @@ export interface LiveSessionState {
   /** Current stream id (Daydream/Livepeer) when streamActive. */
   streamId: string | null;
   /** Set when Superfluid billing fails; UI shows top-up USDC. */
-  billingError: 'insufficient_balance' | 'session_limit_exceeded' | 'rpc_or_unknown' | null;
+  billingError:
+    | 'insufficient_balance'
+    | 'session_limit_exceeded'
+    | 'rpc_or_unknown'
+    | 'wallet_not_ready'
+    | null;
 
   // Scope local server state
   /** Whether Scope server is reachable on localhost. */


### PR DESCRIPTION
## Summary
- Fix buy-credits modal reading USDC from `LightAccount` (was `sca`), so pack buttons enable when the wallet menu shows a balance
- Gate Live AI Start on smart wallet readiness and surface specific billing errors instead of a generic payment-stream failure
- Add billing env validation script (`npm run check:billing-env`) and regression tests for affordability and error messaging

## Test plan
- [ ] Connect wallet on Arbitrum with ≥$5 USDC; open Buy credits — Starter pack is clickable and shows wallet balance
- [ ] Purchase Starter pack; credits balance increases after on-chain tx + sync
- [ ] Open Live AI; wait for wallet ready state; click Start — signing popup appears and session starts
- [ ] With insufficient USDC, verify insufficient-balance message (not generic error)
- [ ] Run `npm run test:run -- src/features/credits src/features/live-ai/lib/start-flow-error.test.ts`
- [ ] Run `npm run check:billing-env` against production env vars


Made with [Cursor](https://cursor.com)