### PR TITLE
fix(credits): sync credit packs after USDC purchase reliably

### DIFF
--- a/api/_credit-store.test.ts
+++ b/api/_credit-store.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { parseRedisInteger } from './_credit-store';
+
+describe('parseRedisInteger', () => {
+  it('parses numbers', () => {
+    expect(parseRedisInteger(50)).toBe(50);
+    expect(parseRedisInteger(50.9)).toBe(50);
+  });
+
+  it('parses numeric strings from Upstash INCRBY', () => {
+    expect(parseRedisInteger('175')).toBe(175);
+    expect(parseRedisInteger(' 500 ')).toBe(500);
+  });
+
+  it('returns 0 for invalid values', () => {
+    expect(parseRedisInteger(null)).toBe(0);
+    expect(parseRedisInteger(undefined)).toBe(0);
+    expect(parseRedisInteger('')).toBe(0);
+    expect(parseRedisInteger('abc')).toBe(0);
+    expect(parseRedisInteger(NaN)).toBe(0);
+  });
+});

--- a/api/_credit-store.ts
+++ b/api/_credit-store.ts
@@ -12,12 +12,23 @@ function processedTxKey(txHash: string): string {
   return `credits:tx:${txHash.toLowerCase()}`;
 }
 
+/** Upstash INCRBY/GET may return numbers or numeric strings depending on client config. */
+export function parseRedisInteger(value: unknown): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.floor(value);
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return Math.floor(parsed);
+  }
+  return 0;
+}
+
 export async function getCreditBalance(address: string): Promise<number> {
   const redis = await getRedis();
   if (!redis) return 0;
-  const raw = await redis.get<number>(balanceKey(address));
-  if (typeof raw !== 'number' || !Number.isFinite(raw)) return 0;
-  return Math.max(0, Math.floor(raw));
+  const raw = await redis.get(balanceKey(address));
+  return Math.max(0, parseRedisInteger(raw));
 }
 
 export interface CreditPurchaseResult {
@@ -106,7 +117,7 @@ export async function debitCredits(
   }
 
   const newBalance = await redis.decrby(balKey, amount);
-  const balance = typeof newBalance === 'number' ? Math.max(0, newBalance) : 0;
+  const balance = Math.max(0, parseRedisInteger(newBalance));
 
   if (idempotencyKey) {
     await redis.set(`credits:debit:${idempotencyKey}`, '1', { ex: 86400 });

--- a/api/_redis-client.ts
+++ b/api/_redis-client.ts
@@ -27,11 +27,8 @@ async function initRedis(): Promise<RedisClient | null> {
 
   try {
     const { Redis } = await import('@upstash/redis');
-    try {
-      return Redis.fromEnv();
-    } catch {
-      return new Redis({ url: creds.url, token: creds.token });
-    }
+    // Always use resolved credentials so KV_REST_* and UPSTASH_* stay in sync.
+    return new Redis({ url: creds.url, token: creds.token });
   } catch (e) {
     console.error('redis init failed', e);
     return null;

--- a/api/credits-sync-purchase.ts
+++ b/api/credits-sync-purchase.ts
@@ -134,7 +134,11 @@ export async function POST(request: Request): Promise<Response> {
 
     if (buyer !== address.toLowerCase()) {
       return Response.json(
-        { ok: false, reason: 'buyer_mismatch' },
+        {
+          ok: false,
+          reason: 'buyer_mismatch',
+          expectedBuyer: buyer,
+        },
         { status: 400 }
       );
     }
@@ -152,10 +156,22 @@ export async function POST(request: Request): Promise<Response> {
       );
     }
 
-    const result = await creditFromPurchase(address, txHash, credits);
+    const result = await creditFromPurchase(buyer, txHash, credits);
+    if (!result.ok) {
+      const status = result.reason === 'disabled' ? 503 : 500;
+      return Response.json(
+        {
+          ok: false,
+          creditsAdded: 0,
+          balance: result.balance,
+          reason: result.reason ?? 'error',
+        },
+        { status }
+      );
+    }
     return Response.json(
       {
-        ok: result.ok,
+        ok: true,
         creditsAdded: result.creditsAdded,
         balance: result.balance,
         reason: result.reason,

--- a/src/features/credits/api/resolve-purchase-tx.test.ts
+++ b/src/features/credits/api/resolve-purchase-tx.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { rankCreditsPurchaseTxHashes } from './resolve-purchase-tx';
+
+describe('rankCreditsPurchaseTxHashes', () => {
+  it('returns empty array for no hashes', async () => {
+    expect(await rankCreditsPurchaseTxHashes([])).toEqual([]);
+  });
+
+  it('returns single hash unchanged', async () => {
+    const hash =
+      '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd' as const;
+    expect(await rankCreditsPurchaseTxHashes([hash])).toEqual([hash]);
+  });
+
+  it('preserves all candidates without picking a silent fallback', async () => {
+    const a =
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as const;
+    const b =
+      '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as const;
+    const ranked = await rankCreditsPurchaseTxHashes([a, b]);
+    expect(ranked).toHaveLength(2);
+    expect(ranked).toContain(a);
+    expect(ranked).toContain(b);
+  });
+});

--- a/src/features/credits/api/resolve-purchase-tx.ts
+++ b/src/features/credits/api/resolve-purchase-tx.ts
@@ -60,24 +60,22 @@ export async function rankCreditsPurchaseTxHashes(
     transport: http(getArbitrumRpcUrl()),
   });
 
-  const withEvent: Hex[] = [];
-  const withoutEvent: Hex[] = [];
-
-  for (const hash of unique) {
-    try {
-      const receipt = await client.getTransactionReceipt({ hash });
-      if (
-        receipt.status === 'success' &&
-        findCreditsPurchasedLog(receipt.logs, paymentContract)
-      ) {
-        withEvent.push(hash);
-      } else {
-        withoutEvent.push(hash);
+  const ranked = await Promise.all(
+    unique.map(async (hash) => {
+      try {
+        const receipt = await client.getTransactionReceipt({ hash });
+        const hasEvent =
+          receipt.status === 'success' &&
+          findCreditsPurchasedLog(receipt.logs, paymentContract);
+        return { hash, hasEvent };
+      } catch {
+        return { hash, hasEvent: false };
       }
-    } catch {
-      withoutEvent.push(hash);
-    }
-  }
+    })
+  );
+
+  const withEvent = ranked.filter((r) => r.hasEvent).map((r) => r.hash);
+  const withoutEvent = ranked.filter((r) => !r.hasEvent).map((r) => r.hash);
 
   return [...withEvent, ...withoutEvent];
 }

--- a/src/features/credits/api/resolve-purchase-tx.ts
+++ b/src/features/credits/api/resolve-purchase-tx.ts
@@ -1,0 +1,83 @@
+import {
+  createPublicClient,
+  decodeEventLog,
+  http,
+  parseAbiItem,
+  type Hex,
+  type Log,
+} from 'viem';
+import { arbitrum } from 'viem/chains';
+import { getPaymentContractAddress } from '@/config/billing';
+
+const CREDITS_PURCHASED = parseAbiItem(
+  'event CreditsPurchased(address indexed buyer, uint8 indexed packId, uint256 credits, uint256 usdcPaid)'
+);
+
+const apiKey = import.meta.env.VITE_ALCHEMY_API_KEY as string | undefined;
+
+function getArbitrumRpcUrl(): string {
+  if (apiKey) return `https://arb-mainnet.g.alchemy.com/v2/${apiKey}`;
+  return 'https://arb1.arbitrum.io/rpc';
+}
+
+function findCreditsPurchasedLog(
+  logs: Log[],
+  contractAddress: string
+): boolean {
+  const target = contractAddress.toLowerCase();
+  for (const log of logs) {
+    if (log.address.toLowerCase() !== target) continue;
+    try {
+      const decoded = decodeEventLog({
+        abi: [CREDITS_PURCHASED],
+        data: log.data,
+        topics: log.topics,
+      });
+      if (decoded.eventName === 'CreditsPurchased') return true;
+    } catch {
+      continue;
+    }
+  }
+  return false;
+}
+
+/**
+ * Orders batched smart-wallet receipt hashes for credit sync.
+ * Hashes whose receipts emit CreditsPurchased come first; never drops candidates
+ * so callers can retry others when RPC indexing lags.
+ */
+export async function rankCreditsPurchaseTxHashes(
+  txHashes: readonly Hex[]
+): Promise<Hex[]> {
+  const unique = [...new Set(txHashes.filter(Boolean))];
+  if (unique.length <= 1) return unique;
+
+  const paymentContract = getPaymentContractAddress();
+  if (!paymentContract) return unique;
+
+  const client = createPublicClient({
+    chain: arbitrum,
+    transport: http(getArbitrumRpcUrl()),
+  });
+
+  const withEvent: Hex[] = [];
+  const withoutEvent: Hex[] = [];
+
+  for (const hash of unique) {
+    try {
+      const receipt = await client.getTransactionReceipt({ hash });
+      if (
+        receipt.status === 'success' &&
+        findCreditsPurchasedLog(receipt.logs, paymentContract)
+      ) {
+        withEvent.push(hash);
+      } else {
+        withoutEvent.push(hash);
+      }
+    } catch {
+      withoutEvent.push(hash);
+    }
+  }
+
+  return [...withEvent, ...withoutEvent];
+}

--- a/src/features/credits/api/sync-purchase.test.ts
+++ b/src/features/credits/api/sync-purchase.test.ts
@@ -68,7 +68,7 @@ describe('syncPurchaseCredits', () => {
 
     expect(result.ok).toBe(false);
     expect(result.syncPending).toBe(true);
-    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(fetch).toHaveBeenCalledTimes(5);
     vi.useRealTimers();
   });
 

--- a/src/features/credits/api/sync-purchase.ts
+++ b/src/features/credits/api/sync-purchase.ts
@@ -10,8 +10,8 @@ export interface SyncPurchaseResult extends SyncPurchaseResponse {
   syncPending?: boolean;
 }
 
-const SYNC_MAX_ATTEMPTS = 3;
-const SYNC_BACKOFF_MS = [1_000, 2_000, 4_000] as const;
+const SYNC_MAX_ATTEMPTS = 5;
+const SYNC_BACKOFF_MS = [1_000, 2_000, 3_000, 5_000, 8_000] as const;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/src/features/credits/components/buy-credits-modal.tsx
+++ b/src/features/credits/components/buy-credits-modal.tsx
@@ -44,7 +44,7 @@ interface BuyCreditsModalProps {
 
 export function BuyCreditsModal({ open, onOpenChange }: BuyCreditsModalProps) {
   const { t } = useTranslation();
-  const { address } = useAccount({ type: 'sca' });
+  const { address } = useAccount({ type: 'LightAccount' });
   const { chain } = useChain();
   const { purchasePack, syncPurchase } = useCredits();
   const { balance: usdcBalance, formatted: usdcFormatted } = useUsdcBalance(

--- a/src/features/credits/hooks/use-credits.ts
+++ b/src/features/credits/hooks/use-credits.ts
@@ -210,9 +210,6 @@ export function useCredits(): UseCreditsResult {
             txHash: candidate,
             syncPending: syncResult.syncPending === true,
           };
-          if (!syncResult.syncPending) {
-            return lastResult;
-          }
         }
 
         return {

--- a/src/features/credits/hooks/use-credits.ts
+++ b/src/features/credits/hooks/use-credits.ts
@@ -19,6 +19,7 @@ import {
   classifyPayFailure,
 } from '@/features/credits/api/buy-credits';
 import { syncPurchaseCredits } from '@/features/credits/api/sync-purchase';
+import { rankCreditsPurchaseTxHashes } from '@/features/credits/api/resolve-purchase-tx';
 import {
   buildCreditsAuthMessage,
   generateCreditsNonce,
@@ -184,20 +185,40 @@ export function useCredits(): UseCreditsResult {
           args: [paymentContract, maxUint256],
         });
 
-        const { txHash } = await sendOps([
+        const { txHash, txHashes } = await sendOps([
           { target: usdcAddress, data: approveData, value: 0n },
           { target: paymentContract, data: buyData, value: 0n },
         ]);
 
-        const syncResult = await syncPurchase(txHash);
-        if (!syncResult.ok) {
-          return {
+        const candidates = await rankCreditsPurchaseTxHashes(
+          txHashes.length > 0 ? txHashes : [txHash]
+        );
+
+        let lastResult: PurchasePackResult = {
+          ok: false,
+          error: 'Sync failed',
+          txHash: candidates[0] ?? txHash,
+        };
+
+        for (const candidate of candidates) {
+          const syncResult = await syncPurchase(candidate);
+          if (syncResult.ok) {
+            return { ok: true, txHash: candidate };
+          }
+          lastResult = {
             ...syncResult,
-            txHash,
+            txHash: candidate,
             syncPending: syncResult.syncPending === true,
           };
+          if (!syncResult.syncPending) {
+            return lastResult;
+          }
         }
-        return { ok: true, txHash };
+
+        return {
+          ...lastResult,
+          txHash: candidates[0] ?? txHash,
+        };
       } catch (e) {
         return { ok: false, error: formatPurchaseError(e) };
       }

--- a/src/hooks/use-smart-wallet-ops.ts
+++ b/src/hooks/use-smart-wallet-ops.ts
@@ -16,6 +16,8 @@ export interface SmartWalletOp {
 export interface SendOpsResult {
   /** Mined transaction hash containing the user operation. */
   txHash: Hex;
+  /** All unique receipt tx hashes (batched calls may expose more than one). */
+  txHashes: Hex[];
 }
 
 interface ClientWithAccount {
@@ -99,9 +101,16 @@ export function useSmartWalletOps(client: ClientWithAccount | undefined) {
           `Transaction failed (status ${String(status.statusCode)})`
         );
       }
-      const txHash = status.receipts?.[0]?.transactionHash;
+      const txHashes = [
+        ...new Set(
+          (status.receipts ?? [])
+            .map((r) => r.transactionHash)
+            .filter((h): h is Hex => Boolean(h))
+        ),
+      ];
+      const txHash = txHashes[txHashes.length - 1];
       if (!txHash) throw new Error('Transaction confirmed without a receipt');
-      return { txHash };
+      return { txHash, txHashes };
     },
     [smartWalletClient]
   );

--- a/vercel.json
+++ b/vercel.json
@@ -6,7 +6,7 @@
   "installCommand": "npm ci",
   "rewrites": [
     {
-      "source": "/(.*)",
+      "source": "/((?!api/).*)",
       "destination": "/index.html"
     }
   ],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
-    include: ['src/**/*.test.{ts,tsx}'],
+    include: ['src/**/*.test.{ts,tsx}', 'api/**/*.test.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary
- Fix credit balance reads from Upstash Redis when values are returned as numeric strings, so purchased credits show up and Flow AI can debit them.
- Rank and try all batched smart-wallet receipt hashes for `CreditsPurchased` instead of silently falling back to the USDC approve tx.
- Harden sync API responses (503 when Redis disabled, credit on-chain buyer) and exclude `/api/*` from SPA rewrites on Vercel.

## Test plan
- [ ] Buy Starter pack on Arbitrum: USDC reaches treasury, balance increases by 50 credits
- [ ] Retry sync with same tx hash is idempotent (no double credit)
- [ ] `GET /api/credits-health` shows `redisConnected: true` in production
- [ ] Flow image generation debits credits after purchase
- [ ] Pending sync retry uses the correct purchase tx hash after batched approve+buy


Made with [Cursor](https://cursor.com)