### PR TITLE
feat(live-ai): auto-insert recordings and mobile add-to-timeline

### DIFF
--- a/src/features/live-ai/components/live-ai-popover.tsx
+++ b/src/features/live-ai/components/live-ai-popover.tsx
@@ -14,9 +14,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { useLiveSessionStore } from '../stores/live-session-store';
+import { useLiveSessionStore, type RecordedTake } from '../stores/live-session-store';
 import { usePlaybackStore } from '@/shared/state/playback';
 import { useTimelineStore, useProjectStore } from '../deps/editor';
+import { toast } from 'sonner';
+import { getInsertRecordedClipErrorMessage } from '../utils/commit-recorded-take';
 import { createStream, isDaydreamConfigured } from '../api/create-stream';
 import {
   createLiveVideoToVideoSession,
@@ -144,6 +146,8 @@ interface LiveAISessionWithBroadcastProps {
 interface LiveAISessionCoreProps extends LiveAISessionWithBroadcastProps {
   setOnPause: (fn: (() => void) | null) => void;
   billingEnabled: boolean;
+  /** Called after a recording is saved; used for auto-add to timeline. */
+  onRecordedTakeComplete?: (take: RecordedTake) => void | Promise<void>;
 }
 
 // No-op when wallet not connected; billing loop is not run.
@@ -214,12 +218,54 @@ export function LiveAIPanelContent() {
   const billingErrorDetail = useLiveSessionStore((s) => s.billingErrorDetail);
   const includeTimelineAudio = useLiveSessionStore((s) => s.includeTimelineAudio);
   const setIncludeTimelineAudio = useLiveSessionStore((s) => s.setIncludeTimelineAudio);
+  const autoAddToTimeline = useLiveSessionStore((s) => s.autoAddToTimeline);
+  const setAutoAddToTimeline = useLiveSessionStore((s) => s.setAutoAddToTimeline);
+  const removeLastRecordedTake = useLiveSessionStore((s) => s.removeLastRecordedTake);
   const isRecording = useLiveSessionStore((s) => s.isRecording);
   const setRecording = useLiveSessionStore((s) => s.setRecording);
   const recordedTakes = useLiveSessionStore((s) => s.recordedTakes);
   const insertRecordedClip = useTimelineStore((s) => s.insertRecordedClip);
   const currentProject = useProjectStore((s) => s.currentProject);
   const [committing, setCommitting] = useState(false);
+
+  const handleCommitTake = useCallback(
+    async (take: RecordedTake) => {
+      const projectId = currentProject?.id;
+      if (!projectId) {
+        toast.error(getInsertRecordedClipErrorMessage('no_project'));
+        return false;
+      }
+      setCommitting(true);
+      try {
+        const result = await insertRecordedClip({
+          blob: take.blob,
+          durationMs: take.durationMs,
+          linkedTimelineStart: take.linkedTimelineStart,
+          projectId,
+        });
+        if (result.ok) {
+          toast.success('Added to timeline');
+          removeLastRecordedTake();
+          return true;
+        }
+        toast.error(getInsertRecordedClipErrorMessage(result.reason));
+        return false;
+      } finally {
+        setCommitting(false);
+      }
+    },
+    [currentProject?.id, insertRecordedClip, removeLastRecordedTake],
+  );
+
+  const handleRecordedTakeComplete = useCallback(
+    async (take: RecordedTake) => {
+      if (!useLiveSessionStore.getState().autoAddToTimeline) {
+        return;
+      }
+      await handleCommitTake(take);
+    },
+    [handleCommitTake],
+  );
 
   const [streamData, setStreamData] = useState<StreamData | null>(null);
   const [streamSource, setStreamSource] = useState<'daydream' | 'livepeer' | null>(null);
@@ -637,6 +683,7 @@ export function LiveAIPanelContent() {
             billingEnabled={Boolean(superfluidConfigured && billingControls)}
             isDaydreamStream={streamSource === 'daydream'}
             selectedModelId={selectedModelId}
+            onRecordedTakeComplete={handleRecordedTakeComplete}
           />
         )}
       </div>
@@ -809,13 +856,27 @@ export function LiveAIPanelContent() {
           </Button>
         )}
         {recordedTakes.length > 0 && (
-          <>
+          <div className="flex items-center gap-2 shrink-0 flex-wrap">
             <Button
-              variant="ghost"
+              variant="default"
               size="sm"
-              className="shrink-0 text-xs"
+              className="text-xs"
+              disabled={!currentProject?.id || committing}
               onClick={() => {
                 const take = recordedTakes[recordedTakes.length - 1];
+                if (!take) return;
+                void handleCommitTake(take);
+              }}
+            >
+              {committing ? 'Adding…' : 'Add to Timeline'}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              className="text-xs"
+              onClick={() => {
+                const take = recordedTakes[recordedTakes.length - 1];
+                if (!take) return;
                 const url = URL.createObjectURL(take.blob);
                 const a = document.createElement('a');
                 a.href = url;
@@ -826,33 +887,19 @@ export function LiveAIPanelContent() {
             >
               Download
             </Button>
-            <Button
-              variant="secondary"
-              size="sm"
-              className="shrink-0 text-xs"
-              disabled={!currentProject?.id || committing}
-              onClick={async () => {
-                const take = recordedTakes[recordedTakes.length - 1];
-                const projectId = currentProject?.id;
-                if (!projectId) return;
-                setCommitting(true);
-                try {
-                  await insertRecordedClip({
-                    blob: take.blob,
-                    durationMs: take.durationMs,
-                    linkedTimelineStart: take.linkedTimelineStart,
-                    projectId,
-                  });
-                } finally {
-                  setCommitting(false);
-                }
-              }}
-            >
-              {committing ? 'Adding…' : 'Commit to timeline'}
-            </Button>
-          </>
+          </div>
         )}
-        <div className="flex items-center gap-2 flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-1 min-w-0 flex-wrap">
+          <Switch
+            id="live-ai-auto-add-timeline"
+            checked={autoAddToTimeline}
+            onCheckedChange={setAutoAddToTimeline}
+          />
+          <Label htmlFor="live-ai-auto-add-timeline" className="text-xs truncate cursor-pointer">
+            Auto-add to timeline
+          </Label>
+        </div>
+        <div className="flex items-center gap-2 flex-1 min-w-0 flex-wrap">
           <Switch
             id="live-ai-include-timeline-audio"
             checked={includeTimelineAudio}
@@ -895,6 +942,7 @@ function LiveAISessionWithBroadcastCore({
   whipUrl,
   localStream,
   onStreamStopped,
+  onRecordedTakeComplete,
   previewView,
   setPreviewView,
   setOnPause,
@@ -1165,12 +1213,14 @@ function LiveAISessionWithBroadcastCore({
         recorder.onstop = () => {
           const blob = new Blob(chunks, { type: recorder.mimeType });
           const durationMs = Date.now() - recordingStartRef.current;
-          addRecordedTake({
+          const take: RecordedTake = {
             blob,
             durationMs,
             linkedTimelineStart: linkedTimelineStartRef.current,
-          });
+          };
+          addRecordedTake(take);
           setRecording(false);
+          void onRecordedTakeComplete?.(take);
         };
         recorderRef.current = recorder;
         recordingStartRef.current = Date.now();
@@ -1186,7 +1236,7 @@ function LiveAISessionWithBroadcastCore({
       recorderRef.current.stop();
       recorderRef.current = null;
     }
-  }, [isRecording, addRecordedTake, setRecording]);
+  }, [isRecording, addRecordedTake, setRecording, onRecordedTakeComplete]);
 
   const handleStop = useCallback(() => {
     broadcast.stop();

--- a/src/features/live-ai/components/live-ai-popover.tsx
+++ b/src/features/live-ai/components/live-ai-popover.tsx
@@ -220,7 +220,7 @@ export function LiveAIPanelContent() {
   const setIncludeTimelineAudio = useLiveSessionStore((s) => s.setIncludeTimelineAudio);
   const autoAddToTimeline = useLiveSessionStore((s) => s.autoAddToTimeline);
   const setAutoAddToTimeline = useLiveSessionStore((s) => s.setAutoAddToTimeline);
-  const removeLastRecordedTake = useLiveSessionStore((s) => s.removeLastRecordedTake);
+  const removeRecordedTake = useLiveSessionStore((s) => s.removeRecordedTake);
   const isRecording = useLiveSessionStore((s) => s.isRecording);
   const setRecording = useLiveSessionStore((s) => s.setRecording);
   const recordedTakes = useLiveSessionStore((s) => s.recordedTakes);
@@ -245,7 +245,7 @@ export function LiveAIPanelContent() {
         });
         if (result.ok) {
           toast.success('Added to timeline');
-          removeLastRecordedTake();
+          removeRecordedTake(take);
           return true;
         }
         toast.error(getInsertRecordedClipErrorMessage(result.reason));
@@ -254,7 +254,7 @@ export function LiveAIPanelContent() {
         setCommitting(false);
       }
     },
-    [currentProject?.id, insertRecordedClip, removeLastRecordedTake],
+    [currentProject?.id, insertRecordedClip, removeRecordedTake],
   );
 
   const handleRecordedTakeComplete = useCallback(

--- a/src/features/live-ai/deps/timeline-contract.ts
+++ b/src/features/live-ai/deps/timeline-contract.ts
@@ -1,0 +1,4 @@
+/**
+ * Contract: live-ai → timeline. Single seam for cross-feature imports.
+ */
+export type { InsertRecordedClipFailureReason } from '@/features/timeline/contracts/live-ai';

--- a/src/features/live-ai/deps/timeline-types.ts
+++ b/src/features/live-ai/deps/timeline-types.ts
@@ -1,0 +1,1 @@
+export type { InsertRecordedClipFailureReason } from '@/features/timeline/contracts/live-ai';

--- a/src/features/live-ai/deps/timeline-types.ts
+++ b/src/features/live-ai/deps/timeline-types.ts
@@ -1,1 +1,1 @@
-export type { InsertRecordedClipFailureReason } from '@/features/timeline/contracts/live-ai';
+export type { InsertRecordedClipFailureReason } from './timeline-contract';

--- a/src/features/live-ai/stores/live-session-store.test.ts
+++ b/src/features/live-ai/stores/live-session-store.test.ts
@@ -19,20 +19,22 @@ describe('useLiveSessionStore', () => {
     expect(useLiveSessionStore.getState().autoAddToTimeline).toBe(false);
   });
 
-  it('removeLastRecordedTake drops the most recent take', () => {
+  it('removeRecordedTake drops the specified take', () => {
     const blob = new Blob(['x'], { type: 'video/webm' });
-    useLiveSessionStore.getState().addRecordedTake({
+    const take1 = {
       blob,
       durationMs: 500,
       linkedTimelineStart: 0,
-    });
-    useLiveSessionStore.getState().addRecordedTake({
+    };
+    const take2 = {
       blob,
       durationMs: 1000,
       linkedTimelineStart: 30,
-    });
+    };
+    useLiveSessionStore.getState().addRecordedTake(take1);
+    useLiveSessionStore.getState().addRecordedTake(take2);
 
-    useLiveSessionStore.getState().removeLastRecordedTake();
+    useLiveSessionStore.getState().removeRecordedTake(take2);
 
     const takes = useLiveSessionStore.getState().recordedTakes;
     expect(takes).toHaveLength(1);

--- a/src/features/live-ai/stores/live-session-store.test.ts
+++ b/src/features/live-ai/stores/live-session-store.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useLiveSessionStore } from './live-session-store';
+
+describe('useLiveSessionStore', () => {
+  beforeEach(() => {
+    useLiveSessionStore.setState({
+      autoAddToTimeline: true,
+      recordedTakes: [],
+      isRecording: false,
+    });
+  });
+
+  it('defaults autoAddToTimeline to true', () => {
+    expect(useLiveSessionStore.getState().autoAddToTimeline).toBe(true);
+  });
+
+  it('updates autoAddToTimeline preference', () => {
+    useLiveSessionStore.getState().setAutoAddToTimeline(false);
+    expect(useLiveSessionStore.getState().autoAddToTimeline).toBe(false);
+  });
+
+  it('removeLastRecordedTake drops the most recent take', () => {
+    const blob = new Blob(['x'], { type: 'video/webm' });
+    useLiveSessionStore.getState().addRecordedTake({
+      blob,
+      durationMs: 500,
+      linkedTimelineStart: 0,
+    });
+    useLiveSessionStore.getState().addRecordedTake({
+      blob,
+      durationMs: 1000,
+      linkedTimelineStart: 30,
+    });
+
+    useLiveSessionStore.getState().removeLastRecordedTake();
+
+    const takes = useLiveSessionStore.getState().recordedTakes;
+    expect(takes).toHaveLength(1);
+    expect(takes[0]?.durationMs).toBe(500);
+  });
+});

--- a/src/features/live-ai/stores/live-session-store.ts
+++ b/src/features/live-ai/stores/live-session-store.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 import type { ScopeSessionData } from '../types';
 
 export interface RecordedTake {
@@ -11,6 +12,8 @@ export interface LiveSessionState {
   isOpen: boolean;
   isRecording: boolean;
   includeTimelineAudio: boolean;
+  /** When true, recordings are inserted on the timeline automatically after stop. */
+  autoAddToTimeline: boolean;
   permissionsGranted: boolean;
   recordedTakes: RecordedTake[];
   popoverPosition: { x: number; y: number };
@@ -47,8 +50,10 @@ export interface LiveSessionActions {
   setOpen: (open: boolean) => void;
   setRecording: (recording: boolean) => void;
   setIncludeTimelineAudio: (include: boolean) => void;
+  setAutoAddToTimeline: (enabled: boolean) => void;
   setPermissionsGranted: (granted: boolean) => void;
   addRecordedTake: (take: RecordedTake) => void;
+  removeLastRecordedTake: () => void;
   clearRecordedTakes: () => void;
   setPopoverPosition: (position: { x: number; y: number }) => void;
   toggleOpen: () => void;
@@ -71,49 +76,66 @@ export interface LiveSessionActions {
 
 const DEFAULT_POSITION = { x: 0, y: 0 };
 
-export const useLiveSessionStore = create<LiveSessionState & LiveSessionActions>()((set) => ({
-  isOpen: false,
-  isRecording: false,
-  includeTimelineAudio: false,
-  permissionsGranted: false,
-  recordedTakes: [],
-  popoverPosition: DEFAULT_POSITION,
-  streamActive: false,
-  streamId: null,
-  billingError: null,
-  billingErrorDetail: null,
+export const useLiveSessionStore = create<LiveSessionState & LiveSessionActions>()(
+  persist(
+    (set) => ({
+      isOpen: false,
+      isRecording: false,
+      includeTimelineAudio: false,
+      autoAddToTimeline: true,
+      permissionsGranted: false,
+      recordedTakes: [],
+      popoverPosition: DEFAULT_POSITION,
+      streamActive: false,
+      streamId: null,
+      billingError: null,
+      billingErrorDetail: null,
 
-  // Scope defaults
-  scopeConnected: false,
-  scopeSessionId: null,
-  scopePipeline: null,
-  scopeHardwareInfo: null,
-  pipelineLoading: false,
-  scopeSession: null,
+      // Scope defaults
+      scopeConnected: false,
+      scopeSessionId: null,
+      scopePipeline: null,
+      scopeHardwareInfo: null,
+      pipelineLoading: false,
+      scopeSession: null,
 
-  setOpen: (open) => set({ isOpen: open }),
-  setRecording: (recording) => set({ isRecording: recording }),
-  setIncludeTimelineAudio: (include) => set({ includeTimelineAudio: include }),
-  setPermissionsGranted: (granted) => set({ permissionsGranted: granted }),
-  addRecordedTake: (take) =>
-    set((state) => ({ recordedTakes: [...state.recordedTakes, take] })),
-  clearRecordedTakes: () => set({ recordedTakes: [] }),
-  setPopoverPosition: (position) => set({ popoverPosition: position }),
-  toggleOpen: () => set((state) => ({ isOpen: !state.isOpen })),
-  setStreamActive: (active) => set({ streamActive: active }),
-  setStreamId: (id) => set({ streamId: id }),
-  setBillingError: (error, detail) =>
-    set({
-      billingError: error,
-      billingErrorDetail: error === null ? null : (detail ?? null),
+      setOpen: (open) => set({ isOpen: open }),
+      setRecording: (recording) => set({ isRecording: recording }),
+      setIncludeTimelineAudio: (include) => set({ includeTimelineAudio: include }),
+      setAutoAddToTimeline: (enabled) => set({ autoAddToTimeline: enabled }),
+      setPermissionsGranted: (granted) => set({ permissionsGranted: granted }),
+      addRecordedTake: (take) =>
+        set((state) => ({ recordedTakes: [...state.recordedTakes, take] })),
+      removeLastRecordedTake: () =>
+        set((state) => ({
+          recordedTakes:
+            state.recordedTakes.length > 0
+              ? state.recordedTakes.slice(0, -1)
+              : state.recordedTakes,
+        })),
+      clearRecordedTakes: () => set({ recordedTakes: [] }),
+      setPopoverPosition: (position) => set({ popoverPosition: position }),
+      toggleOpen: () => set((state) => ({ isOpen: !state.isOpen })),
+      setStreamActive: (active) => set({ streamActive: active }),
+      setStreamId: (id) => set({ streamId: id }),
+      setBillingError: (error, detail) =>
+        set({
+          billingError: error,
+          billingErrorDetail: error === null ? null : (detail ?? null),
+        }),
+      clearBillingError: () => set({ billingError: null, billingErrorDetail: null }),
+
+      // Scope actions
+      setScopeConnected: (connected) => set({ scopeConnected: connected }),
+      setScopeSessionId: (id) => set({ scopeSessionId: id }),
+      setScopePipeline: (pipeline) => set({ scopePipeline: pipeline }),
+      setScopeHardwareInfo: (info) => set({ scopeHardwareInfo: info }),
+      setPipelineLoading: (loading) => set({ pipelineLoading: loading }),
+      setScopeSession: (session) => set({ scopeSession: session }),
     }),
-  clearBillingError: () => set({ billingError: null, billingErrorDetail: null }),
-
-  // Scope actions
-  setScopeConnected: (connected) => set({ scopeConnected: connected }),
-  setScopeSessionId: (id) => set({ scopeSessionId: id }),
-  setScopePipeline: (pipeline) => set({ scopePipeline: pipeline }),
-  setScopeHardwareInfo: (info) => set({ scopeHardwareInfo: info }),
-  setPipelineLoading: (loading) => set({ pipelineLoading: loading }),
-  setScopeSession: (session) => set({ scopeSession: session }),
-}));
+    {
+      name: 'live-ai-session',
+      partialize: (state) => ({ autoAddToTimeline: state.autoAddToTimeline }),
+    },
+  ),
+);

--- a/src/features/live-ai/stores/live-session-store.ts
+++ b/src/features/live-ai/stores/live-session-store.ts
@@ -53,7 +53,7 @@ export interface LiveSessionActions {
   setAutoAddToTimeline: (enabled: boolean) => void;
   setPermissionsGranted: (granted: boolean) => void;
   addRecordedTake: (take: RecordedTake) => void;
-  removeLastRecordedTake: () => void;
+  removeRecordedTake: (take: RecordedTake) => void;
   clearRecordedTakes: () => void;
   setPopoverPosition: (position: { x: number; y: number }) => void;
   toggleOpen: () => void;
@@ -106,12 +106,9 @@ export const useLiveSessionStore = create<LiveSessionState & LiveSessionActions>
       setPermissionsGranted: (granted) => set({ permissionsGranted: granted }),
       addRecordedTake: (take) =>
         set((state) => ({ recordedTakes: [...state.recordedTakes, take] })),
-      removeLastRecordedTake: () =>
+      removeRecordedTake: (take) =>
         set((state) => ({
-          recordedTakes:
-            state.recordedTakes.length > 0
-              ? state.recordedTakes.slice(0, -1)
-              : state.recordedTakes,
+          recordedTakes: state.recordedTakes.filter((t) => t !== take),
         })),
       clearRecordedTakes: () => set({ recordedTakes: [] }),
       setPopoverPosition: (position) => set({ popoverPosition: position }),

--- a/src/features/live-ai/utils/commit-recorded-take.ts
+++ b/src/features/live-ai/utils/commit-recorded-take.ts
@@ -1,0 +1,22 @@
+import type { InsertRecordedClipFailureReason } from '@/features/live-ai/deps/timeline-types';
+
+export function getInsertRecordedClipErrorMessage(
+  reason: InsertRecordedClipFailureReason,
+): string {
+  switch (reason) {
+    case 'no_project':
+      return 'Open a project before adding recordings to the timeline.';
+    case 'import_failed':
+      return 'Failed to import the recording into the media library.';
+    case 'resolve_failed':
+      return 'Recording imported but playback URL could not be resolved.';
+    case 'no_track':
+      return 'Unlock a visible track to add the recording.';
+    case 'no_space':
+      return 'Not enough space on the timeline—trim clips or add a track.';
+    case 'build_failed':
+      return 'Failed to create a timeline clip from the recording.';
+    default:
+      return 'Failed to add recording to timeline.';
+  }
+}

--- a/src/features/media-library/components/media-card.tsx
+++ b/src/features/media-library/components/media-card.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react';
-import { Video, FileAudio, Image as ImageIcon, MoreVertical, Trash2, Loader2, Link2Off, RefreshCw, Zap, FileText } from 'lucide-react';
+import { useState, useEffect, useCallback } from 'react';
+import { Video, FileAudio, Image as ImageIcon, MoreVertical, Trash2, Loader2, Link2Off, RefreshCw, Zap, FileText, Plus } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -20,6 +20,10 @@ import {
   getTranscriptionOverallPercent,
   getTranscriptionStageLabel,
 } from '@/shared/utils/transcription-progress';
+import { useTimelineStore } from '@/features/media-library/deps/timeline-stores';
+import { useIsMobile } from '../hooks/use-is-mobile';
+import { toast } from 'sonner';
+import { getTimelinePlacementErrorMessage } from '@/features/media-library/deps/timeline-utils';
 
 interface MediaCardProps {
   media: MediaMetadata;
@@ -34,6 +38,9 @@ interface MediaCardProps {
 
 export function MediaCard({ media, selected = false, isBroken = false, onSelect, onDoubleClick, onDelete, onRelink, viewMode = 'grid' }: MediaCardProps) {
   const [thumbnailUrl, setThumbnailUrl] = useState<string | null>(null);
+  const [addingToTimeline, setAddingToTimeline] = useState(false);
+  const isMobile = useIsMobile();
+  const addMediaToTimeline = useTimelineStore((s) => s.addMediaToTimeline);
   const selectedMediaIds = useMediaLibraryStore((s) => s.selectedMediaIds);
   const mediaItems = useMediaLibraryStore((s) => s.mediaItems);
   const importingIds = useMediaLibraryStore((s) => s.importingIds);
@@ -204,6 +211,26 @@ export function MediaCard({ media, selected = false, isBroken = false, onSelect,
     onSelect?.(e);
   };
 
+  const handleAddToTimeline = useCallback(async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (addingToTimeline || isBroken || isImporting) return;
+
+    setAddingToTimeline(true);
+    try {
+      const result = await addMediaToTimeline(media.id);
+      if (result.ok) {
+        toast.success('Added to timeline');
+      } else {
+        toast.error(getTimelinePlacementErrorMessage(result.reason));
+      }
+    } finally {
+      setAddingToTimeline(false);
+    }
+  }, [addMediaToTimeline, addingToTimeline, isBroken, isImporting, media.id]);
+
+  const showAddToTimeline = isMobile && !isBroken && !isImporting;
+
   const transcriptProgressLabel = transcriptProgress
     ? `${getTranscriptionStageLabel(transcriptProgress.stage)} (${Math.round(getTranscriptionOverallPercent(transcriptProgress))}%)`
     : 'Transcribing...';
@@ -310,18 +337,41 @@ export function MediaCard({ media, selected = false, isBroken = false, onSelect,
 
         {/* Actions - hidden during upload */}
         {!isImporting && (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
+          <div className="flex items-center gap-1 flex-shrink-0">
+            {showAddToTimeline && (
               <Button
-                variant="ghost"
+                variant="secondary"
                 size="icon"
-                className="h-6 w-6 transition-all hover:bg-primary/20 hover:text-primary flex-shrink-0"
+                className="h-6 w-6"
+                aria-label="Add to timeline"
+                disabled={addingToTimeline}
+                onClick={handleAddToTimeline}
               >
-                <MoreVertical className="w-3 h-3" />
+                {addingToTimeline ? (
+                  <Loader2 className="w-3 h-3 animate-spin" />
+                ) : (
+                  <Plus className="w-3 h-3" />
+                )}
               </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" onClick={(e) => e.stopPropagation()}>
-              {isBroken && onRelink && (
+            )}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 transition-all hover:bg-primary/20 hover:text-primary flex-shrink-0"
+                >
+                  <MoreVertical className="w-3 h-3" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" onClick={(e) => e.stopPropagation()}>
+                {showAddToTimeline && (
+                  <DropdownMenuItem onClick={handleAddToTimeline} disabled={addingToTimeline}>
+                    <Plus className="w-3 h-3 mr-2" />
+                    {addingToTimeline ? 'Adding…' : 'Add to Timeline'}
+                  </DropdownMenuItem>
+                )}
+                {isBroken && onRelink && (
                 <DropdownMenuItem onClick={(e) => { e.stopPropagation(); onRelink(); }} className="text-primary focus:text-primary">
                   <RefreshCw className="w-3 h-3 mr-2" />
                   Relink File...
@@ -363,6 +413,7 @@ export function MediaCard({ media, selected = false, isBroken = false, onSelect,
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
+          </div>
         )}
       </div>
     );
@@ -470,18 +521,41 @@ export function MediaCard({ media, selected = false, isBroken = false, onSelect,
 
           {/* Actions dropdown - hidden during upload */}
           {!isImporting && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
+            <div className="flex items-center gap-0.5 flex-shrink-0">
+              {showAddToTimeline && (
                 <Button
-                  variant="ghost"
+                  variant="secondary"
                   size="icon"
-                  className="h-5 w-5 transition-all hover:bg-primary/20 hover:text-primary flex-shrink-0"
+                  className="h-5 w-5"
+                  aria-label="Add to timeline"
+                  disabled={addingToTimeline}
+                  onClick={handleAddToTimeline}
                 >
-                  <MoreVertical className="w-2.5 h-2.5" />
+                  {addingToTimeline ? (
+                    <Loader2 className="w-2.5 h-2.5 animate-spin" />
+                  ) : (
+                    <Plus className="w-2.5 h-2.5" />
+                  )}
                 </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="start" onClick={(e) => e.stopPropagation()}>
-                {isBroken && onRelink && (
+              )}
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-5 w-5 transition-all hover:bg-primary/20 hover:text-primary flex-shrink-0"
+                  >
+                    <MoreVertical className="w-2.5 h-2.5" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start" onClick={(e) => e.stopPropagation()}>
+                  {showAddToTimeline && (
+                    <DropdownMenuItem onClick={handleAddToTimeline} disabled={addingToTimeline}>
+                      <Plus className="w-3 h-3 mr-2" />
+                      {addingToTimeline ? 'Adding…' : 'Add to Timeline'}
+                    </DropdownMenuItem>
+                  )}
+                  {isBroken && onRelink && (
                   <DropdownMenuItem onClick={(e) => { e.stopPropagation(); onRelink(); }} className="text-primary focus:text-primary">
                     <RefreshCw className="w-3 h-3 mr-2" />
                     Relink File...
@@ -523,6 +597,7 @@ export function MediaCard({ media, selected = false, isBroken = false, onSelect,
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
+            </div>
           )}
         </div>
       </div>

--- a/src/features/media-library/deps/timeline-utils.ts
+++ b/src/features/media-library/deps/timeline-utils.ts
@@ -1,1 +1,1 @@
-export { autoMatchOrphanedClips } from './timeline-contract';
+export { autoMatchOrphanedClips, getTimelinePlacementErrorMessage } from './timeline-contract';

--- a/src/features/media-library/hooks/use-is-mobile.ts
+++ b/src/features/media-library/hooks/use-is-mobile.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+
+/** Matches editor mobile breakpoint (max-width: 767px). */
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return window.matchMedia('(max-width: 767px)').matches;
+  });
+
+  useEffect(() => {
+    const mql = window.matchMedia('(max-width: 767px)');
+    const handler = () => setIsMobile(mql.matches);
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, []);
+
+  return isMobile;
+}

--- a/src/features/media-library/hooks/use-is-mobile.ts
+++ b/src/features/media-library/hooks/use-is-mobile.ts
@@ -2,13 +2,11 @@ import { useEffect, useState } from 'react';
 
 /** Matches editor mobile breakpoint (max-width: 767px). */
 export function useIsMobile(): boolean {
-  const [isMobile, setIsMobile] = useState(() => {
-    if (typeof window === 'undefined') return false;
-    return window.matchMedia('(max-width: 767px)').matches;
-  });
+  const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
     const mql = window.matchMedia('(max-width: 767px)');
+    setIsMobile(mql.matches);
     const handler = () => setIsMobile(mql.matches);
     mql.addEventListener('change', handler);
     return () => mql.removeEventListener('change', handler);

--- a/src/features/timeline/components/timeline-track.tsx
+++ b/src/features/timeline/components/timeline-track.tsx
@@ -714,12 +714,15 @@ export const TimelineTrack = memo(function TimelineTrack({ track }: TimelineTrac
         const clip = useGenerativeStore.getState().getClipById(generativeClipId);
         if (clip && currentProject?.id) {
           const { insertRecordedClip } = await import('../stores/actions/recorded-clip-actions');
-          await insertRecordedClip({
+          const result = await insertRecordedClip({
             blob: clip.blob,
             durationMs: clip.durationMs,
             linkedTimelineStart: dropFrame,
             projectId: currentProject.id,
           });
+          if (!result.ok) {
+            toast.error('Failed to add AI clip to timeline');
+          }
         } else {
           logger.warn('Generative clip not found or no project', { generativeClipId });
         }

--- a/src/features/timeline/contracts/live-ai.ts
+++ b/src/features/timeline/contracts/live-ai.ts
@@ -1,0 +1,5 @@
+/**
+ * Timeline contract consumed by live-ai feature adapters.
+ */
+
+export type { InsertRecordedClipFailureReason } from '../types';

--- a/src/features/timeline/contracts/media-library.ts
+++ b/src/features/timeline/contracts/media-library.ts
@@ -20,3 +20,4 @@ export {
 
 export { autoMatchOrphanedClips } from '../utils/media-validation';
 export { gifFrameCache } from '../services/gif-frame-cache';
+export { getTimelinePlacementErrorMessage } from '../utils/timeline-placement-errors';

--- a/src/features/timeline/stores/actions/recorded-clip-actions.test.ts
+++ b/src/features/timeline/stores/actions/recorded-clip-actions.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TimelineTrack } from '@/types/timeline';
+import { useItemsStore } from '../items-store';
+import { useTimelineSettingsStore } from '../timeline-settings-store';
+import { insertRecordedClip, addMediaToTimeline } from './recorded-clip-actions';
+
+const mediaLibraryMocks = vi.hoisted(() => ({
+  importMediaWithFile: vi.fn(),
+  getThumbnailBlobUrl: vi.fn(),
+  loadMediaItems: vi.fn(),
+  mediaItems: [] as Array<{
+    id: string;
+    fileName: string;
+    mimeType: string;
+    duration: number;
+    thumbnailId: string | null;
+  }>,
+}));
+
+vi.mock('@/features/timeline/deps/media-library-service', () => ({
+  mediaLibraryService: {
+    importMediaWithFile: mediaLibraryMocks.importMediaWithFile,
+    getThumbnailBlobUrl: mediaLibraryMocks.getThumbnailBlobUrl,
+  },
+}));
+
+vi.mock('@/features/timeline/deps/media-library-store', () => ({
+  useMediaLibraryStore: {
+    getState: () => ({
+      loadMediaItems: mediaLibraryMocks.loadMediaItems,
+      mediaItems: mediaLibraryMocks.mediaItems,
+    }),
+  },
+}));
+
+vi.mock('@/features/timeline/deps/media-library-resolver', () => ({
+  resolveMediaUrl: vi.fn(),
+}));
+
+vi.mock('@/features/timeline/deps/projects', () => ({
+  useProjectStore: {
+    getState: () => ({
+      currentProject: {
+        id: 'project-1',
+        metadata: { width: 1920, height: 1080 },
+      },
+    }),
+  },
+}));
+
+vi.mock('@/shared/state/playback', () => ({
+  usePlaybackStore: {
+    getState: () => ({ currentFrame: 45 }),
+  },
+}));
+
+vi.mock('./item-actions', () => ({
+  addItem: vi.fn(),
+}));
+
+import { resolveMediaUrl } from '@/features/timeline/deps/media-library-resolver';
+import { addItem } from './item-actions';
+
+function makeTrack(overrides: Partial<TimelineTrack> = {}): TimelineTrack {
+  return {
+    id: 'track-1',
+    name: 'Track 1',
+    type: 'video',
+    order: 0,
+    visible: true,
+    locked: false,
+    muted: false,
+    isGroup: false,
+    ...overrides,
+  };
+}
+
+describe('insertRecordedClip', () => {
+  beforeEach(() => {
+    vi.mocked(mediaLibraryMocks.importMediaWithFile).mockReset();
+    vi.mocked(mediaLibraryMocks.loadMediaItems).mockReset();
+    vi.mocked(mediaLibraryMocks.getThumbnailBlobUrl).mockReset();
+    mediaLibraryMocks.mediaItems = [];
+    vi.mocked(resolveMediaUrl).mockReset();
+    vi.mocked(addItem).mockReset();
+
+    useTimelineSettingsStore.setState({ fps: 30, isDirty: false });
+    useItemsStore.getState().setItems([]);
+    useItemsStore.getState().setTracks([makeTrack()]);
+  });
+
+  it('returns no_project when projectId is empty', async () => {
+    const result = await insertRecordedClip({
+      blob: new Blob(['x'], { type: 'video/webm' }),
+      durationMs: 1000,
+      linkedTimelineStart: 0,
+      projectId: '',
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'no_project' });
+  });
+
+  it('returns no_track when all tracks are locked', async () => {
+    useItemsStore.getState().setTracks([makeTrack({ locked: true })]);
+
+    const result = await insertRecordedClip({
+      blob: new Blob(['x'], { type: 'video/webm' }),
+      durationMs: 1000,
+      linkedTimelineStart: 0,
+      projectId: 'project-1',
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'no_track' });
+    expect(mediaLibraryMocks.importMediaWithFile).not.toHaveBeenCalled();
+  });
+
+  it('inserts clip on the timeline on success', async () => {
+    mediaLibraryMocks.importMediaWithFile.mockResolvedValue({
+      id: 'media-1',
+      fileName: 'ai-recording.webm',
+      mimeType: 'video/webm',
+      duration: 1,
+      thumbnailId: null,
+    });
+    mediaLibraryMocks.loadMediaItems.mockResolvedValue(undefined);
+    vi.mocked(resolveMediaUrl).mockResolvedValue('blob:recording');
+
+    const result = await insertRecordedClip({
+      blob: new Blob(['x'], { type: 'video/webm' }),
+      durationMs: 1000,
+      linkedTimelineStart: 30,
+      projectId: 'project-1',
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.mediaId).toBe('media-1');
+      expect(result.from).toBe(30);
+      expect(result.trackId).toBe('track-1');
+    }
+    expect(addItem).toHaveBeenCalledOnce();
+    expect(mediaLibraryMocks.loadMediaItems).toHaveBeenCalledOnce();
+  });
+});
+
+describe('addMediaToTimeline', () => {
+  beforeEach(() => {
+    vi.mocked(resolveMediaUrl).mockReset();
+    vi.mocked(addItem).mockReset();
+    mediaLibraryMocks.mediaItems = [];
+    useTimelineSettingsStore.setState({ fps: 30, isDirty: false });
+    useItemsStore.getState().setItems([]);
+    useItemsStore.getState().setTracks([makeTrack()]);
+  });
+
+  it('returns media_not_found when media is missing', async () => {
+    const result = await addMediaToTimeline('missing-id');
+    expect(result).toEqual({ ok: false, reason: 'media_not_found' });
+  });
+
+  it('adds media at the playhead on success', async () => {
+    mediaLibraryMocks.mediaItems = [
+      {
+        id: 'media-1',
+        fileName: 'clip.mp4',
+        mimeType: 'video/mp4',
+        duration: 2,
+        thumbnailId: null,
+      },
+    ];
+    vi.mocked(resolveMediaUrl).mockResolvedValue('blob:clip');
+
+    const result = await addMediaToTimeline('media-1');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.from).toBe(45);
+      expect(result.mediaId).toBe('media-1');
+    }
+    expect(addItem).toHaveBeenCalledOnce();
+  });
+});

--- a/src/features/timeline/stores/actions/recorded-clip-actions.test.ts
+++ b/src/features/timeline/stores/actions/recorded-clip-actions.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { TimelineTrack } from '@/types/timeline';
+import type { TimelineItem, TimelineTrack } from '@/types/timeline';
 import { useItemsStore } from '../items-store';
 import { useTimelineSettingsStore } from '../timeline-settings-store';
 import { insertRecordedClip, addMediaToTimeline } from './recorded-clip-actions';
@@ -65,13 +65,38 @@ function makeTrack(overrides: Partial<TimelineTrack> = {}): TimelineTrack {
   return {
     id: 'track-1',
     name: 'Track 1',
-    type: 'video',
+    height: 60,
     order: 0,
     visible: true,
     locked: false,
     muted: false,
-    isGroup: false,
+    solo: false,
+    items: [],
     ...overrides,
+  };
+}
+
+function makeAudioItem(trackId: string): TimelineItem {
+  return {
+    id: 'audio-item-1',
+    trackId,
+    from: 0,
+    durationInFrames: 30,
+    label: 'Audio',
+    type: 'audio',
+    src: 'blob:audio',
+  };
+}
+
+function makeVideoItem(trackId: string): TimelineItem {
+  return {
+    id: 'video-item-1',
+    trackId,
+    from: 0,
+    durationInFrames: 30,
+    label: 'Video',
+    type: 'video',
+    src: 'blob:video',
   };
 }
 
@@ -141,6 +166,23 @@ describe('insertRecordedClip', () => {
     expect(addItem).toHaveBeenCalledOnce();
     expect(mediaLibraryMocks.loadMediaItems).toHaveBeenCalledOnce();
   });
+
+  it('returns no_track when only audio tracks are available', async () => {
+    useItemsStore.getState().setTracks([
+      makeTrack({ id: 'audio-track', name: 'Audio 1', order: 0 }),
+    ]);
+    useItemsStore.getState().setItems([makeAudioItem('audio-track')]);
+
+    const result = await insertRecordedClip({
+      blob: new Blob(['x'], { type: 'video/webm' }),
+      durationMs: 1000,
+      linkedTimelineStart: 0,
+      projectId: 'project-1',
+    });
+
+    expect(result).toEqual({ ok: false, reason: 'no_track' });
+    expect(mediaLibraryMocks.importMediaWithFile).not.toHaveBeenCalled();
+  });
 });
 
 describe('addMediaToTimeline', () => {
@@ -176,6 +218,35 @@ describe('addMediaToTimeline', () => {
     if (result.ok) {
       expect(result.from).toBe(45);
       expect(result.mediaId).toBe('media-1');
+    }
+    expect(addItem).toHaveBeenCalledOnce();
+  });
+
+  it('places audio media on an audio track instead of a video track', async () => {
+    useItemsStore.getState().setTracks([
+      makeTrack({ id: 'video-track', name: 'Video 1', order: 0 }),
+      makeTrack({ id: 'audio-track', name: 'Audio 1', order: 1 }),
+    ]);
+    useItemsStore.getState().setItems([
+      makeVideoItem('video-track'),
+      makeAudioItem('audio-track'),
+    ]);
+    mediaLibraryMocks.mediaItems = [
+      {
+        id: 'media-audio',
+        fileName: 'voice.wav',
+        mimeType: 'audio/wav',
+        duration: 2,
+        thumbnailId: null,
+      },
+    ];
+    vi.mocked(resolveMediaUrl).mockResolvedValue('blob:voice');
+
+    const result = await addMediaToTimeline('media-audio');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.trackId).toBe('audio-track');
     }
     expect(addItem).toHaveBeenCalledOnce();
   });

--- a/src/features/timeline/stores/actions/recorded-clip-actions.ts
+++ b/src/features/timeline/stores/actions/recorded-clip-actions.ts
@@ -7,6 +7,8 @@ import type {
   InsertRecordedClipParams,
   InsertRecordedClipResult,
 } from '../../types';
+import type { TimelineItem, TimelineTrack } from '@/types/timeline';
+import type { DroppableMediaType } from '../../utils/dropped-media';
 import { useItemsStore } from '../items-store';
 import { useTimelineSettingsStore } from '../timeline-settings-store';
 import { useProjectStore } from '@/features/timeline/deps/projects';
@@ -18,6 +20,35 @@ import { buildTimelineBaseItem, buildTypedTimelineItem } from '../../utils/build
 import { logger } from './shared';
 import { addItem } from './item-actions';
 import { usePlaybackStore } from '@/shared/state/playback';
+
+function trackAcceptsMediaType(
+  track: TimelineTrack,
+  mediaType: DroppableMediaType,
+  items: readonly TimelineItem[],
+): boolean {
+  if (track.isGroup || !track.visible || track.locked) {
+    return false;
+  }
+
+  const trackItems = items.filter((item) => item.trackId === track.id);
+  if (trackItems.length === 0) {
+    return true;
+  }
+
+  if (mediaType === 'audio') {
+    return trackItems.every((item) => item.type === 'audio');
+  }
+
+  return trackItems.every((item) => item.type !== 'audio');
+}
+
+function findDroppableTrack(
+  tracks: TimelineTrack[],
+  items: readonly TimelineItem[],
+  mediaType: DroppableMediaType,
+): TimelineTrack | undefined {
+  return tracks.find((track) => trackAcceptsMediaType(track, mediaType, items));
+}
 
 /**
  * Insert a recorded Live AI clip (blob) onto the timeline.
@@ -35,9 +66,10 @@ export async function insertRecordedClip(
   }
 
   const tracks = useItemsStore.getState().tracks;
-  const droppableTrack = tracks.find((t) => !t.isGroup && t.visible && !t.locked);
+  const items = useItemsStore.getState().items;
+  const droppableTrack = findDroppableTrack(tracks, items, 'video');
   if (!droppableTrack) {
-    logger.warn('No droppable track available for recorded clip');
+    logger.warn('No droppable video track available for recorded clip');
     return { ok: false, reason: 'no_track' };
   }
 
@@ -64,7 +96,6 @@ export async function insertRecordedClip(
       }
     }
 
-    const items = useItemsStore.getState().items;
     const fps = useTimelineSettingsStore.getState().fps;
     const project = useProjectStore.getState().currentProject;
     const canvasWidth = project?.metadata.width ?? 1920;
@@ -162,9 +193,10 @@ export async function addMediaToTimeline(mediaId: string): Promise<AddMediaToTim
   }
 
   const tracks = useItemsStore.getState().tracks;
-  const droppableTrack = tracks.find((t) => !t.isGroup && t.visible && !t.locked);
+  const items = useItemsStore.getState().items;
+  const droppableTrack = findDroppableTrack(tracks, items, mediaType);
   if (!droppableTrack) {
-    logger.warn('No droppable track available for media add');
+    logger.warn(`No droppable track available for media type: ${mediaType}`);
     return { ok: false, reason: 'no_track' };
   }
 
@@ -188,7 +220,6 @@ export async function addMediaToTimeline(mediaId: string): Promise<AddMediaToTim
       }
     }
 
-    const items = useItemsStore.getState().items;
     const mediaDurationSec = media.duration > 0 ? media.duration : 5;
     const durationInFrames = Math.max(1, Math.round(mediaDurationSec * fps));
     const playheadFrame = usePlaybackStore.getState().currentFrame;

--- a/src/features/timeline/stores/actions/recorded-clip-actions.ts
+++ b/src/features/timeline/stores/actions/recorded-clip-actions.ts
@@ -2,7 +2,11 @@
  * Recorded Clip Actions - Import AI-recorded video blobs to media library and timeline.
  */
 
-import type { InsertRecordedClipParams } from '../../types';
+import type {
+  AddMediaToTimelineResult,
+  InsertRecordedClipParams,
+  InsertRecordedClipResult,
+} from '../../types';
 import { useItemsStore } from '../items-store';
 import { useTimelineSettingsStore } from '../timeline-settings-store';
 import { useProjectStore } from '@/features/timeline/deps/projects';
@@ -13,6 +17,7 @@ import { findNearestAvailableSpace } from '../../utils/collision-utils';
 import { buildTimelineBaseItem, buildTypedTimelineItem } from '../../utils/build-timeline-item-from-media';
 import { logger } from './shared';
 import { addItem } from './item-actions';
+import { usePlaybackStore } from '@/shared/state/playback';
 
 /**
  * Insert a recorded Live AI clip (blob) onto the timeline.
@@ -20,24 +25,36 @@ import { addItem } from './item-actions';
  * 2. Resolves blob URL and thumbnail
  * 3. Creates a video timeline item at the given position
  */
-export async function insertRecordedClip(params: InsertRecordedClipParams): Promise<void> {
+export async function insertRecordedClip(
+  params: InsertRecordedClipParams,
+): Promise<InsertRecordedClipResult> {
   const { blob, durationMs, linkedTimelineStart, projectId } = params;
 
+  if (!projectId) {
+    return { ok: false, reason: 'no_project' };
+  }
+
+  const tracks = useItemsStore.getState().tracks;
+  const droppableTrack = tracks.find((t) => !t.isGroup && t.visible && !t.locked);
+  if (!droppableTrack) {
+    logger.warn('No droppable track available for recorded clip');
+    return { ok: false, reason: 'no_track' };
+  }
+
   try {
-    const file = new File([blob], `ai-recording-${Date.now()}.webm`, { type: blob.type || 'video/webm' });
+    const file = new File([blob], `ai-recording-${Date.now()}.webm`, {
+      type: blob.type || 'video/webm',
+    });
     const media = await mediaLibraryService.importMediaWithFile(file, projectId);
 
-    // Refresh the media library store so the clip shows in the sidebar
     await useMediaLibraryStore.getState().loadMediaItems();
 
-    // Resolve blob URL for playback
     const blobUrl = await resolveMediaUrl(media.id);
     if (!blobUrl || blobUrl === '') {
       logger.error('Failed to resolve blob URL for recorded clip', { mediaId: media.id });
-      return;
+      return { ok: false, reason: 'resolve_failed' };
     }
 
-    // Resolve thumbnail
     let thumbnailUrl: string | null = null;
     if (media.thumbnailId) {
       try {
@@ -47,25 +64,14 @@ export async function insertRecordedClip(params: InsertRecordedClipParams): Prom
       }
     }
 
-    // Get timeline settings
-    const tracks = useItemsStore.getState().tracks;
     const items = useItemsStore.getState().items;
     const fps = useTimelineSettingsStore.getState().fps;
     const project = useProjectStore.getState().currentProject;
     const canvasWidth = project?.metadata.width ?? 1920;
     const canvasHeight = project?.metadata.height ?? 1080;
 
-    // Find a droppable track (prefer first non-group, visible, unlocked track)
-    const droppableTrack = tracks.find((t) => !t.isGroup && t.visible && !t.locked);
-    if (!droppableTrack) {
-      logger.warn('No droppable track available for recorded clip');
-      return;
-    }
-
-    // Calculate duration in frames
     const durationInFrames = Math.max(1, Math.round((durationMs / 1000) * fps));
 
-    // Find collision-free position
     const proposedPosition = Math.max(0, linkedTimelineStart);
     const trackItems = items.filter((i) => i.trackId === droppableTrack.id);
     const finalPosition = findNearestAvailableSpace(
@@ -77,10 +83,9 @@ export async function insertRecordedClip(params: InsertRecordedClipParams): Prom
 
     if (finalPosition === null) {
       logger.warn('No available space on track for recorded clip');
-      return;
+      return { ok: false, reason: 'no_space' };
     }
 
-    // Build timeline item
     const baseItem = buildTimelineBaseItem({
       media,
       mediaId: media.id,
@@ -103,7 +108,7 @@ export async function insertRecordedClip(params: InsertRecordedClipParams): Prom
 
     if (!timelineItem) {
       logger.error('Failed to build timeline item for recorded clip');
-      return;
+      return { ok: false, reason: 'build_failed' };
     }
 
     addItem(timelineItem);
@@ -113,8 +118,17 @@ export async function insertRecordedClip(params: InsertRecordedClipParams): Prom
       from: finalPosition,
       durationInFrames,
     });
+
+    return {
+      ok: true,
+      mediaId: media.id,
+      itemId: timelineItem.id,
+      from: finalPosition,
+      trackId: droppableTrack.id,
+    };
   } catch (error) {
     logger.error('Failed to insert recorded clip', error);
+    return { ok: false, reason: 'import_failed' };
   }
 }
 
@@ -122,75 +136,115 @@ export async function insertRecordedClip(params: InsertRecordedClipParams): Prom
  * Add existing media to the timeline at the playhead position.
  * Mobile-friendly alternative to drag-drop.
  */
-export async function addMediaToTimeline(mediaId: string): Promise<void> {
+export async function addMediaToTimeline(mediaId: string): Promise<AddMediaToTimelineResult> {
+  const project = useProjectStore.getState().currentProject;
+  if (!project?.id) {
+    return { ok: false, reason: 'no_project' };
+  }
+
   const media = useMediaLibraryStore.getState().mediaItems.find((m) => m.id === mediaId);
   if (!media) {
     logger.error('Media not found for addMediaToTimeline', { mediaId });
-    return;
+    return { ok: false, reason: 'media_not_found' };
   }
-
-  const fps = useTimelineSettingsStore.getState().fps;
-  const project = useProjectStore.getState().currentProject;
-  const canvasWidth = project?.metadata.width ?? 1920;
-  const canvasHeight = project?.metadata.height ?? 1080;
-
-  const blobUrl = await resolveMediaUrl(mediaId);
-  if (!blobUrl || blobUrl === '') {
-    logger.error('Failed to resolve blob URL', { mediaId });
-    return;
-  }
-
-  let thumbnailUrl: string | null = null;
-  if (media.thumbnailId) {
-    try {
-      thumbnailUrl = await mediaLibraryService.getThumbnailBlobUrl(mediaId);
-    } catch {
-      // Optional
-    }
-  }
-
-  const tracks = useItemsStore.getState().tracks;
-  const items = useItemsStore.getState().items;
-  const droppableTrack = tracks.find((t) => !t.isGroup && t.visible && !t.locked);
-  if (!droppableTrack) return;
-
-  // Calculate duration: use media duration or default 5s for images
-  const mediaDurationSec = media.duration > 0 ? media.duration : 5;
-  const durationInFrames = Math.max(1, Math.round(mediaDurationSec * fps));
-
-  // Place at frame 0 (playhead would be better but keeping it simple)
-  const trackItems = items.filter((i) => i.trackId === droppableTrack.id);
-  const finalPosition = findNearestAvailableSpace(0, durationInFrames, droppableTrack.id, trackItems);
-  if (finalPosition === null) return;
 
   const mimeType = media.mimeType || '';
   const mediaType = mimeType.startsWith('video/')
     ? 'video'
     : mimeType.startsWith('audio/')
       ? 'audio'
-      : 'image';
+      : mimeType.startsWith('image/')
+        ? 'image'
+        : null;
 
-  const baseItem = buildTimelineBaseItem({
-    media,
-    mediaId,
-    label: media.fileName,
-    trackId: droppableTrack.id,
-    from: finalPosition,
-    durationInFrames,
-    timelineFps: fps,
-  });
+  if (!mediaType) {
+    return { ok: false, reason: 'unsupported_type' };
+  }
 
-  const timelineItem = buildTypedTimelineItem({
-    baseItem,
-    mediaType,
-    blobUrl,
-    thumbnailUrl,
-    media,
-    canvasWidth,
-    canvasHeight,
-  });
+  const tracks = useItemsStore.getState().tracks;
+  const droppableTrack = tracks.find((t) => !t.isGroup && t.visible && !t.locked);
+  if (!droppableTrack) {
+    logger.warn('No droppable track available for media add');
+    return { ok: false, reason: 'no_track' };
+  }
 
-  if (timelineItem) {
+  try {
+    const fps = useTimelineSettingsStore.getState().fps;
+    const canvasWidth = project.metadata.width ?? 1920;
+    const canvasHeight = project.metadata.height ?? 1080;
+
+    const blobUrl = await resolveMediaUrl(mediaId);
+    if (!blobUrl || blobUrl === '') {
+      logger.error('Failed to resolve blob URL', { mediaId });
+      return { ok: false, reason: 'resolve_failed' };
+    }
+
+    let thumbnailUrl: string | null = null;
+    if (media.thumbnailId) {
+      try {
+        thumbnailUrl = await mediaLibraryService.getThumbnailBlobUrl(mediaId);
+      } catch {
+        // Optional
+      }
+    }
+
+    const items = useItemsStore.getState().items;
+    const mediaDurationSec = media.duration > 0 ? media.duration : 5;
+    const durationInFrames = Math.max(1, Math.round(mediaDurationSec * fps));
+    const playheadFrame = usePlaybackStore.getState().currentFrame;
+
+    const trackItems = items.filter((i) => i.trackId === droppableTrack.id);
+    const finalPosition = findNearestAvailableSpace(
+      Math.max(0, playheadFrame),
+      durationInFrames,
+      droppableTrack.id,
+      trackItems,
+    );
+    if (finalPosition === null) {
+      return { ok: false, reason: 'no_space' };
+    }
+
+    const baseItem = buildTimelineBaseItem({
+      media,
+      mediaId,
+      label: media.fileName,
+      trackId: droppableTrack.id,
+      from: finalPosition,
+      durationInFrames,
+      timelineFps: fps,
+    });
+
+    const timelineItem = buildTypedTimelineItem({
+      baseItem,
+      mediaType,
+      blobUrl,
+      thumbnailUrl,
+      media,
+      canvasWidth,
+      canvasHeight,
+    });
+
+    if (!timelineItem) {
+      return { ok: false, reason: 'build_failed' };
+    }
+
     addItem(timelineItem);
+    logger.info('Added media to timeline', {
+      mediaId,
+      trackId: droppableTrack.id,
+      from: finalPosition,
+      durationInFrames,
+    });
+
+    return {
+      ok: true,
+      mediaId,
+      itemId: timelineItem.id,
+      from: finalPosition,
+      trackId: droppableTrack.id,
+    };
+  } catch (error) {
+    logger.error('Failed to add media to timeline', error);
+    return { ok: false, reason: 'import_failed' };
   }
 }

--- a/src/features/timeline/types.ts
+++ b/src/features/timeline/types.ts
@@ -119,9 +119,9 @@ export interface TimelineActions {
   markDirty: () => void;
   markClean: () => void;
   /** Add media to timeline at playhead (mobile-friendly, no drag required) */
-  addMediaToTimeline: (mediaId: string) => Promise<void>;
+  addMediaToTimeline: (mediaId: string) => Promise<AddMediaToTimelineResult>;
   /** Insert a recorded Live AI clip (blob) at the given timeline position */
-  insertRecordedClip: (params: InsertRecordedClipParams) => Promise<void>;
+  insertRecordedClip: (params: InsertRecordedClipParams) => Promise<InsertRecordedClipResult>;
 }
 
 export interface InsertRecordedClipParams {
@@ -130,3 +130,41 @@ export interface InsertRecordedClipParams {
   linkedTimelineStart: number;
   projectId: string;
 }
+
+export type TimelinePlacementFailureReason =
+  | 'no_project'
+  | 'media_not_found'
+  | 'unsupported_type'
+  | 'import_failed'
+  | 'resolve_failed'
+  | 'no_track'
+  | 'no_space'
+  | 'build_failed';
+
+export type InsertRecordedClipFailureReason = TimelinePlacementFailureReason;
+
+export type InsertRecordedClipResult =
+  | {
+      ok: true;
+      mediaId: string;
+      itemId: string;
+      from: number;
+      trackId: string;
+    }
+  | {
+      ok: false;
+      reason: InsertRecordedClipFailureReason;
+    };
+
+export type AddMediaToTimelineResult =
+  | {
+      ok: true;
+      mediaId: string;
+      itemId: string;
+      from: number;
+      trackId: string;
+    }
+  | {
+      ok: false;
+      reason: TimelinePlacementFailureReason;
+    };

--- a/src/features/timeline/utils/timeline-placement-errors.ts
+++ b/src/features/timeline/utils/timeline-placement-errors.ts
@@ -1,0 +1,26 @@
+import type { TimelinePlacementFailureReason } from '@/features/timeline/types';
+
+export function getTimelinePlacementErrorMessage(
+  reason: TimelinePlacementFailureReason,
+): string {
+  switch (reason) {
+    case 'no_project':
+      return 'Open a project before adding media to the timeline.';
+    case 'media_not_found':
+      return 'Media item not found. Try refreshing the library.';
+    case 'unsupported_type':
+      return 'This file type cannot be added to the timeline.';
+    case 'import_failed':
+      return 'Failed to import the media into the library.';
+    case 'resolve_failed':
+      return 'Media imported but playback URL could not be resolved.';
+    case 'no_track':
+      return 'Unlock a visible track to add media.';
+    case 'no_space':
+      return 'Not enough space on the timeline—trim clips or add a track.';
+    case 'build_failed':
+      return 'Failed to create a timeline clip from this media.';
+    default:
+      return 'Failed to add media to timeline.';
+  }
+}


### PR DESCRIPTION
## Summary
- Live AI recordings auto-insert on the timeline at the playhead when recording stops, with success/error toasts and a persisted auto-add toggle (default on).
- Media library cards on mobile get an **Add to Timeline** action so imports no longer require download-and-reimport.
- `insertRecordedClip` and `addMediaToTimeline` return structured success/error results instead of failing silently.

## Test plan
- [ ] Start Live AI session → record → stop: clip appears on timeline at playhead without extra clicks
- [ ] Toggle auto-add off → record → stop: **Add to Timeline** button appears and works
- [ ] Lock all tracks → auto-add shows error toast; take remains for retry after unlock
- [ ] On mobile width, tap **Add to Timeline** on a media card → clip lands at playhead with toast
- [ ] Generative Clip Bin drag-drop still works with new `insertRecordedClip` return type
- [ ] `npm run test:run -- recorded-clip-actions live-session-store`


Made with [Cursor](https://cursor.com)