### PR TITLE
fix(api): parse request body before auth and guard wallet fallback

### DIFF
--- a/api/_wallet-auth.ts
+++ b/api/_wallet-auth.ts
@@ -65,8 +65,10 @@ export async function verifyPrivyAccessToken(
     }
 
     // Fall back to the first linked wallet only when no expected address was supplied.
+    const firstWallet = linkedWallets[0];
+    if (!firstWallet) return null;
     return {
-      address: linkedWallets[0].address.toLowerCase() as `0x${string}`,
+      address: firstWallet.address.toLowerCase() as `0x${string}`,
     };
   } catch {
     return null;

--- a/api/generate-image.ts
+++ b/api/generate-image.ts
@@ -28,19 +28,23 @@ export async function POST(request: Request): Promise<Response> {
     return Response.json({ error: 'missing authorization' }, { status: 401 });
   }
 
+  let body: Record<string, unknown>;
+  try {
+    const parsed = await request.json();
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return Response.json({ error: 'invalid body' }, { status: 400 });
+    }
+    body = parsed as Record<string, unknown>;
+  } catch {
+    return Response.json({ error: 'invalid body' }, { status: 400 });
+  }
+
   const auth = await verifyPrivyAccessToken(
     token,
     typeof body.walletAddress === 'string' ? body.walletAddress : undefined
   );
   if (!auth) {
     return Response.json({ error: 'invalid authorization' }, { status: 401 });
-  }
-
-  let body: Record<string, unknown>;
-  try {
-    body = (await request.json()) as Record<string, unknown>;
-  } catch {
-    return Response.json({ error: 'invalid body' }, { status: 400 });
   }
 
   const prompt = typeof body.prompt === 'string' ? body.prompt.trim() : '';

--- a/api/generate-video.ts
+++ b/api/generate-video.ts
@@ -32,19 +32,23 @@ export async function POST(request: Request): Promise<Response> {
     return Response.json({ error: 'missing authorization' }, { status: 401 });
   }
 
+  let body: Record<string, unknown>;
+  try {
+    const parsed = await request.json();
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return Response.json({ error: 'invalid body' }, { status: 400 });
+    }
+    body = parsed as Record<string, unknown>;
+  } catch {
+    return Response.json({ error: 'invalid body' }, { status: 400 });
+  }
+
   const auth = await verifyPrivyAccessToken(
     token,
     typeof body.walletAddress === 'string' ? body.walletAddress : undefined
   );
   if (!auth) {
     return Response.json({ error: 'invalid authorization' }, { status: 401 });
-  }
-
-  let body: Record<string, unknown>;
-  try {
-    body = (await request.json()) as Record<string, unknown>;
-  } catch {
-    return Response.json({ error: 'invalid body' }, { status: 400 });
   }
 
   const prompt = typeof body.prompt === 'string' ? body.prompt.trim() : '';


### PR DESCRIPTION
Fixes three TypeScript/runtime issues reported in the latest Vercel build log:

- `api/generate-image.ts`: parse the JSON body **before** reading `body.walletAddress` for `verifyPrivyAccessToken`. Reading it before declaration caused TS2448/TS2454 and would break at runtime.
- `api/generate-video.ts`: same body-before-auth fix.
- `api/_wallet-auth.ts`: guard `linkedWallets[0]` when falling back to the first linked wallet, instead of returning a possibly-`undefined` address.

No functional behavior change for valid requests; invalid/missing bodies now correctly return 400 before auth is attempted.