### PR TITLE
fix(onramp): prefill email from Privy login

### DIFF
--- a/src/components/headless-cdp-onramp.tsx
+++ b/src/components/headless-cdp-onramp.tsx
@@ -17,7 +17,9 @@ import {
   TabsTrigger,
 } from '@/components/ui/tabs';
 import { getOnrampApiBaseUrl } from '@/config/onramp';
+import { useWalletContext } from '@/context/wallet-context';
 import { createLogger, createOperationId } from '@/shared/logging/logger';
+import { getPrivyUserEmail } from '@/utils/privy-user';
 
 const log = createLogger('headless-cdp-onramp');
 
@@ -131,13 +133,16 @@ async function createOnrampOrder(
  */
 export function HeadlessCdpOnramp({
   address,
-  email: prefilledEmail,
+  email: emailOverride,
   redirectUrl,
   onSuccess,
   onError,
   className,
   children,
 }: HeadlessCdpOnrampProps) {
+  const { user } = useWalletContext();
+  const prefilledEmail = emailOverride ?? getPrivyUserEmail(user);
+
   const [activeTab, setActiveTab] = useState<OnrampPaymentMethod>(
     'GUEST_CHECKOUT_APPLE_PAY'
   );

--- a/src/components/wallet-connect-button.tsx
+++ b/src/components/wallet-connect-button.tsx
@@ -78,7 +78,6 @@ export function WalletConnectButton({
     chain,
     switchChain,
     isConnecting,
-    user,
   } = useWalletContext();
   const address = wallet?.address as `0x${string}` | undefined;
   const { formatted: usdcFormatted } = useUsdcBalance(chain, address);
@@ -137,8 +136,6 @@ export function WalletConnectButton({
   }
 
   const displayText = address ? truncateAddress(address) : 'Connected';
-  const prefillEmail =
-    typeof user?.email === 'string' ? user.email : undefined;
 
   return (
     <>
@@ -284,7 +281,6 @@ export function WalletConnectButton({
           </DialogHeader>
           <HeadlessCdpOnramp
             address={address}
-            email={prefillEmail}
             onSuccess={() => {
               setOnrampOpen(false);
             }}

--- a/src/features/live-ai/components/insufficient-balance-paywall.tsx
+++ b/src/features/live-ai/components/insufficient-balance-paywall.tsx
@@ -32,7 +32,7 @@ import { HeadlessCdpOnramp } from '@/components/headless-cdp-onramp';
  *   3. If the user is not a premium member, also offer Subscribe for the lower rate.
  */
 export function InsufficientBalancePaywall() {
-  const { account: address, chain, user } = useWalletContext();
+  const { account: address, chain } = useWalletContext();
   const { isPremiumMember } = usePremiumMembership(address);
   const { openSubscribeCheckout, isConfigured: isUnlockConfigured } =
     useUnlockCheckout();
@@ -44,8 +44,6 @@ export function InsufficientBalancePaywall() {
 
   const hasAnyUsdc = Boolean(usdcBalance && Number(usdcBalance) > 0);
   const showSubscribe = isUnlockConfigured && !isPremiumMember;
-  const prefillEmail =
-    typeof user?.email === 'string' ? user.email : undefined;
 
   return (
     <>
@@ -114,7 +112,6 @@ export function InsufficientBalancePaywall() {
           </DialogHeader>
           <HeadlessCdpOnramp
             address={address}
-            email={prefillEmail}
             onSuccess={() => {
               setOnrampOpen(false);
             }}

--- a/src/features/metoken/components/buy-metoken-modal.tsx
+++ b/src/features/metoken/components/buy-metoken-modal.tsx
@@ -36,7 +36,7 @@ interface BuyMetokenModalProps {
 const BASE_CHAIN_ID = base.id;
 
 export function BuyMetokenModal({ open, onOpenChange }: BuyMetokenModalProps) {
-  const { account, chain, user } = useWalletContext();
+  const { account, chain } = useWalletContext();
   const queryClient = useQueryClient();
   const { sendOps, ready: walletReady } = useSmartWalletOps();
   const {
@@ -174,9 +174,6 @@ export function BuyMetokenModal({ open, onOpenChange }: BuyMetokenModalProps) {
     }
   }, [account, onBase, usdcInput, walletReady, sendOps, onOpenChange]);
 
-  const prefillEmail =
-    typeof user?.email === 'string' ? user.email : undefined;
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-md">
@@ -264,7 +261,6 @@ export function BuyMetokenModal({ open, onOpenChange }: BuyMetokenModalProps) {
                 </p>
                 <HeadlessCdpOnramp
                   address={account}
-                  email={prefillEmail}
                   onSuccess={() => setOnrampSuccess(true)}
                   onError={(msg) => toast.error('Buy USDC', { description: msg })}
                 />
@@ -296,7 +292,6 @@ export function BuyMetokenModal({ open, onOpenChange }: BuyMetokenModalProps) {
                 Need more USDC?{' '}
                 <HeadlessCdpOnramp
                   address={account}
-                  email={prefillEmail}
                   onSuccess={() => setOnrampSuccess(true)}
                   onError={(msg) => toast.error('Buy USDC', { description: msg })}
                   className="inline-block"

--- a/src/features/metoken/components/insufficient-metoken-paywall.tsx
+++ b/src/features/metoken/components/insufficient-metoken-paywall.tsx
@@ -30,15 +30,13 @@ interface InsufficientMetokenPaywallProps {
 export function InsufficientMetokenPaywall({
   message = 'Buy CRTVAI to generate AI renders.',
 }: InsufficientMetokenPaywallProps) {
-  const { account, chain, user } = useWalletContext();
+  const { account, chain } = useWalletContext();
   const { formatted, symbol } = useCrtvaiBalance(account);
   const { balance: usdcBalance } = useUsdcBalance(chain, account);
   const [buyOpen, setBuyOpen] = useState(false);
   const [onrampOpen, setOnrampOpen] = useState(false);
 
   const hasAnyUsdc = Boolean(usdcBalance && Number(usdcBalance) > 0);
-  const prefillEmail =
-    typeof user?.email === 'string' ? user.email : undefined;
 
   return (
     <>
@@ -92,7 +90,6 @@ export function InsufficientMetokenPaywall({
           </DialogHeader>
           <HeadlessCdpOnramp
             address={account}
-            email={prefillEmail}
             onSuccess={() => {
               setOnrampOpen(false);
             }}

--- a/src/utils/privy-user.test.ts
+++ b/src/utils/privy-user.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import type { User } from '@privy-io/react-auth';
+import { getPrivyUserEmail } from './privy-user';
+
+describe('getPrivyUserEmail', () => {
+  it('returns email login address when present', () => {
+    const user = {
+      email: { address: 'alice@example.com' },
+    } as User;
+
+    expect(getPrivyUserEmail(user)).toBe('alice@example.com');
+  });
+
+  it('returns Google OAuth email when email login is absent', () => {
+    const user = {
+      google: { email: 'bob@gmail.com', name: 'Bob', subject: 'sub' },
+    } as User;
+
+    expect(getPrivyUserEmail(user)).toBe('bob@gmail.com');
+  });
+
+  it('prefers email login over Google email', () => {
+    const user = {
+      email: { address: 'alice@example.com' },
+      google: { email: 'alice@gmail.com', name: 'Alice', subject: 'sub' },
+    } as User;
+
+    expect(getPrivyUserEmail(user)).toBe('alice@example.com');
+  });
+
+  it('returns undefined when no email is available', () => {
+    expect(getPrivyUserEmail(null)).toBeUndefined();
+    expect(getPrivyUserEmail(undefined)).toBeUndefined();
+    expect(getPrivyUserEmail({} as User)).toBeUndefined();
+  });
+});

--- a/src/utils/privy-user.ts
+++ b/src/utils/privy-user.ts
@@ -1,0 +1,15 @@
+import type { User } from '@privy-io/react-auth';
+
+/**
+ * Extract the logged-in user's email from a Privy User.
+ * Prefer email login (`user.email.address`), then Google OAuth (`user.google.email`).
+ */
+export function getPrivyUserEmail(
+  user: User | null | undefined
+): string | undefined {
+  const fromEmail = user?.email?.address;
+  if (fromEmail) return fromEmail;
+  const fromGoogle = user?.google?.email;
+  if (fromGoogle) return fromGoogle;
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- Prefill the Buy USDC / CDP on-ramp email field from Privy login (`user.email.address` or `user.google.email`)
- Fix callers that incorrectly treated `user.email` as a string (so prefill never worked)
- Centralize lookup in `getPrivyUserEmail` inside `HeadlessCdpOnramp`

## Test plan
- [ ] Log in with email, open Buy USDC — email field is prefilled
- [ ] Log in with Google, open Buy USDC — email field is prefilled
- [ ] Wallet-only login with no email — field stays empty and editable
- [ ] Phone field remains blank; form still requires a valid US phone to submit
- [ ] `npx vitest run src/utils/privy-user.test.ts` passes