### PR TITLE
feat(wallet): add Send USDC transfer from wallet menu

### DIFF
--- a/src/components/send-usdc-modal.tsx
+++ b/src/components/send-usdc-modal.tsx
@@ -18,7 +18,11 @@ import { Label } from '@/components/ui/label';
 import { USDC_ADDRESS_BY_CHAIN_ID } from '@/config/chains';
 import { useSendUsdc } from '@/hooks/use-send-usdc';
 import { useUsdcBalance } from '@/hooks/use-usdc-balance';
-import { validateUsdcSend } from '@/shared/utils/usdc-transfer';
+import {
+  getMaxSendableUsdc,
+  getUsdcGasReserveUsdc6,
+  validateUsdcSend,
+} from '@/shared/utils/usdc-transfer';
 
 interface SendUsdcModalProps {
   open: boolean;
@@ -32,6 +36,7 @@ export function SendUsdcModal({ open, onOpenChange }: SendUsdcModalProps) {
     balance: usdcBalance,
     formatted: usdcFormatted,
     isLoading: isBalanceLoading,
+    isError: isBalanceError,
   } = useUsdcBalance(chain, address as `0x${string}` | undefined);
   const { sendUsdc, ready } = useSendUsdc();
 
@@ -49,6 +54,11 @@ export function SendUsdcModal({ open, onOpenChange }: SendUsdcModalProps) {
     }
   }, [open]);
 
