### PR TITLE
fix(wallet,media): put USDC first and enable add-to-timeline on tablet

### DIFF
--- a/src/components/wallet-connect-button.tsx
+++ b/src/components/wallet-connect-button.tsx
@@ -172,19 +172,9 @@ export function WalletConnectButton({
               <Copy className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden />
             </DropdownMenuItem>
           )}
-          <DropdownMenuItem disabled className="text-muted-foreground">
-            {crtvaiSymbol}: {crtvaiFormatted}
-          </DropdownMenuItem>
+          {/* USDC first */}
           <DropdownMenuItem disabled className="text-muted-foreground">
             USDC: {usdcFormatted}
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            onClick={() => setBuyMetokenOpen(true)}
-            className="flex cursor-pointer items-center gap-2"
-            aria-label="Buy CRTVAI"
-          >
-            <Sparkles className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden />
-            Buy CRTVAI
           </DropdownMenuItem>
           <DropdownMenuItem
             onClick={handleBuyUsdc}
@@ -201,6 +191,18 @@ export function WalletConnectButton({
           >
             <Send className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden />
             Send USDC
+          </DropdownMenuItem>
+          {/* CRTVAI below USDC */}
+          <DropdownMenuItem disabled className="text-muted-foreground">
+            {crtvaiSymbol}: {crtvaiFormatted}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => setBuyMetokenOpen(true)}
+            className="flex cursor-pointer items-center gap-2"
+            aria-label="Buy CRTVAI"
+          >
+            <Sparkles className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden />
+            Buy CRTVAI
           </DropdownMenuItem>
           {isUnlockConfigured && !isPremiumMember && (
             <DropdownMenuItem

--- a/src/features/media-library/hooks/use-is-mobile.ts
+++ b/src/features/media-library/hooks/use-is-mobile.ts
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
 
-/** Matches editor mobile breakpoint (max-width: 767px). */
+/** Matches editor mobile and tablet breakpoints (max-width: 1023px). */
 export function useIsMobile(): boolean {
   const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {
-    const mql = window.matchMedia('(max-width: 767px)');
+    const mql = window.matchMedia('(max-width: 1023px)');
     setIsMobile(mql.matches);
     const handler = () => setIsMobile(mql.matches);
     mql.addEventListener('change', handler);


### PR DESCRIPTION
## What\n\n- Reorders the wallet dropdown so the USDC balance, **Buy USDC**, and **Send USDC** actions appear first, ahead of the credits / CRTVAI block.\n- Expands the media card mobile breakpoint to include tablets (), so the **Add to Timeline** option is visible in the more menu on tablet and phone.\n\n## Verification\n- 
> pixels@0.0.0 lint
> eslint .


/Users/sirgawain/Developer/edit-pixels/.worktrees/agent-mobile-fixes/src/context/wallet-context.tsx
  49:17  warning  Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components  react-refresh/only-export-components

/Users/sirgawain/Developer/edit-pixels/.worktrees/agent-mobile-fixes/src/features/credits/components/buy-credits-modal.tsx
  283:17  warning  Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components  react-refresh/only-export-components

/Users/sirgawain/Developer/edit-pixels/.worktrees/agent-mobile-fixes/src/features/preview/components/video-preview.tsx
  2567:3  warning  Unused eslint-disable directive (no problems were reported from 'react-hooks/exhaustive-deps')

/Users/sirgawain/Developer/edit-pixels/.worktrees/agent-mobile-fixes/src/features/timeline/components/timeline-item/index.tsx
  1275:11  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any

✖ 4 problems (0 errors, 4 warnings)
  0 errors and 1 warning potentially fixable with the `--fix` option. passed (only pre-existing warnings).\n- 
> pixels@0.0.0 test:run
> vitest run


[1m[30m[46m RUN [49m[39m[22m [36mv4.1.9 [39m[90m/Users/sirgawain/Developer/edit-pixels/.worktrees/agent-mobile-fixes[39m

 [32m✓[39m src/shared/ui/property-controls/number-input.test.tsx [2m([22m[2m2 tests[22m[2m)[22m[32m 143[2mms[22m[39m
 [32m✓[39m src/features/keyframes/components/dopesheet-editor/drag-preview.test.tsx [2m([22m[2m1 test[22m[2m)[22m[32m 247[2mms[22m[39m
 [32m✓[39m src/features/keyframes/components/dopesheet-editor/header-frame-readout.test.tsx [2m([22m[2m4 tests[22m[2m)[22m[33m 350[2mms[22m[39m
 [32m✓[39m src/features/keyframes/components/dopesheet-editor/input-commit.test.tsx [2m([22m[2m3 tests[22m[2m)[22m[33m 528[2mms[22m[39m
 [32m✓[39m src/features/editor/components/properties-sidebar/components/slider-input.test.tsx [2m([22m[2m2 tests[22m[2m)[22m[32m 249[2mms[22m[39m
 [32m✓[39m src/features/credits/components/buy-credits-modal.test.tsx [2m([22m[2m3 tests[22m[2m)[22m[33m 393[2mms[22m[39m
 [32m✓[39m src/features/keyframes/components/value-graph-editor/index.test.tsx [2m([22m[2m1 test[22m[2m)[22m[32m 196[2mms[22m[39m
 [32m✓[39m src/features/keyframes/components/dopesheet-editor/playhead-overlay.test.tsx [2m([22m[2m1 test[22m[2m)[22m[32m 193[2mms[22m[39m
 [32m✓[39m src/features/preview/components/timecode-display.test.tsx [2m([22m[2m1 test[22m[2m)[22m[32m 117[2mms[22m[39m
 [32m✓[39m src/features/preview/utils/render-pump-invariants.test.ts [2m([22m[2m18 tests[22m[2m)[22m[32m 187[2mms[22m[39m
 [32m✓[39m src/features/keyframes/components/value-graph-editor/use-graph-interaction.test.tsx [2m([22m[2m3 tests[22m[2m)[22m[32m 178[2mms[22m[39m
 [32m✓[39m src/features/preview/components/playback-controls.test.tsx [2m([22m[2m1 test[22m[2m)[22m[32m 211[2mms[22m[39m
 [32m✓[39m src/features/timeline/components/track-row-frame.test.tsx [2m([22m[2m2 tests[22m[2m)[22m[32m 27[2mms[22m[39m
 [32m✓[39m src/features/preview/components/mask-editor-overlay.test.tsx [2m([22m[2m24 tests[22m[2m)[22m[32m 204[2mms[22m[39m
[90mstdout[2m | src/features/preview/components/video-preview.sync.test.tsx[2m > [22m[2mVideoPreview sync behavior[2m > [22m[2mshows the playback transition overlay only while a transition is active during playback
[22m[39m[VideoPreview] preview_transition_session {
  opId: [32m'e5c59b1f'[39m,
  env: [32m'development'[39m,
  outcome: [32m'success'[39m,
  duration_ms: [33m2[39m,
  startFrame: [33m40[39m,
  endFrame: [33m60[39m,
  mode: [32m'dom'[39m,
  complex: [33mfalse[39m,
  leftClipId: [32m'clip-left'[39m,
  rightClipId: [32m'clip-right'[39m,
  leftSpeed: [33m1[39m,
  rightSpeed: [33m1[39m,
  leftHasEffects: [33mfalse[39m,
  rightHasEffects: [33mfalse[39m,
  prepareMs: [33m0[39m,
  preparedFrame: [33m-1[39m,
  bufferedFramesPeak: [33m0[39m,
  entryMisses: [33m0[39m,
  readyLeadMs: [33m0[39m,
  sessionDurationMs: [33m0.35766700000021956[39m
}
[VideoPreview] preview_transition_session {
  opId: [32m'a7d93d12'[39m,
  env: [32m'development'[39m,
  outcome: [32m'success'[39m,
  duration_ms: [33m1[39m,
  startFrame: [33m40[39m,
  endFrame: [33m60[39m,
  mode: [32m'dom'[39m,
  complex: [33mfalse[39m,
  leftClipId: [32m'clip-left'[39m,
  rightClipId: [32m'clip-right'[39m,
  leftSpeed: [33m1[39m,
  rightSpeed: [33m1[39m,
  leftHasEffects: [33mfalse[39m,
  rightHasEffects: [33mfalse[39m,
  prepareMs: [33m0[39m,
  preparedFrame: [33m-1[39m,
  bufferedFramesPeak: [33m0[39m,
  entryMisses: [33m0[39m,
  readyLeadMs: [33m0[39m,
  sessionDurationMs: [33m0.19016699999974662[39m
}

[90mstdout[2m | src/features/preview/components/video-preview.sync.test.tsx[2m > [22m[2mVideoPreview sync behavior[2m > [22m[2mshows the playback transition overlay only while a transition is active during playback
[22m[39m[VideoPreview] preview_transition_session {
  opId: [32m'1ffcda16'[39m,
  env: [32m'development'[39m,
  outcome: [32m'success'[39m,
  duration_ms: [33m6[39m,
  startFrame: [33m40[39m,
  endFrame: [33m60[39m,
  mode: [32m'dom'[39m,
  complex: [33mfalse[39m,
  leftClipId: [32m'clip-left'[39m,
  rightClipId: [32m'clip-right'[39m,
  leftSpeed: [33m1[39m,
  rightSpeed: [33m1[39m,
  leftHasEffects: [33mfalse[39m,
  rightHasEffects: [33mfalse[39m,
  prepareMs: [33m1.278707999999824[39m,
  preparedFrame: [33m40[39m,
  bufferedFramesPeak: [33m1[39m,
  entryMisses: [33m0[39m,
  readyLeadMs: [33m0[39m,
  sessionDurationMs: [33m5.960707999999613[39m
}

[90mstdout[2m | src/features/preview/components/video-preview.sync.test.tsx[2m > [22m[2mVideoPreview sync behavior[2m > [22m[2mpre-renders the first transition frame before handoff and reuses it at transition start
[22m[39m[VideoPreview] preview_transition_session {
  opId: [32m'7d1aff7e'[39m,
  env: [32m'development'[39m,
  outcome: [32m'success'[39m,
  duration_ms: [33m0[39m,
  startFrame: [33m40[39m,
  endFrame: [33m60[39m,
  mode: [32m'dom'[39m,
  complex: [33mfalse[39m,
  leftClipId: [32m'clip-left'[39m,
  rightClipId: [32m'clip-right'[39m,
  leftSpeed: [33m1[39m,
  rightSpeed: [33m1[39m,
  leftHasEffects: [33mfalse[39m,
  rightHasEffects: [33mfalse[39m,
  prepareMs: [33m0[39m,
  preparedFrame: [33m-1[39m,
  bufferedFramesPeak: [33m0[39m,
  entryMisses: [33m0[39m,
  readyLeadMs: [33m0[39m,
  sessionDurationMs: [33m0.1709579999997004[39m
}
[VideoPreview] preview_transition_session {
  opId: [32m'2d9d9c37'[39m,
  env: [32m'development'[39m,
  outcome: [32m'success'[39m,
  duration_ms: [33m2[39m,
  startFrame: [33m40[39m,
  endFrame: [33m60[39m,
  mode: [32m'dom'[39m,
  complex: [33mfalse[39m,
  leftClipId: [32m'clip-left'[39m,
  rightClipId: [32m'clip-right'[39m,
  leftSpeed: [33m1[39m,
  rightSpeed: [33m1[39m,
  leftHasEffects: [33mfalse[39m,
  rightHasEffects: [33mfalse[39m,
  prepareMs: [33m0[39m,
  preparedFrame: [33m-1[39m,
  bufferedFramesPeak: [33m0[39m,
  entryMisses: [33m0[39m,
  readyLeadMs: [33m0[39m,
  sessionDurationMs: [33m0.6260830000001079[39m
}

[90mstdout[2m | src/features/preview/components/video-preview.sync.test.tsx[2m > [22m[2mVideoPreview sync behavior[2m > [22m[2mstarts transition prewarm when a transition is added during scrub preview
[22m[39m[VideoPreview] preview_transition_session {
  opId: [32m'83b7d36d'[39m,
  env: [32m'development'[39m,
  outcome: [32m'success'[39m,
  duration_ms: [33m9[39m,
  startFrame: [33m40[39m,
  endFrame: [33m60[39m,
  mode: [32m'dom'[39m,
  complex: [33mfalse[39m,
  leftClipId: [32m'clip-left'[39m,
  rightClipId: [32m'clip-right'[39m,
  leftSpeed: [33m1[39m,
  rightSpeed: [33m1[39m,
  leftHasEffects: [33mfalse[39m,
  rightHasEffects: [33mfalse[39m,
  prepareMs: [33m0.9605419999998048[39m,
  preparedFrame: [33m40[39m,
  bufferedFramesPeak: [33m1[39m,
  entryMisses: [33m0[39m,
  readyLeadMs: [33m0[39m,
  sessionDurationMs: [33m8.13666700000067[39m
}

[90mstdout[2m | src/features/preview/components/video-preview.sync.test.tsx[2m > [22m[2mVideoPreview sync behavior[2m > [22m[2mkeeps the transition overlay active for a short cooldown after the overlap ends
[22m[39m[VideoPreview] preview_transition_session {
  opId: [32m'5980dae9'[39m,
  env: [32m'development'[39m,
  outcome: [32m'success'[39m,
  duration_ms: [33m0[39m,
  startFrame: [33m40[39m,
  endFrame: [33m60[39m,
  mode: [32m'dom'[39m,
  complex: [33mfalse[39m,
  leftClipId: [32m'clip-left'[39m,
  rightClipId: [32m'clip-right'[39m,
  leftSpeed: [33m1[39m,
  rightSpeed: [33m1[39m,
  leftHasEffects: [33mfalse[39m,
  rightHasEffects: [33mfalse[39m,
  prepareMs: [33m0[39m,
  preparedFrame: [33m-1[39m,
  bufferedFramesPeak: [33m0[39m,
  entryMisses: [33m0[39m,
  readyLeadMs: [33m0[39m,
  sessionDurationMs: [33m0.6165829999999914[39m
}
[VideoPreview] preview_transition_session {
  opId: [32m'0a0b61d8'[39m,
  env: [32m'development'[39m,
  outcome: [32m'success'[39m,
  duration_ms: [33m0[39m,
  startFrame: [33m40[39m,
  endFrame: [33m60[39m,
  mode: [32m'dom'[39m,
  complex: [33mfalse[39m,
  leftClipId: [32m'clip-left'[39m,
  rightClipId: [32m'clip-right'[39m,
  leftSpeed: [33m1[39m,
  rightSpeed: [33m1[39m,
  leftHasEffects: [33mfalse[39m,
  rightHasEffects: [33mfalse[39m,
  prepareMs: [33m0[39m,
  preparedFrame: [33m-1[39m,
  bufferedFramesPeak: [33m0[39m,
  entryMisses: [33m0[39m,
  readyLeadMs: [33m0[39m,
  sessionDurationMs: [33m0.2001669999999649[39m
}

[90mstdout[2m | src/features/preview/components/video-preview.sync.test.tsx[2m > [22m[2mVideoPreview sync behavior[2m > [22m[2mkeeps the transition overlay active for a short cooldown after the overlap ends
[22m[39m[VideoPreview] preview_transition_session {
  opId: [32m'044684ed'[39m,
  env: [32m'development'[39m,
  outcome: [32m'success'[39m,
  duration_ms: [33m60[39m,
  startFrame: [33m40[39m,
  endFrame: [33m60[39m,
  mode: [32m'dom'[39m,
  complex: [33mfalse[39m,
  leftClipId: [32m'clip-left'[39m,
  rightClipId: [32m'clip-right'[39m,
  leftSpeed: [33m1[39m,
  rightSpeed: [33m1[39m,
  leftHasEffects: [33mfalse[39m,
  rightHasEffects: [33mfalse[39m,
  prepareMs: [33m0.2023750000007567[39m,
  preparedFrame: [33m40[39m,
  bufferedFramesPeak: [33m1[39m,
  entryMisses: [33m0[39m,
  readyLeadMs: [33m0[39m,
  sessionDurationMs: [33m59.27254200000061[39m
}

 [32m✓[39m src/features/live-ai/utils/billing-error-detail.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 58[2mms[22m[39m
 [32m✓[39m src/features/settings/stores/settings-store.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m src/features/preview/components/video-preview.sync.test.tsx [2m([22m[2m19 tests[22m[2m)[22m[33m 615[2mms[22m[39m
 [32m✓[39m src/features/composition-runtime/components/composition-content.masks.test.tsx [2m([22m[2m3 tests[22m[2m)[22m[32m 41[2mms[22m[39m
 [32m✓[39m src/features/preview/hooks/use-visual-transform.test.tsx [2m([22m[2m3 tests[22m[2m)[22m[32m 35[2mms[22m[39m
 [32m✓[39m src/features/keyframes/hooks/use-animated-transform.test.tsx [2m([22m[2m5 tests[22m[2m)[22m[32m 59[2mms[22m[39m
 [32m✓[39m src/features/timeline/components/transition-item.test.tsx [2m([22m[2m3 tests[22m[2m)[22m[32m 50[2mms[22m[39m
 [32m✓[39m src/features/editor/components/properties-sidebar/clip-panel/index.test.tsx [2m([22m[2m2 tests[22m[2m)[22m[33m 323[2mms[22m[39m
 [32m✓[39m src/features/export/utils/canvas-render-orchestrator.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 44[2mms[22m[39m
 [32m✓[39m src/features/composition-runtime/components/stable-video-sequence.test.tsx [2m([22m[2m1 test[22m[2m)[22m[32m 42[2mms[22m[39m
 [32m✓[39m src/features/timeline/hooks/use-visible-items.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 51[2mms[22m[39m
 [32m✓[39m src/features/editor/components/preview-area.test.tsx [2m([22m[2m4 tests[22m[2m)[22m[32m 263[2mms[22m[39m
 [32m✓[39m src/features/credits/api/buy-credits.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m src/features/timeline/components/timeline-item/segment-status-overlays.test.tsx [2m([22m[2m2 tests[22m[2m)[22m[32m 30[2mms[22m[39m
 [32m✓[39m src/config/credits.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m src/features/timeline/utils/razor-snap.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 9[2mms[22m[39m
 [32m✓[39m src/features/timeline/components/timeline-navigator.test.tsx [2m([22m[2m3 tests[22m[2m)[22m[32m 29[2mms[22m[39m
 [32m✓[39m src/features/credits/api/sync-purchase.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 13[2mms[22m[39m
 [32m✓[39m src/features/player/video/VideoSourcePool.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m src/features/timeline/hooks/use-transition-breakage-notifications.test.tsx [2m([22m[2m2 tests[22m[2m)[22m[32m 21[2mms[22m[39m
 [32m✓[39m src/features/media-library/services/media-library-service.test.ts [2m([22m[2m30 tests[22m[2m)[22m[32m 53[2mms[22m[39m
 [32m✓[39m src/config/hotkeys.test.ts [2m([22m[2m16 tests[22m[2m)[22m[32m 9[2mms[22m[39m
 [32m✓[39m src/shared/state/local-inference/registry.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m src/features/preview/components/edit-panels.smoke.test.tsx [2m([22m[2m3 tests[22m[2m)[22m[32m 33[2mms[22m[39m
 [32m✓[39m src/features/composition-runtime/components/composition-content.keyframes.test.tsx [2m([22m[2m1 test[22m[2m)[22m[32m 43[2mms[22m[39m
 [32m✓[39m src/features/keyframes/components/dopesheet-editor/row-controls.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 5[2mms[22m[39m
[90mstdout[2m | src/features/timeline/stores/timeline-store-facade.test.ts[2m > [22m[2mTimelineStoreFacade[2m > [22m[2mloadTimeline[2m > [22m[2minitializes default tracks for new project with no timeline
[22m[39m[TimelineStore] loadTimeline: initializing new project with default track

[90mstdout[2m | src/features/timeline/stores/timeline-store-facade.test.ts[2m > [22m[2mTimelineStoreFacade[2m > [22m[2mloadTimeline[2m > [22m[2mrestores timeline state from project data
[22m[39m[TimelineStore] loadTimeline: loading existing timeline {
  tracksCount: [33m1[39m,
  itemsCount: [33m1[39m,
  keyframesCount: [33m0[39m,
  transitionsCount: [33m0[39m,
  schemaVersion: [33m1[39m
}

[90mstdout[2m | src/features/timeline/stores/timeline-store-facade.test.ts[2m > [22m[2mTimelineStoreFacade[2m > [22m[2mloadTimeline[2m > [22m[2mmarks timeline as not loading after completion
[22m[39m[TimelineStore] loadTimeline: initializing new project with default track

 [32m✓[39m src/features/timeline/stores/timeline-store-facade.test.ts [2m([22m[2m17 tests[22m[2m)[22m[32m 13[2mms[22m[39m
[90mstdout[2m | src/features/preview/utils/media-resolver.test.ts[2m > [22m[2mresolveMediaUrl[2m > [22m[2mresolves media from service when not cached
[22m[39m[BlobUrlManager] Revoked blob URL for media media-1

[90mstdout[2m | src/features/preview/utils/media-resolver.test.ts[2m > [22m[2mresolveMediaUrl[2m > [22m[2mreturns empty string when media not found
[22m[39m[BlobUrlManager] Revoked blob URL for media media-1

[90mstdout[2m | src/features/preview/utils/media-resolver.test.ts[2m > [22m[2mresolveMediaUrl[2m > [22m[2mdeduplicates concurrent requests for same mediaId
[22m[39m[BlobUrlManager] Revoked blob URL for media media-1

[90mstdout[2m | src/features/preview/utils/media-resolver.test.ts[2m > [22m[2mresolveMediaUrls[2m > [22m[2mresolves src for video, audio, and image items
[22m[39m[BlobUrlManager] Revoked blob URL for media media-1

[90mstdout[2m | src/features/preview/utils/media-resolver.test.ts[2m > [22m[2mresolveMediaUrls[2m > [22m[2mdoes not mutate original tracks
[22m[39m[BlobUrlManager] Revoked blob URL for media media-1

[90mstdout[2m | src/features/preview/utils/media-resolver.test.ts[2m > [22m[2mrelinking regression[2m > [22m[2mresolves URL after failed initial resolution + blobUrlManager invalidation
[22m[39m[BlobUrlManager] Revoked blob URL for media media-1

[90mstdout[2m | src/features/preview/utils/media-resolver.test.ts[2m > [22m[2mrelinking regression[2m > [22m[2mresolves fresh URL after successful resolution + invalidation + re-resolve
[22m[39m[BlobUrlManager] Revoked blob URL for media media-1

 [32m✓[39m src/features/preview/utils/media-resolver.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 14[2mms[22m[39m
 [32m✓[39m src/features/timeline/hooks/use-waveform-prefetch.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 13[2mms[22m[39m
 [32m✓[39m src/features/preview/utils/preview-state-coordinator.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 4[2mms[22m[39m
[90mstdout[2m | src/features/media-library/stores/media-relinking-actions.test.ts[2m > [22m[2mcreateRelinkingActions[2m > [22m[2mrelinkMedia[2m > [22m[2mupdates mediaItems with the relinked metadata
[22m[39m[BlobUrlManager] Revoked blob URL for media media-1

 [32m✓[39m src/features/media-library/stores/media-relinking-actions.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 13[2mms[22m[39m
[90mstdout[2m | src/features/export/utils/canvas-item-renderer.composition-masks.test.ts[2m > [22m[2mcanvas-item-renderer composition masks[2m > [22m[2mapplies active sub-comp masks only to lower tracks and does not render mask shapes as regular content
[22m[39m[CanvasItemRenderer] Rendering sub-comp item {
  itemId: [32m'sub-cont'[39m,
  type: [32m'shape'[39m,
  localFrame: [33m0[39m,
  subItemFrom: [33m0[39m,
  subItemDuration: [33m60[39m,
  hasExtractor: [33mfalse[39m,
  hasImage: [33mfalse[39m,
  hasGif: [33mfalse[39m
}

[90mstdout[2m | src/features/export/utils/canvas-item-renderer.composition-masks.test.ts[2m > [22m[2mcanvas-item-renderer composition masks[2m > [22m[2mapplies active sub-comp masks only to lower tracks and does not render mask shapes as regular content
[22m[39m[CanvasItemRenderer] Sub-comp render complete {
  compositionId: [32m'sub-comp'[39m,
  localFrame: [33m0[39m,
  renderedSubItems: [33m1[39m,
  trackCount: [33m2[39m
}

[90mstdout[2m | src/features/export/utils/canvas-item-renderer.composition-masks.test.ts[2m > [22m[2mcanvas-item-renderer composition masks[2m > [22m[2mdoes not apply a sub-comp mask to content above the mask track
[22m[39m[CanvasItemRenderer] Rendering sub-comp item {
  itemId: [32m'sub-cont'[39m,
  type: [32m'shape'[39m,
  localFrame: [33m0[39m,
  subItemFrom: [33m0[39m,
  subItemDuration: [33m60[39m,
  hasExtractor: [33mfalse[39m,
  hasImage: [33mfalse[39m,
  hasGif: [33mfalse[39m
}

[90mstdout[2m | src/features/export/utils/canvas-item-renderer.composition-masks.test.ts[2m > [22m[2mcanvas-item-renderer composition masks[2m > [22m[2mdoes not apply a sub-comp mask to content above the mask track
[22m[39m[CanvasItemRenderer] Sub-comp render complete {
  compositionId: [32m'sub-comp'[39m,
  localFrame: [33m0[39m,
  renderedSubItems: [33m1[39m,
  trackCount: [33m2[39m
}

 [32m✓[39m src/features/export/utils/canvas-item-renderer.composition-masks.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 6[2mms[22m[39m
[90mstdout[2m | src/features/timeline/stores/actions/recorded-clip-actions.test.ts[2m > [22m[2minsertRecordedClip[2m > [22m[2minserts clip on the timeline on success
[22m[39m[TimelineActions] Inserted recorded AI clip onto timeline {
  mediaId: [32m'media-1'[39m,
  trackId: [32m'track-1'[39m,
  from: [33m30[39m,
  durationInFrames: [33m30[39m
}

[90mstdout[2m | src/features/timeline/stores/actions/recorded-clip-actions.test.ts[2m > [22m[2maddMediaToTimeline[2m > [22m[2madds media at the playhead on success
[22m[39m[TimelineActions] Added media to timeline {
  mediaId: [32m'media-1'[39m,
  trackId: [32m'track-1'[39m,
  from: [33m45[39m,
  durationInFrames: [33m60[39m
}

[90mstdout[2m | src/features/timeline/stores/actions/recorded-clip-actions.test.ts[2m > [22m[2maddMediaToTimeline[2m > [22m[2mplaces audio media on an audio track instead of a video track
[22m[39m[TimelineActions] Added media to timeline {
  mediaId: [32m'media-audio'[39m,
  trackId: [32m'audio-track'[39m,
  from: [33m45[39m,
  durationInFrames: [33m60[39m
}

 [32m✓[39m src/features/timeline/stores/actions/recorded-clip-actions.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 12[2mms[22m[39m
 [32m✓[39m src/features/preview/stores/playback-store.test.ts [2m([22m[2m23 tests[22m[2m)[22m[32m 7[2mms[22m[39m
[90mstdout[2m | src/features/timeline/stores/items-store.test.ts[2m > [22m[2mitems-store rate stretch[2m > [22m[2msplitItem sets explicit sourceStart on both left and right items
[22m[39m[ItemsStore] _splitItem: Original sourceStart:0 speed:1 leftDuration:150 rightDuration:150
[ItemsStore] _splitItem: boundaries.right.sourceStart:150 rightItem.sourceStart:150

 [32m✓[39m src/features/timeline/stores/items-store.test.ts [2m([22m[2m12 tests[22m[2m)[22m[32m 11[2mms[22m[39m
 [32m✓[39m src/features/media-library/services/media-library-service.generated-image.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 12[2mms[22m[39m
 [32m✓[39m src/features/export/utils/canvas-masks.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m src/features/media-library/utils/caption-items.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m src/features/editor/stores/selection-store.test.ts [2m([22m[2m22 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m src/features/timeline/stores/actions/item-actions.slip-slide.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m src/features/timeline/utils/trim-utils.test.ts [2m([22m[2m13 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/features/projects/utils/project-helpers.test.ts [2m([22m[2m33 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m src/features/composition-runtime/utils/dom-video-element-registry.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m src/features/timeline/stores/keyframe-selection-store.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m src/features/preview/utils/playback-transition-overlay.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m src/features/preview/utils/text-layout.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m src/features/composition-runtime/contexts/composition-space-context.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/features/timeline/utils/drop-placement.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 9[2mms[22m[39m
 [32m✓[39m src/features/timeline/utils/bento-layout.test.ts [2m([22m[2m18 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m src/shared/utils/usdc-transfer.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 36[2mms[22m[39m
 [32m✓[39m src/features/editor/utils/transition-ui-config.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/features/preview/utils/adaptive-preview-quality.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m src/shared/utils/whisper-settings.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m src/features/composition-runtime/utils/transition-shadow-warmup.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m src/features/timeline/hooks/use-rate-stretch.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/features/preview/utils/preview-interaction-mode.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m src/lib/gpu-effects/index.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m src/features/preview/utils/path-fit.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m src/features/credits/api/resolve-purchase-tx.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m src/features/export/utils/canvas-effects.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/features/composition-runtime/utils/frame-scene.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/features/timeline/utils/transition-edit-guards.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/features/composition-runtime/utils/scene-assembly.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 13[2mms[22m[39m
 [32m✓[39m src/domain/timeline/transitions/transition-planner.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/features/keyframes/utils/interpolation.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 2[2mms[22m[39m
[90mstdout[2m | src/infrastructure/browser/blob-url-manager.test.ts[2m > [22m[2mBlobUrlManager[2m > [22m[2macquire[2m > [22m[2mreturns the same URL for duplicate acquires
[22m[39m[BlobUrlManager] Revoked blob URL for media media-1

[90mstdout[2m | src/infrastructure/browser/blob-url-manager.test.ts[2m > [22m[2mBlobUrlManager[2m > [22m[2macquire[2m > [22m[2mincrements ref count on duplicate acquire
[22m[39m[BlobUrlManager] Revoked blob URL for media media-1

[90mstdout[2m | src/infrastructure/browser/blob-url-manager.test.ts[2m > [22m[2mBlobUrlManager[2m > [22m[2macquire[2m > [22m[2mincrements ref count on duplicate acquire
[22m[39m[BlobUrlManager] Revoked blob URL for media media-1

[90mstdout[2m | src/infrastructure/browser/blob-url-manager.test.ts[2m > [22m[2mBlobUrlManager[2m > [22m[2minvalidate[2m > [22m[2mremoves and revokes the blob URL regardless of ref count
[22m[39m[BlobUrlManager] Revoked blob URL for media media-1

[90mstdout[2m | src/infrastructure/browser/blob-url-manager.test.ts[2m > [22m[2mBlobUrlManager[2m > [22m[2mrelease[2m > [22m[2mrevokes URL when refCount reaches zero
[22m[39m[BlobUrlManager] Revoked blob URL for media media-1

[90mstdout[2m | src/infrastructure/browser/blob-url-manager.test.ts[2m > [22m[2mBlobUrlManager[2m > [22m[2mrelease[2m > [22m[2mrevokes URL when refCount reaches zero
[22m[39m[BlobUrlManager] Revoked blob URL for media media-1

[90mstdout[2m | src/infrastructure/browser/blob-url-manager.test.ts[2m > [22m[2mBlobUrlManager[2m > [22m[2mreleaseAll[2m > [22m[2mrevokes all URLs and clears entries
[22m[39m[BlobUrlManager] Revoked blob URL for media media-1
[BlobUrlManager] Revoked blob URL for media media-2

 [32m✓[39m src/infrastructure/browser/blob-url-manager.test.ts [2m([22m[2m11 tests[22m[2m)[22m[32m 15[2mms[22m[39m
 [32m✓[39m src/features/timeline/utils/timeline-snap-utils.test.ts [2m([22m[2m12 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m src/features/composition-runtime/utils/video-scene.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m src/features/composition-runtime/utils/transition-scene.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m src/features/preview/utils/scrubbing-cache.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m src/features/composition-runtime/utils/audio-scene.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m src/features/preview/utils/preload-window.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/features/preview/utils/preload-burst.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m src/features/preview/utils/preview-perf-metrics.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m src/features/timeline/utils/transition-utils.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/features/timeline/stores/keyframes-store.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m src/features/settings/components/hotkey-editor.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m src/features/composition-runtime/utils/audio-codec-detection.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m src/features/composition-runtime/utils/clip-mask-raster.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/features/player/clock/Clock.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m src/features/timeline/stores/actions/item-actions.add-placement.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m src/features/timeline/utils/sub-composition-normalizer.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m src/config/superfluid.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m src/features/editor/stores/editor-store.test.ts [2m([22m[2m12 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/features/keyframes/components/dopesheet-editor/index.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/features/preview/utils/player-seek-guard.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m src/features/editor/components/properties-sidebar/clip-panel/text-animation-presets.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m src/features/preview/utils/source-warm-target.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 9[2mms[22m[39m
 [32m✓[39m src/shared/utils/managed-worker-session.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/features/preview/utils/fast-scrub-overlay-guard.test.ts [2m([22m[2m6 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m src/features/composition-runtime/utils/video-timing.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 12[2mms[22m[39m
 [32m✓[39m src/features/timeline/utils/transition-preview-geometry.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/features/timeline/utils/slide-utils.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/features/credits/usdc-for-purchase.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 15[2mms[22m[39m
 [32m✓[39m src/features/composition-runtime/utils/mask-info.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m src/features/composition-runtime/hooks/use-transition-participant-sync.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m src/domain/timeline/transitions/engine-wipe.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m src/shared/utils/managed-worker-pool.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/features/timeline/stores/commands/labels.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m src/shared/utils/managed-worker.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/features/keyframes/utils/auto-keyframe.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m src/features/live-ai/lib/start-flow-error.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m src/shared/utils/transcription-progress.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m src/features/live-ai/stores/live-session-store.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m src/shared/state/local-inference/types.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 3[2mms[22m[39m
[90mstdout[2m | src/features/export/utils/timeline-to-composition.test.ts[2m > [22m[2mconvertTimelineToComposition IO marker conversion[2m > [22m[2mconverts IO trims from timeline frames to source frames using source FPS
[22m[39m[TimelineToComposition] Keyframes processing {
  inputKeyframes: [33m0[39m,
  outputKeyframes: [33m0[39m,
  hasIOMarkerOffsets: [33mtrue[39m,
  hasSplitClips: [33mfalse[39m,
  keyframeDetails: []
}

 [32m✓[39m src/features/export/utils/timeline-to-composition.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/features/export/utils/dom-video-drift.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 8[2mms[22m[39m
 [32m✓[39m src/features/preview/utils/fast-scrub-prewarm.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/shared/state/playback/frame-resolution.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m src/features/export/utils/canvas-keyframes.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m src/features/editor/components/properties-sidebar/clip-panel/index.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/features/preview/utils/text-render-guard.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/features/timeline/utils/transition-linked-neighbors.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/features/timeline/utils/dropped-media.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m src/shared/utils/mask-scope.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m api/_credit-store.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m src/features/preview/utils/source-media-sync.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m src/features/preview/hooks/use-gpu-effects-overlay.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 2[2mms[22m[39m

[2m Test Files [22m [1m[32m132 passed[39m[22m[90m (132)[39m
[2m      Tests [22m [1m[32m744 passed[39m[22m[90m (744)[39m
[2m   Start at [22m 16:28:37
[2m   Duration [22m 16.07s[2m (transform 13.82s, setup 10.19s, import 37.21s, tests 5.64s, environment 68.93s)[22m passed: 132 test files, 744 tests.\n- 
> pixels@0.0.0 build
> vite build

vite v6.4.3 building for production...
transforming...
✓ 10931 modules transformed.
rendering chunks...
computing gzip size...
dist/assets/__vite-browser-external-D9Y_u8YU.js          0.13 kB
dist/assets/preview-contract-GiwlZjD6.js                 0.37 kB
dist/assets/decoder-prewarm-worker-D7v2Q5U0.js           1.63 kB
dist/index.html                                          1.82 kB │ gzip:   0.71 kB
dist/assets/proxy-generation-worker-DQAzJEDT.js          2.83 kB
dist/assets/waveform-worker-BVybMqNc.js                  3.06 kB
dist/assets/whisper.worker-BqTlqi0P.js                   3.51 kB
dist/assets/filmstrip-extraction-worker-E9ymwgZ6.js      3.64 kB
dist/assets/packet-DYhFgbMz.js                           4.58 kB
dist/assets/media-processor.worker-DreVbc2q.js           4.66 kB
dist/assets/opfs-worker-fFgNDS8I.js                      5.04 kB
dist/assets/soundtouch-kAKNTTJE.js                      13.73 kB
dist/assets/canvas-audio-CA3w4zc_.js                    14.74 kB
dist/assets/custom-coder-CNB9f537.js                   102.57 kB
dist/assets/custom-coder-CVY9HToy.js                   102.57 kB
dist/assets/decoder.worker-CIXJmrrB.js                 304.15 kB
dist/assets/mediabunny-mp3-encoder-BlfuC2SQ.js         311.29 kB
dist/assets/index-CIoP67W3.js                          553.06 kB
dist/assets/index-DWEwnJJW.js                          557.49 kB
dist/assets/export-render.worker-C9QyFz0V.js           622.67 kB
dist/assets/index-CLfjns2d.js                          657.39 kB
dist/assets/mediabunny-ac3-ClziSG6u.js               1,144.23 kB
dist/assets/mediabunny-ac3-DrPJ9PqN.js               1,144.23 kB
dist/assets/index-BdLhAh-x.css                         126.88 kB │ gzip:  19.68 kB
dist/assets/alert-Bt0L-ukW.js                            0.84 kB │ gzip:   0.48 kB │ map:     2.04 kB
dist/assets/ac3-decoder-C5W_jD5M.js                      0.87 kB │ gzip:   0.52 kB │ map:     2.03 kB
dist/assets/core-logger-BrAkqT9i.js                      0.99 kB │ gzip:   0.50 kB │ map:     8.29 kB
dist/assets/generative-contract--75Lvro5.js              1.73 kB │ gzip:   0.77 kB │ map:    11.40 kB
dist/assets/preview-contract-8mvk6sND.js                 2.12 kB │ gzip:   1.05 kB │ map:     9.49 kB
dist/assets/effects-BOfz4Z2-.js                          4.53 kB │ gzip:   1.51 kB │ map:     9.66 kB
dist/assets/bundle-import-service-CAtif6Aw.js            5.98 kB │ gzip:   2.49 kB │ map:    23.68 kB
dist/assets/gif-processing-CNw5tbJV.js                   7.25 kB │ gzip:   2.71 kB │ map:    30.58 kB
dist/assets/bundle-export-dialog-DSI0Tjkv.js            11.45 kB │ gzip:   3.93 kB │ map:    41.68 kB
dist/assets/audio-processing-kAKNTTJE.js                13.73 kB │ gzip:   3.95 kB │ map:    42.80 kB
dist/assets/canvas-audio-CkF03sG3.js                    14.55 kB │ gzip:   5.48 kB │ map:    70.85 kB
dist/assets/browser-D2SfJ2Hi.js                         17.31 kB │ gzip:   7.87 kB │ map:   130.91 kB
dist/assets/generative-NlfVaxIq.js                      21.24 kB │ gzip:   6.31 kB │ map:    75.38 kB
dist/assets/export-dialog-C8wjQ0D_.js                   24.05 kB │ gzip:   7.57 kB │ map:    84.53 kB
dist/assets/vendor-icons-DliclnW6.js                    59.92 kB │ gzip:  10.90 kB │ map:   146.57 kB
dist/assets/media-mp3-encoder-TwOWUiAm.js              311.07 kB │ gzip: 131.53 kB │ map:   324.37 kB
dist/assets/vendor-ui-and-wallet-CxnaG31Q.js           437.35 kB │ gzip: 135.08 kB │ map: 2,237.67 kB
dist/assets/media-bunny-core-Cf23LiAi.js               657.23 kB │ gzip: 164.56 kB │ map: 2,647.95 kB
dist/assets/_projectId.lazy-DrBJYkTs.js                994.01 kB │ gzip: 283.11 kB │ map: 4,294.66 kB
dist/assets/media-ac3-decoder-AdfG3idj.js            1,144.05 kB │ gzip: 299.08 kB │ map: 2,247.19 kB
dist/assets/index-X1oXYn8D.js                        2,031.17 kB │ gzip: 578.51 kB │ map: 4,863.16 kB
✓ built in 45.21s passed.\n\n### Files changed\n- \n- 