### PR TITLE
fix(api): resolve credits serverless ESM import crashes

### DIFF
--- a/api/_credit-store.test.ts
+++ b/api/_credit-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { parseRedisInteger } from './_credit-store';
+import { parseRedisInteger } from './_credit-store.js';
 
 describe('parseRedisInteger', () => {
   it('parses numbers', () => {

--- a/api/_credit-store.ts
+++ b/api/_credit-store.ts
@@ -1,4 +1,4 @@
-import { getRedis, isRedisConfigured } from './_redis-client';
+import { getRedis, isRedisConfigured } from './_redis-client.js';
 
 export function isCreditStoreConfigured(): boolean {
   return isRedisConfigured();

--- a/api/_promo-store.ts
+++ b/api/_promo-store.ts
@@ -1,5 +1,5 @@
-import { addCredits } from './_credit-store';
-import { getRedis, isRedisConfigured } from './_redis-client';
+import { addCredits } from './_credit-store.js';
+import { getRedis, isRedisConfigured } from './_redis-client.js';
 
 export function isPromoStoreConfigured(): boolean {
   return isRedisConfigured();

--- a/api/_wallet-auth.ts
+++ b/api/_wallet-auth.ts
@@ -3,7 +3,7 @@ import {
   ADDRESS_REGEX,
   HEX_SIG_REGEX,
   MAX_SIG_AGE_MS,
-} from './_address';
+} from './_address.js';
 
 export { ADDRESS_REGEX, HEX_SIG_REGEX, MAX_SIG_AGE_MS };
 

--- a/api/credits-balance.ts
+++ b/api/credits-balance.ts
@@ -3,8 +3,8 @@
  * Returns credit balance for a wallet.
  */
 
-import { ADDRESS_REGEX } from './_address';
-import { getCreditBalance, isCreditStoreConfigured } from './_credit-store';
+import { ADDRESS_REGEX } from './_address.js';
+import { getCreditBalance, isCreditStoreConfigured } from './_credit-store.js';
 
 export async function GET(request: Request): Promise<Response> {
   try {

--- a/api/credits-claim-membership.ts
+++ b/api/credits-claim-membership.ts
@@ -6,23 +6,17 @@
  * Body: { address, timestamp, nonce, signature }
  */
 
-import { createPublicClient, http, parseAbi } from 'viem';
-import { arbitrum } from 'viem/chains';
 import {
   buildCreditsAuthMessage,
   parseWalletAuthBody,
   verifyWalletMessage,
-} from './_wallet-auth';
+} from './_wallet-auth.js';
 import {
   addCredits,
   getCreditBalance,
   isCreditStoreConfigured,
-} from './_credit-store';
-import { getRedis } from './_redis-client';
-
-const UNLOCK_HAS_VALID_KEY_ABI = parseAbi([
-  'function getHasValidKey(address) view returns (bool)',
-]);
+} from './_credit-store.js';
+import { getRedis } from './_redis-client.js';
 
 /** Pixels Premium Unlock lock on Arbitrum ($30/mo). Keep in sync with src/infrastructure/unlock/membership.ts */
 const PIXELS_PREMIUM_LOCK_DEFAULT =
@@ -86,6 +80,12 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   try {
+    const { createPublicClient, http, parseAbi } = await import('viem');
+    const { arbitrum } = await import('viem/chains');
+    const unlockHasValidKeyAbi = parseAbi([
+      'function getHasValidKey(address) view returns (bool)',
+    ]);
+
     const client = createPublicClient({
       chain: arbitrum,
       transport: http(getArbitrumRpcUrl()),
@@ -93,7 +93,7 @@ export async function POST(request: Request): Promise<Response> {
 
     const hasKey = await client.readContract({
       address: getLockAddress(),
-      abi: UNLOCK_HAS_VALID_KEY_ABI,
+      abi: unlockHasValidKeyAbi,
       functionName: 'getHasValidKey',
       args: [auth.address as `0x${string}`],
     });

--- a/api/credits-debit.ts
+++ b/api/credits-debit.ts
@@ -8,8 +8,8 @@ import {
   buildCreditsAuthMessage,
   parseWalletAuthBody,
   verifyWalletMessage,
-} from './_wallet-auth';
-import { debitCredits, isCreditStoreConfigured } from './_credit-store';
+} from './_wallet-auth.js';
+import { debitCredits, isCreditStoreConfigured } from './_credit-store.js';
 
 const VALID_REASONS = new Set(['live_ai', 'flow_video', 'flow_image']);
 

--- a/api/credits-health.ts
+++ b/api/credits-health.ts
@@ -3,7 +3,7 @@
  * Diagnostic probe for credits API dependencies (Redis + viem).
  */
 
-import { isRedisConfigured, getRedis } from './_redis-client';
+import { isRedisConfigured, getRedis } from './_redis-client.js';
 
 export async function GET(): Promise<Response> {
   const redisConfigured = isRedisConfigured();

--- a/api/credits-redeem-promo.ts
+++ b/api/credits-redeem-promo.ts
@@ -8,8 +8,8 @@ import {
   buildCreditsAuthMessage,
   parseWalletAuthBody,
   verifyWalletMessage,
-} from './_wallet-auth';
-import { isPromoStoreConfigured, redeemPromoCode } from './_promo-store';
+} from './_wallet-auth.js';
+import { isPromoStoreConfigured, redeemPromoCode } from './_promo-store.js';
 
 const REDEEM_RATE_WINDOW_MS = 60_000;
 const REDEEM_RATE_MAX = 5;

--- a/api/credits-sync-purchase.ts
+++ b/api/credits-sync-purchase.ts
@@ -4,23 +4,15 @@
  * Body: { address, txHash }
  */
 
-import {
-  createPublicClient,
-  decodeEventLog,
-  http,
-  parseAbiItem,
-  type Log,
-} from 'viem';
-import { arbitrum } from 'viem/chains';
-import { ADDRESS_REGEX } from './_address';
-import { validateCreditPurchaseEvent } from './_credit-packs';
-import { creditFromPurchase, isCreditStoreConfigured } from './_credit-store';
-
-const CREDITS_PURCHASED = parseAbiItem(
-  'event CreditsPurchased(address indexed buyer, uint8 indexed packId, uint256 credits, uint256 usdcPaid)'
-);
+import type { Log } from 'viem';
+import { ADDRESS_REGEX } from './_address.js';
+import { validateCreditPurchaseEvent } from './_credit-packs.js';
+import { creditFromPurchase, isCreditStoreConfigured } from './_credit-store.js';
 
 const TX_HASH_REGEX = /^0x[a-fA-F0-9]{64}$/;
+
+const CREDITS_PURCHASED_EVENT =
+  'event CreditsPurchased(address indexed buyer, uint8 indexed packId, uint256 credits, uint256 usdcPaid)';
 
 function getPaymentContract(): `0x${string}` | null {
   const v =
@@ -47,16 +39,18 @@ type CreditsPurchasedLog = {
   };
 };
 
-function findCreditsPurchasedLog(
+async function findCreditsPurchasedLog(
   logs: Log[],
   contractAddress: string
-): CreditsPurchasedLog | null {
+): Promise<CreditsPurchasedLog | null> {
+  const { decodeEventLog, parseAbiItem } = await import('viem');
+  const creditsPurchased = parseAbiItem(CREDITS_PURCHASED_EVENT);
   const target = contractAddress.toLowerCase();
   for (const log of logs) {
     if (log.address.toLowerCase() !== target) continue;
     try {
       const decoded = decodeEventLog({
-        abi: [CREDITS_PURCHASED],
+        abi: [creditsPurchased],
         data: log.data,
         topics: log.topics,
       });
@@ -107,6 +101,8 @@ export async function POST(request: Request): Promise<Response> {
   }
 
   try {
+    const { createPublicClient, http } = await import('viem');
+    const { arbitrum } = await import('viem/chains');
     const client = createPublicClient({
       chain: arbitrum,
       transport: http(getArbitrumRpcUrl()),
@@ -119,7 +115,7 @@ export async function POST(request: Request): Promise<Response> {
       return Response.json({ ok: false, reason: 'tx_failed' }, { status: 400 });
     }
 
-    const decoded = findCreditsPurchasedLog(receipt.logs, contractAddress);
+    const decoded = await findCreditsPurchasedLog(receipt.logs, contractAddress);
     if (!decoded || decoded.eventName !== 'CreditsPurchased') {
       return Response.json(
         { ok: false, reason: 'event_not_found' },

--- a/api/credits-sync-purchase.ts
+++ b/api/credits-sync-purchase.ts
@@ -64,6 +64,42 @@ async function findCreditsPurchasedLog(
   return null;
 }
 
+function classifyReceiptFetchError(e: unknown): {
+  reason: string;
+  status: number;
+} {
+  const message =
+    e instanceof Error ? e.message.toLowerCase() : String(e).toLowerCase();
+  const name =
+    e && typeof e === 'object' && 'name' in e ? String(e.name) : '';
+
+  if (
+    name === 'TransactionReceiptNotFoundError' ||
+    (message.includes('receipt') && message.includes('not found'))
+  ) {
+    return { reason: 'receipt_not_found', status: 404 };
+  }
+
+  if (
+    name === 'TransactionNotFoundError' ||
+    name === 'InvalidParamsRpcError'
+  ) {
+    return { reason: 'tx_not_found', status: 400 };
+  }
+
+  if (
+    name === 'HttpRequestError' ||
+    name === 'TimeoutError' ||
+    name === 'RpcRequestError' ||
+    message.includes('timeout') ||
+    message.includes('fetch failed')
+  ) {
+    return { reason: 'rpc_error', status: 503 };
+  }
+
+  return { reason: 'error', status: 500 };
+}
+
 export async function POST(request: Request): Promise<Response> {
   if (!isCreditStoreConfigured()) {
     return Response.json(
@@ -108,9 +144,24 @@ export async function POST(request: Request): Promise<Response> {
       transport: http(getArbitrumRpcUrl()),
     });
 
-    const receipt = await client.getTransactionReceipt({
-      hash: txHash as `0x${string}`,
-    });
+    let receipt;
+    try {
+      receipt = await client.getTransactionReceipt({
+        hash: txHash as `0x${string}`,
+      });
+    } catch (e) {
+      const classified = classifyReceiptFetchError(e);
+      console.error('credits-sync-purchase receipt fetch failed', {
+        txHash,
+        reason: classified.reason,
+        error: e,
+      });
+      return Response.json(
+        { ok: false, reason: classified.reason },
+        { status: classified.status }
+      );
+    }
+
     if (receipt.status !== 'success') {
       return Response.json({ ok: false, reason: 'tx_failed' }, { status: 400 });
     }

--- a/api/generate-image.ts
+++ b/api/generate-image.ts
@@ -6,9 +6,9 @@ import {
   buildCreditsAuthMessage,
   parseWalletAuthBody,
   verifyWalletMessage,
-} from './_wallet-auth';
-import { debitCredits, isCreditStoreConfigured } from './_credit-store';
-import { evolinkServerPost, isEvolinkServerConfigured } from './_evolink-server';
+} from './_wallet-auth.js';
+import { debitCredits, isCreditStoreConfigured } from './_credit-store.js';
+import { evolinkServerPost, isEvolinkServerConfigured } from './_evolink-server.js';
 
 function quoteNanobananaCredits(quality: string): number {
   const map: Record<string, number> = {

--- a/api/generate-task.ts
+++ b/api/generate-task.ts
@@ -3,7 +3,7 @@
  * Poll Evolink task status (no additional credit charge).
  */
 
-import { evolinkServerGet, isEvolinkServerConfigured } from './_evolink-server';
+import { evolinkServerGet, isEvolinkServerConfigured } from './_evolink-server.js';
 
 export async function GET(request: Request): Promise<Response> {
   if (!isEvolinkServerConfigured()) {

--- a/api/generate-video.ts
+++ b/api/generate-video.ts
@@ -6,9 +6,9 @@ import {
   buildCreditsAuthMessage,
   parseWalletAuthBody,
   verifyWalletMessage,
-} from './_wallet-auth';
-import { debitCredits, isCreditStoreConfigured } from './_credit-store';
-import { evolinkServerPost, isEvolinkServerConfigured } from './_evolink-server';
+} from './_wallet-auth.js';
+import { debitCredits, isCreditStoreConfigured } from './_credit-store.js';
+import { evolinkServerPost, isEvolinkServerConfigured } from './_evolink-server.js';
 
 function quoteSeedanceCredits(body: Record<string, unknown>): number {
   const duration = typeof body.duration === 'number' ? body.duration : 5;

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["./**/*.ts"]
+}

--- a/src/features/credits/api/sync-purchase.test.ts
+++ b/src/features/credits/api/sync-purchase.test.ts
@@ -88,4 +88,31 @@ describe('syncPurchaseCredits', () => {
     expect(result.syncPending).toBe(false);
     expect(fetch).toHaveBeenCalledTimes(1);
   });
+
+  it('retries on receipt_not_found then succeeds', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(globalThis, 'fetch')
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ ok: false, reason: 'receipt_not_found' }), {
+          status: 404,
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ ok: true, creditsAdded: 50, balance: 50 }),
+          { status: 200 }
+        )
+      );
+
+    const promise = syncPurchaseCredits(
+      '0x1234567890123456789012345678901234567890',
+      '0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+    );
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result.ok).toBe(true);
+    expect(fetch).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
 });

--- a/src/features/credits/api/sync-purchase.ts
+++ b/src/features/credits/api/sync-purchase.ts
@@ -26,6 +26,7 @@ const TERMINAL_SYNC_REASONS = new Set([
   'buyer_mismatch',
   'pack_mismatch',
   'tx_failed',
+  'tx_not_found',
 ]);
 
 function isRetryableSyncFailure(
@@ -37,6 +38,8 @@ function isRetryableSyncFailure(
     reason === 'error' ||
     reason === 'disabled' ||
     reason === 'event_not_found' ||
+    reason === 'receipt_not_found' ||
+    reason === 'rpc_error' ||
     reason === 'network_error' ||
     status >= 500
   );


### PR DESCRIPTION
## Summary
- Add `.js` extensions to all relative imports under `api/` so Node ESM on Vercel can resolve modules at load time (fixes `ERR_MODULE_NOT_FOUND` / `FUNCTION_INVOCATION_FAILED` on credits routes).
- Add `api/tsconfig.json` with `NodeNext` module resolution to enforce ESM import rules.
- Lazy-load `viem` in `credits-sync-purchase` and `credits-claim-membership` to reduce cold-start pressure.

## Test plan
- [ ] Deploy preview and confirm `GET /api/credits-health` returns JSON (not Vercel crash page)
- [ ] Confirm `GET /api/credits-balance?address=0x...` returns `200` JSON
- [ ] Confirm `POST /api/credits-sync-purchase` returns structured JSON errors (400/503), not `FUNCTION_INVOCATION_FAILED`
- [ ] Verify Vercel runtime logs no longer show `ERR_MODULE_NOT_FOUND` for `/api/credits-*`
- [x] `npm run test:run api/_credit-store.test.ts`
- [x] `npx tsc -p api/tsconfig.json`


Made with [Cursor](https://cursor.com)