+  const gasReserveUsdc6 = chain ? getUsdcGasReserveUsdc6(chain.id) : 0;
+  const maxSendableUsdc = chain
+    ? getMaxSendableUsdc(usdcBalance, chain.id)
+    : null;
+
   const validation = useMemo(
     () =>
       validateUsdcSend({
@@ -56,20 +66,24 @@ export function SendUsdcModal({ open, onOpenChange }: SendUsdcModalProps) {
         amount,
         balance: usdcBalance,
         senderAddress: address,
+        gasReserveUsdc6,
       }),
-    [address, amount, recipient, usdcBalance]
+    [address, amount, gasReserveUsdc6, recipient, usdcBalance]
   );
 
   const canSend =
     ready &&
     !isBalanceLoading &&
+    !isBalanceError &&
     validation.ok &&
     !isSending &&
     Boolean(chain && usdcBalance !== null);
 
+  const hasPositiveBalance = maxSendableUsdc !== null && Number(maxSendableUsdc) > 0;
+
   const handleMax = () => {
-    if (usdcBalance) {
-      setAmount(usdcBalance);
+    if (maxSendableUsdc) {
+      setAmount(maxSendableUsdc);
       setError(null);
     }
   };
@@ -99,9 +113,32 @@ export function SendUsdcModal({ open, onOpenChange }: SendUsdcModalProps) {
   const hasUsdc = chain ? chain.id in USDC_ADDRESS_BY_CHAIN_ID : false;
   const unsupportedNetwork = Boolean(chain && !hasUsdc);
 
+  const balanceStatusText = (() => {
+    if (isBalanceLoading) return 'Checking USDC balance…';
+    if (unsupportedNetwork) return 'USDC is not available on this network.';
+    if (isBalanceError || usdcBalance === null) {
+      return 'Failed to load USDC balance.';
+    }
+    return `Available: ${usdcFormatted} USDC`;
+  })();
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && isSending) return;
+    onOpenChange(nextOpen);
+  };
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md">
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        className="sm:max-w-md"
+        hideCloseButton={isSending}
+        onEscapeKeyDown={(event) => {
+          if (isSending) event.preventDefault();
+        }}
+        onPointerDownOutside={(event) => {
+          if (isSending) event.preventDefault();
+        }}
+      >
         <DialogHeader>
           <DialogTitle>Send USDC</DialogTitle>
           <DialogDescription>
@@ -111,13 +148,7 @@ export function SendUsdcModal({ open, onOpenChange }: SendUsdcModalProps) {
         </DialogHeader>
 
         <div className="grid gap-4 py-2">
-          <div className="text-muted-foreground text-sm">
-            {isBalanceLoading
-              ? 'Checking USDC balance…'
-              : unsupportedNetwork
-                ? 'USDC is not available on this network.'
-                : `Available: ${usdcFormatted} USDC`}
-          </div>
+          <div className="text-muted-foreground text-sm">{balanceStatusText}</div>
 
           <div className="grid gap-2">
             <Label htmlFor="send-usdc-recipient">Recipient address</Label>
@@ -144,7 +175,9 @@ export function SendUsdcModal({ open, onOpenChange }: SendUsdcModalProps) {
                 size="sm"
                 className="h-auto px-2 py-1 text-xs"
                 onClick={handleMax}
-                disabled={!usdcBalance || isSending || unsupportedNetwork}
+                disabled={
+                  !hasPositiveBalance || isSending || unsupportedNetwork
+                }
               >
                 Max
               </Button>
@@ -173,7 +206,7 @@ export function SendUsdcModal({ open, onOpenChange }: SendUsdcModalProps) {
         <DialogFooter>
           <Button
             variant="outline"
-            onClick={() => onOpenChange(false)}
+            onClick={() => handleOpenChange(false)}
             disabled={isSending}
           >
             Cancel

--- a/src/components/send-usdc-modal.tsx
+++ b/src/components/send-usdc-modal.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useAccount, useChain } from '@account-kit/react';
+import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { USDC_ADDRESS_BY_CHAIN_ID } from '@/config/chains';
+import { useSendUsdc } from '@/hooks/use-send-usdc';
+import { useUsdcBalance } from '@/hooks/use-usdc-balance';
+import { validateUsdcSend } from '@/shared/utils/usdc-transfer';
+
+interface SendUsdcModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function SendUsdcModal({ open, onOpenChange }: SendUsdcModalProps) {
+  const { address } = useAccount({ type: 'LightAccount' });
+  const { chain } = useChain();
+  const {
+    balance: usdcBalance,
+    formatted: usdcFormatted,
+    isLoading: isBalanceLoading,
+  } = useUsdcBalance(chain, address as `0x${string}` | undefined);
+  const { sendUsdc, ready } = useSendUsdc();
+
+  const [recipient, setRecipient] = useState('');
+  const [amount, setAmount] = useState('');
+  const [isSending, setIsSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setRecipient('');
+      setAmount('');
+      setError(null);
+      setIsSending(false);
+    }
+  }, [open]);
+
+  const validation = useMemo(
+    () =>
+      validateUsdcSend({
+        recipient,
+        amount,
+        balance: usdcBalance,
+        senderAddress: address,
+      }),
+    [address, amount, recipient, usdcBalance]
+  );
+
+  const canSend =
+    ready &&
+    !isBalanceLoading &&
+    validation.ok &&
+    !isSending &&
+    Boolean(chain && usdcBalance !== null);
+
+  const handleMax = () => {
+    if (usdcBalance) {
+      setAmount(usdcBalance);
+      setError(null);
+    }
+  };
+
+  const handleSend = async () => {
+    if (!validation.ok) {
+      setError(validation.error);
+      return;
+    }
+    setIsSending(true);
+    setError(null);
+    try {
+      const result = await sendUsdc(recipient, amount, usdcBalance);
+      if (result.ok) {
+        toast.success('USDC sent', {
+          description: `Sent ${amount} USDC to ${recipient.trim()}`,
+        });
+        onOpenChange(false);
+      } else {
+        setError(result.error ?? 'Transfer failed');
+      }
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  const hasUsdc = chain ? chain.id in USDC_ADDRESS_BY_CHAIN_ID : false;
+  const unsupportedNetwork = Boolean(chain && !hasUsdc);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Send USDC</DialogTitle>
+          <DialogDescription>
+            Send USDC from your wallet
+            {chain ? ` on ${chain.name}` : ''} to another address.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-2">
+          <div className="text-muted-foreground text-sm">
+            {isBalanceLoading
+              ? 'Checking USDC balance…'
+              : unsupportedNetwork
+                ? 'USDC is not available on this network.'
+                : `Available: ${usdcFormatted} USDC`}
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="send-usdc-recipient">Recipient address</Label>
+            <Input
+              id="send-usdc-recipient"
+              placeholder="0x…"
+              value={recipient}
+              onChange={(e) => {
+                setRecipient(e.target.value);
+                setError(null);
+              }}
+              disabled={isSending || unsupportedNetwork}
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </div>
+
+          <div className="grid gap-2">
+            <div className="flex items-center justify-between gap-2">
+              <Label htmlFor="send-usdc-amount">Amount (USDC)</Label>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-auto px-2 py-1 text-xs"
+                onClick={handleMax}
+                disabled={!usdcBalance || isSending || unsupportedNetwork}
+              >
+                Max
+              </Button>
+            </div>
+            <Input
+              id="send-usdc-amount"
+              type="text"
+              inputMode="decimal"
+              placeholder="0.00"
+              value={amount}
+              onChange={(e) => {
+                setAmount(e.target.value);
+                setError(null);
+              }}
+              disabled={isSending || unsupportedNetwork}
+            />
+          </div>
+
+          {(error || (!validation.ok && (recipient || amount))) && (
+            <p className="text-destructive text-sm">
+              {error ?? (!validation.ok ? validation.error : null)}
+            </p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isSending}
+          >
+            Cancel
+          </Button>
+          <Button onClick={() => void handleSend()} disabled={!canSend}>
+            {isSending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Sending…
+              </>
+            ) : (
+              'Send USDC'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/wallet-connect-button.tsx
+++ b/src/components/wallet-connect-button.tsx
@@ -10,7 +10,15 @@ import {
 } from '@account-kit/react';
 import { useNavigate } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
-import { Copy, DollarSign, Gift, Settings2, Sparkles, Wallet } from 'lucide-react';
+import {
+  Copy,
+  DollarSign,
+  Gift,
+  Send,
+  Settings2,
+  Sparkles,
+  Wallet,
+} from 'lucide-react';
 import { toast } from 'sonner';
 import { useBuyUsdcOnramp } from '@/hooks/use-buy-usdc-onramp';
 import { useUnlockCheckout } from '@/hooks/use-unlock-checkout';
@@ -39,6 +47,7 @@ import {
 import { alchemyConfig, SWITCHABLE_CHAINS } from '@/config/alchemy';
 import { canAffordAnyCreditPack } from '@/features/credits/usdc-for-purchase';
 import { formatSubscribeCta } from '@/shared/utils/currency-display';
+import { SendUsdcModal } from '@/components/send-usdc-modal';
 import { useUsdcBalance } from '@/hooks/use-usdc-balance';
 
 const ARBITRUM_ONE_CHAIN_ID = 42_161;
@@ -109,6 +118,7 @@ function WalletConnectButtonInner({
   const { balance, isLoading: creditsLoading, claimMembershipCredits } = useCredits();
 
   const [buyCreditsOpen, setBuyCreditsOpen] = useState(false);
+  const [sendUsdcOpen, setSendUsdcOpen] = useState(false);
   const [redeemOpen, setRedeemOpen] = useState(false);
   const [claimingMembership, setClaimingMembership] = useState(false);
 
@@ -227,6 +237,14 @@ function WalletConnectButtonInner({
             <DollarSign className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden />
             {isOnrampLoading ? 'Opening…' : 'Buy USDC'}
           </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => setSendUsdcOpen(true)}
+            className="flex cursor-pointer items-center gap-2"
+            aria-label="Send USDC"
+          >
+            <Send className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden />
+            Send USDC
+          </DropdownMenuItem>
           {isUnlockConfigured && !isPremiumMember && (
             <DropdownMenuItem
               onClick={openSubscribeCheckout}
@@ -307,6 +325,7 @@ function WalletConnectButtonInner({
       </DropdownMenuContent>
     </DropdownMenu>
       <BuyCreditsModal open={buyCreditsOpen} onOpenChange={setBuyCreditsOpen} />
+      <SendUsdcModal open={sendUsdcOpen} onOpenChange={setSendUsdcOpen} />
       <RedeemPromoModal open={redeemOpen} onOpenChange={setRedeemOpen} />
     </>
   );

--- a/src/hooks/use-send-usdc.ts
+++ b/src/hooks/use-send-usdc.ts
@@ -1,0 +1,88 @@
+import { useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import {
+  useAccount,
+  useChain,
+  useSmartAccountClient,
+} from '@account-kit/react';
+import type { Hex } from 'viem';
+import { USDC_ADDRESS_BY_CHAIN_ID } from '@/config/chains';
+import { useSmartWalletOps } from '@/hooks/use-smart-wallet-ops';
+import {
+  buildUsdcTransferCalldata,
+  validateUsdcSend,
+} from '@/shared/utils/usdc-transfer';
+
+export interface SendUsdcResult {
+  ok: boolean;
+  txHash?: Hex;
+  error?: string;
+}
+
+export function useSendUsdc() {
+  const { address } = useAccount({ type: 'LightAccount' });
+  const { chain } = useChain();
+  const { client } = useSmartAccountClient({ type: 'LightAccount' });
+  const { sendOps, ready } = useSmartWalletOps(client ?? undefined);
+  const queryClient = useQueryClient();
+
+  const usdcAddress = chain ? USDC_ADDRESS_BY_CHAIN_ID[chain.id] : undefined;
+
+  const sendUsdc = useCallback(
+    async (
+      recipient: string,
+      amount: string,
+      balance: string | null
+    ): Promise<SendUsdcResult> => {
+      if (!client || !address || !chain || !usdcAddress) {
+        return { ok: false, error: 'Wallet not ready on a supported network' };
+      }
+      if (!ready) {
+        return { ok: false, error: 'Wallet not ready' };
+      }
+
+      const validation = validateUsdcSend({
+        recipient,
+        amount,
+        balance,
+        senderAddress: address,
+      });
+      if (!validation.ok) {
+        return { ok: false, error: validation.error };
+      }
+
+      try {
+        const data = buildUsdcTransferCalldata(
+          validation.recipient,
+          validation.amountUsdc6
+        );
+        const { txHash } = await sendOps([
+          { target: usdcAddress, data, value: 0n },
+        ]);
+        await queryClient.invalidateQueries({
+          queryKey: ['usdc-balance', chain.id, address],
+        });
+        return { ok: true, txHash };
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Transfer failed';
+        const lower = message.toLowerCase();
+        if (
+          lower.includes('insufficient') ||
+          lower.includes('balance') ||
+          lower.includes('exceeds balance')
+        ) {
+          return { ok: false, error: 'Insufficient USDC balance' };
+        }
+        return { ok: false, error: message };
+      }
+    },
+    [address, chain, client, queryClient, ready, sendOps, usdcAddress]
+  );
+
+  return {
+    sendUsdc,
+    ready: ready && Boolean(usdcAddress),
+    usdcAddress,
+  };
+}

--- a/src/hooks/use-send-usdc.ts
+++ b/src/hooks/use-send-usdc.ts
@@ -10,6 +10,7 @@ import { USDC_ADDRESS_BY_CHAIN_ID } from '@/config/chains';
 import { useSmartWalletOps } from '@/hooks/use-smart-wallet-ops';
 import {
   buildUsdcTransferCalldata,
+  getUsdcGasReserveUsdc6,
   validateUsdcSend,
 } from '@/shared/utils/usdc-transfer';
 
@@ -46,6 +47,7 @@ export function useSendUsdc() {
         amount,
         balance,
         senderAddress: address,
+        gasReserveUsdc6: getUsdcGasReserveUsdc6(chain.id),
       });
       if (!validation.ok) {
         return { ok: false, error: validation.error };

--- a/src/shared/utils/usdc-transfer.test.ts
+++ b/src/shared/utils/usdc-transfer.test.ts
@@ -1,5 +1,17 @@
-import { describe, expect, it } from 'vitest';
-import { buildUsdcTransferCalldata, validateUsdcSend } from './usdc-transfer';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/config/gas-sponsorship', () => ({
+  getPurchaseGasBufferUsdc6: vi.fn(() => 0),
+}));
+
+import { getPurchaseGasBufferUsdc6 } from '@/config/gas-sponsorship';
+import {
+  buildUsdcTransferCalldata,
+  getMaxSendableUsdc,
+  validateUsdcSend,
+} from './usdc-transfer';
+
+const mockedGasBuffer = vi.mocked(getPurchaseGasBufferUsdc6);
 
 const SENDER = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
 const RECIPIENT = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8';
@@ -16,6 +28,30 @@ describe('validateUsdcSend', () => {
     if (result.ok) {
       expect(result.recipient).toBe(RECIPIENT);
       expect(result.amountUsdc6).toBe(1_500_000n);
+    }
+  });
+
+  it('accepts trailing and leading decimal points', () => {
+    const trailingResult = validateUsdcSend({
+      recipient: RECIPIENT,
+      amount: '1.',
+      balance: '10',
+      senderAddress: SENDER,
+    });
+    expect(trailingResult.ok).toBe(true);
+    if (trailingResult.ok) {
+      expect(trailingResult.amountUsdc6).toBe(1_000_000n);
+    }
+
+    const leadingResult = validateUsdcSend({
+      recipient: RECIPIENT,
+      amount: '.5',
+      balance: '10',
+      senderAddress: SENDER,
+    });
+    expect(leadingResult.ok).toBe(true);
+    if (leadingResult.ok) {
+      expect(leadingResult.amountUsdc6).toBe(500_000n);
     }
   });
 
@@ -52,6 +88,20 @@ describe('validateUsdcSend', () => {
     expect(result).toEqual({ ok: false, error: 'Insufficient USDC balance' });
   });
 
+  it('rejects amounts that exceed spendable balance after gas reserve', () => {
+    const result = validateUsdcSend({
+      recipient: RECIPIENT,
+      amount: '10',
+      balance: '10',
+      senderAddress: SENDER,
+      gasReserveUsdc6: 1_000_000,
+    });
+    expect(result).toEqual({
+      ok: false,
+      error: 'Insufficient USDC after reserving gas fees',
+    });
+  });
+
   it('rejects more than six decimal places', () => {
     const result = validateUsdcSend({
       recipient: RECIPIENT,
@@ -63,6 +113,25 @@ describe('validateUsdcSend', () => {
       ok: false,
       error: 'USDC supports up to 6 decimal places',
     });
+  });
+});
+
+describe('getMaxSendableUsdc', () => {
+  const ARBITRUM_ONE_CHAIN_ID = 42_161;
+
+  it('returns full balance when no gas reserve applies', () => {
+    mockedGasBuffer.mockReturnValue(0);
+    expect(getMaxSendableUsdc('5', ARBITRUM_ONE_CHAIN_ID)).toBe('5');
+  });
+
+  it('subtracts gas reserve when configured', () => {
+    mockedGasBuffer.mockReturnValue(1_000_000);
+    expect(getMaxSendableUsdc('2', ARBITRUM_ONE_CHAIN_ID)).toBe('1');
+  });
+
+  it('returns null when balance does not exceed gas reserve', () => {
+    mockedGasBuffer.mockReturnValue(1_000_000);
+    expect(getMaxSendableUsdc('0.5', ARBITRUM_ONE_CHAIN_ID)).toBeNull();
   });
 });
 

--- a/src/shared/utils/usdc-transfer.test.ts
+++ b/src/shared/utils/usdc-transfer.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { buildUsdcTransferCalldata, validateUsdcSend } from './usdc-transfer';
+
+const SENDER = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
+const RECIPIENT = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8';
+
+describe('validateUsdcSend', () => {
+  it('accepts a valid recipient and amount within balance', () => {
+    const result = validateUsdcSend({
+      recipient: RECIPIENT,
+      amount: '1.5',
+      balance: '10',
+      senderAddress: SENDER,
+    });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.recipient).toBe(RECIPIENT);
+      expect(result.amountUsdc6).toBe(1_500_000n);
+    }
+  });
+
+  it('rejects invalid addresses', () => {
+    const result = validateUsdcSend({
+      recipient: 'not-an-address',
+      amount: '1',
+      balance: '10',
+      senderAddress: SENDER,
+    });
+    expect(result).toEqual({ ok: false, error: 'Invalid wallet address' });
+  });
+
+  it('rejects sending to self', () => {
+    const result = validateUsdcSend({
+      recipient: SENDER,
+      amount: '1',
+      balance: '10',
+      senderAddress: SENDER,
+    });
+    expect(result).toEqual({
+      ok: false,
+      error: 'Cannot send USDC to your own address',
+    });
+  });
+
+  it('rejects amounts above balance', () => {
+    const result = validateUsdcSend({
+      recipient: RECIPIENT,
+      amount: '5',
+      balance: '4.99',
+      senderAddress: SENDER,
+    });
+    expect(result).toEqual({ ok: false, error: 'Insufficient USDC balance' });
+  });
+
+  it('rejects more than six decimal places', () => {
+    const result = validateUsdcSend({
+      recipient: RECIPIENT,
+      amount: '0.0000001',
+      balance: '10',
+      senderAddress: SENDER,
+    });
+    expect(result).toEqual({
+      ok: false,
+      error: 'USDC supports up to 6 decimal places',
+    });
+  });
+});
+
+describe('buildUsdcTransferCalldata', () => {
+  it('encodes an ERC-20 transfer call', () => {
+    const data = buildUsdcTransferCalldata(RECIPIENT, 1_000_000n);
+    expect(data.startsWith('0xa9059cbb')).toBe(true);
+  });
+});

--- a/src/shared/utils/usdc-transfer.ts
+++ b/src/shared/utils/usdc-transfer.ts
@@ -1,0 +1,76 @@
+import { encodeFunctionData, erc20Abi, isAddress, parseUnits } from 'viem';
+
+export const USDC_DECIMALS = 6;
+
+export type UsdcSendValidation =
+  | { ok: true; recipient: `0x${string}`; amountUsdc6: bigint }
+  | { ok: false; error: string };
+
+export function validateUsdcSend(params: {
+  recipient: string;
+  amount: string;
+  balance: string | null;
+  senderAddress?: string;
+}): UsdcSendValidation {
+  const trimmedRecipient = params.recipient.trim();
+  if (!trimmedRecipient) {
+    return { ok: false, error: 'Enter a recipient address' };
+  }
+  if (!isAddress(trimmedRecipient)) {
+    return { ok: false, error: 'Invalid wallet address' };
+  }
+  const recipient = trimmedRecipient as `0x${string}`;
+  if (
+    params.senderAddress &&
+    recipient.toLowerCase() === params.senderAddress.toLowerCase()
+  ) {
+    return { ok: false, error: 'Cannot send USDC to your own address' };
+  }
+
+  const trimmedAmount = params.amount.trim();
+  if (!trimmedAmount) {
+    return { ok: false, error: 'Enter an amount' };
+  }
+  if (!/^\d+(\.\d+)?$/.test(trimmedAmount)) {
+    return { ok: false, error: 'Enter a valid amount' };
+  }
+  const decimalPart = trimmedAmount.split('.')[1];
+  if (decimalPart && decimalPart.length > USDC_DECIMALS) {
+    return { ok: false, error: `USDC supports up to ${USDC_DECIMALS} decimal places` };
+  }
+
+  let amountUsdc6: bigint;
+  try {
+    amountUsdc6 = parseUnits(trimmedAmount, USDC_DECIMALS);
+  } catch {
+    return { ok: false, error: 'Enter a valid amount' };
+  }
+  if (amountUsdc6 <= 0n) {
+    return { ok: false, error: 'Amount must be greater than zero' };
+  }
+
+  if (params.balance !== null) {
+    let balanceUsdc6: bigint;
+    try {
+      balanceUsdc6 = parseUnits(params.balance, USDC_DECIMALS);
+    } catch {
+      return { ok: false, error: 'Could not read wallet balance' };
+    }
+    if (amountUsdc6 > balanceUsdc6) {
+      return { ok: false, error: 'Insufficient USDC balance' };
+    }
+  }
+
+  return { ok: true, recipient, amountUsdc6 };
+}
+
+export function buildUsdcTransferCalldata(
+  recipient: `0x${string}`,
+  amountUsdc6: bigint
+): `0x${string}` {
+  return encodeFunctionData({
+    abi: erc20Abi,
+    functionName: 'transfer',
+    args: [recipient, amountUsdc6],
+  });
+}

--- a/src/shared/utils/usdc-transfer.ts
+++ b/src/shared/utils/usdc-transfer.ts
@@ -1,4 +1,5 @@
-import { encodeFunctionData, erc20Abi, isAddress, parseUnits } from 'viem';
+import { encodeFunctionData, erc20Abi, formatUnits, isAddress, parseUnits } from 'viem';
+import { getPurchaseGasBufferUsdc6 } from '@/config/gas-sponsorship';
 
 export const USDC_DECIMALS = 6;
 
@@ -6,11 +7,32 @@ export type UsdcSendValidation =
   | { ok: true; recipient: `0x${string}`; amountUsdc6: bigint }
   | { ok: false; error: string };
 
+export function getUsdcGasReserveUsdc6(chainId: number): number {
+  return getPurchaseGasBufferUsdc6(chainId);
+}
+
+/** Spendable USDC after reserving ERC-20 gas, or null when balance is too low. */
+export function getMaxSendableUsdc(
+  balance: string | null,
+  chainId: number
+): string | null {
+  if (balance === null) return null;
+  try {
+    const balanceUsdc6 = parseUnits(balance, USDC_DECIMALS);
+    const reserveUsdc6 = BigInt(getPurchaseGasBufferUsdc6(chainId));
+    if (balanceUsdc6 <= reserveUsdc6) return null;
+    return formatUnits(balanceUsdc6 - reserveUsdc6, USDC_DECIMALS);
+  } catch {
+    return null;
+  }
+}
+
 export function validateUsdcSend(params: {
   recipient: string;
   amount: string;
   balance: string | null;
   senderAddress?: string;
+  gasReserveUsdc6?: number;
 }): UsdcSendValidation {
   const trimmedRecipient = params.recipient.trim();
   if (!trimmedRecipient) {
@@ -31,7 +53,7 @@ export function validateUsdcSend(params: {
   if (!trimmedAmount) {
     return { ok: false, error: 'Enter an amount' };
   }
-  if (!/^\d+(\.\d+)?$/.test(trimmedAmount)) {
+  if (!/^(?:\d+\.?\d*|\.\d+)$/.test(trimmedAmount)) {
     return { ok: false, error: 'Enter a valid amount' };
   }
   const decimalPart = trimmedAmount.split('.')[1];
@@ -58,6 +80,13 @@ export function validateUsdcSend(params: {
     }
     if (amountUsdc6 > balanceUsdc6) {
       return { ok: false, error: 'Insufficient USDC balance' };
+    }
+    const gasReserveUsdc6 = BigInt(params.gasReserveUsdc6 ?? 0);
+    if (gasReserveUsdc6 > 0n && amountUsdc6 + gasReserveUsdc6 > balanceUsdc6) {
+      return {
+        ok: false,
+        error: 'Insufficient USDC after reserving gas fees',
+      };
     }
   }
 


### PR DESCRIPTION
## Summary
- Adds a Send USDC modal so connected users can transfer USDC to another wallet address from the wallet dropdown.
- Uses the existing smart wallet ops path for ERC-20 transfers on networks with configured USDC addresses.
- Includes validation for recipient, amount, balance, and self-send prevention, plus unit tests.

## Test plan
- [ ] Connect wallet on Arbitrum One with USDC balance
- [ ] Open wallet menu → Send USDC
- [ ] Verify invalid address and insufficient balance errors
- [ ] Send a small USDC amount to a test address and confirm balance updates
- [ ] Switch to an unsupported network and confirm the modal shows unavailable state
- [ ] Run `npm run test:run -- src/shared/utils/usdc-transfer.test.ts`


Made with [Cursor](https://cursor.com)