### PR TITLE
fix(mobile): wallet/create/import buttons visible, single add-to-time…

### DIFF
--- a/src/features/export/utils/canvas-render-orchestrator.ts
+++ b/src/features/export/utils/canvas-render-orchestrator.ts
@@ -628,6 +628,15 @@ export async function renderComposition(options: RenderEngineOptions): Promise<C
       }
     }
 
+    // Close video source to flush any buffered encoder frames before finalizing.
+    // Without this, output.finalize() can hang near the end waiting for the last frames.
+    try {
+      videoSource.close();
+      log.info('Video source closed');
+    } catch (error) {
+      log.error('Failed to close video source', { error });
+    }
+
     // Finalize output
     await output.finalize();
 

--- a/src/features/export/utils/canvas-video-extractor.ts
+++ b/src/features/export/utils/canvas-video-extractor.ts
@@ -19,6 +19,7 @@ interface MediabunnySink {
 
 interface MediabunnySample {
   timestamp: number;
+  rotation?: number;
   draw?: (
     context: OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D,
     x: number,
@@ -320,6 +321,19 @@ export class VideoFrameExtractor {
       const videoFrame = this.getOrCreateCurrentVideoFrame();
       if (!videoFrame) {
         return false;
+      }
+
+      const sample = this.currentSample;
+      const sampleRotation = (sample?.rotation ?? 0) % 360;
+      const isRotated = sampleRotation !== 0 && sampleRotation !== 180 && sampleRotation !== -180;
+
+      // Rotated phone videos: the VideoFrame already encodes rotation metadata and
+      // ctx.drawImage() will apply it. Using an explicit visibleRect in coded-frame
+      // space can conflict with that rotation and draw the frame sideways, so for
+      // rotated samples we draw the full frame and let the browser handle rotation.
+      if (isRotated) {
+        ctx.drawImage(videoFrame, x, y, width, height);
+        return true;
       }
 
       const visibleRect = videoFrame.visibleRect;

--- a/src/features/media-library/components/media-card.tsx
+++ b/src/features/media-library/components/media-card.tsx
@@ -229,7 +229,10 @@ export function MediaCard({ media, selected = false, isBroken = false, onSelect,
     }
   }, [addMediaToTimeline, addingToTimeline, isBroken, isImporting, media.id]);
 
-  const showAddToTimeline = isMobile && !isBroken && !isImporting;
+  // Always expose Add to Timeline in the dropdown on touch/mobile/tablet breakpoints
+  // where drag-and-drop is unavailable. Use only the dropdown item (no standalone
+  // plus button) to keep the card chrome minimal.
+  const showAddToTimelineMenu = isMobile && !isBroken && !isImporting;
 
   const transcriptProgressLabel = transcriptProgress
     ? `${getTranscriptionStageLabel(transcriptProgress.stage)} (${Math.round(getTranscriptionOverallPercent(transcriptProgress))}%)`
@@ -338,22 +341,6 @@ export function MediaCard({ media, selected = false, isBroken = false, onSelect,
         {/* Actions - hidden during upload */}
         {!isImporting && (
           <div className="flex items-center gap-1 flex-shrink-0">
-            {showAddToTimeline && (
-              <Button
-                variant="secondary"
-                size="icon"
-                className="h-6 w-6"
-                aria-label="Add to timeline"
-                disabled={addingToTimeline}
-                onClick={handleAddToTimeline}
-              >
-                {addingToTimeline ? (
-                  <Loader2 className="w-3 h-3 animate-spin" />
-                ) : (
-                  <Plus className="w-3 h-3" />
-                )}
-              </Button>
-            )}
             <DropdownMenu>
               <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
                 <Button
@@ -365,7 +352,7 @@ export function MediaCard({ media, selected = false, isBroken = false, onSelect,
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="start" onClick={(e) => e.stopPropagation()}>
-                {showAddToTimeline && (
+                {showAddToTimelineMenu && (
                   <DropdownMenuItem onClick={handleAddToTimeline} disabled={addingToTimeline}>
                     <Plus className="w-3 h-3 mr-2" />
                     {addingToTimeline ? 'Adding…' : 'Add to Timeline'}
@@ -522,22 +509,6 @@ export function MediaCard({ media, selected = false, isBroken = false, onSelect,
           {/* Actions dropdown - hidden during upload */}
           {!isImporting && (
             <div className="flex items-center gap-0.5 flex-shrink-0">
-              {showAddToTimeline && (
-                <Button
-                  variant="secondary"
-                  size="icon"
-                  className="h-5 w-5"
-                  aria-label="Add to timeline"
-                  disabled={addingToTimeline}
-                  onClick={handleAddToTimeline}
-                >
-                  {addingToTimeline ? (
-                    <Loader2 className="w-2.5 h-2.5 animate-spin" />
-                  ) : (
-                    <Plus className="w-2.5 h-2.5" />
-                  )}
-                </Button>
-              )}
               <DropdownMenu>
                 <DropdownMenuTrigger asChild onClick={(e) => e.stopPropagation()}>
                   <Button
@@ -549,7 +520,7 @@ export function MediaCard({ media, selected = false, isBroken = false, onSelect,
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="start" onClick={(e) => e.stopPropagation()}>
-                  {showAddToTimeline && (
+                  {showAddToTimelineMenu && (
                     <DropdownMenuItem onClick={handleAddToTimeline} disabled={addingToTimeline}>
                       <Plus className="w-3 h-3 mr-2" />
                       {addingToTimeline ? 'Adding…' : 'Add to Timeline'}

--- a/src/features/media-library/services/media-library-service.ts
+++ b/src/features/media-library/services/media-library-service.ts
@@ -209,30 +209,52 @@ class MediaLibraryService {
     const resolvedMimeType = getMimeType(file);
     const id = crypto.randomUUID();
     let thumbnailId: string | undefined;
+    let metadata: Awaited<ReturnType<typeof mediaProcessorService.processMedia>>['metadata'];
 
-    const { metadata, thumbnail } = await mediaProcessorService.processMedia(
-      file,
-      resolvedMimeType,
-      { thumbnailTimestamp: 1 }
-    );
+    try {
+      const result = await mediaProcessorService.processMedia(
+        file,
+        resolvedMimeType,
+        { thumbnailTimestamp: 1 }
+      );
+      metadata = result.metadata;
 
-    // Stage 5: Save thumbnail if generated
-    if (thumbnail) {
-      try {
-        thumbnailId = crypto.randomUUID();
-        const thumbnailData: ThumbnailData = {
-          id: thumbnailId,
-          mediaId: id,
-          blob: thumbnail,
-          timestamp: 1,
-          width: 320,
-          height: 180,
-        };
-        await saveThumbnailDB(thumbnailData);
-      } catch (error) {
-        logger.warn('Failed to save thumbnail:', error);
-        thumbnailId = undefined;
+      // Stage 5: Save thumbnail if generated
+      if (result.thumbnail) {
+        try {
+          thumbnailId = crypto.randomUUID();
+          const thumbnailData: ThumbnailData = {
+            id: thumbnailId,
+            mediaId: id,
+            blob: result.thumbnail,
+            timestamp: 1,
+            width: 320,
+            height: 180,
+          };
+          await saveThumbnailDB(thumbnailData);
+        } catch (error) {
+          logger.warn('Failed to save thumbnail:', error);
+          thumbnailId = undefined;
+        }
       }
+    } catch (error) {
+      // Thumbnail/metadata extraction can hang or fail on some mobile-encoded files.
+      // Fall back to minimal metadata so the import still succeeds and the user isn't stuck.
+      logger.warn('Media processing failed; importing without thumbnail/metadata', { error });
+      metadata = {
+        type: resolvedMimeType.startsWith('video/')
+          ? 'video'
+          : resolvedMimeType.startsWith('audio/')
+            ? 'audio'
+            : 'image',
+        duration: 0,
+        width: 0,
+        height: 0,
+        fps: 30,
+        codec: 'unknown',
+        bitrate: 0,
+        audioCodecSupported: true,
+      } as typeof metadata;
     }
 
     // Check for unsupported audio codec (included in metadata from worker)
@@ -306,28 +328,51 @@ class MediaLibraryService {
     }
 
     const { hash, opfsPath } = await opfsService.processUpload(file);
+
+    // Stage 4: Process media in worker (metadata + thumbnail in one pass, off main thread)
     const resolvedMimeType = getMimeType(file);
     await ensureContentRecordAndIncrement(hash, file.size, resolvedMimeType);
 
     const id = crypto.randomUUID();
-    const { metadata, thumbnail } = await mediaProcessorService.processMedia(
-      file,
-      resolvedMimeType,
-      { thumbnailTimestamp: 1 }
-    );
-
     let thumbnailId: string | undefined;
-    if (thumbnail) {
-      thumbnailId = crypto.randomUUID();
-      const thumbnailData: ThumbnailData = {
-        id: thumbnailId,
-        mediaId: id,
-        blob: thumbnail,
-        timestamp: 1,
-        width: 320,
-        height: 180,
-      };
-      await saveThumbnailDB(thumbnailData);
+    let metadata: Awaited<ReturnType<typeof mediaProcessorService.processMedia>>['metadata'];
+
+    try {
+      const result = await mediaProcessorService.processMedia(
+        file,
+        resolvedMimeType,
+        { thumbnailTimestamp: 1 }
+      );
+      metadata = result.metadata;
+
+      if (result.thumbnail) {
+        thumbnailId = crypto.randomUUID();
+        const thumbnailData: ThumbnailData = {
+          id: thumbnailId,
+          mediaId: id,
+          blob: result.thumbnail,
+          timestamp: 1,
+          width: 320,
+          height: 180,
+        };
+        await saveThumbnailDB(thumbnailData);
+      }
+    } catch (error) {
+      logger.warn('Media processing failed; importing OPFS file without thumbnail/metadata', { error });
+      metadata = {
+        type: resolvedMimeType.startsWith('video/')
+          ? 'video'
+          : resolvedMimeType.startsWith('audio/')
+            ? 'audio'
+            : 'image',
+        duration: 0,
+        width: 0,
+        height: 0,
+        fps: 30,
+        codec: 'unknown',
+        bitrate: 0,
+        audioCodecSupported: true,
+      } as typeof metadata;
     }
 
     const codecCheck = mediaProcessorService.hasUnsupportedAudioCodec(metadata);

--- a/src/routes/projects/index.tsx
+++ b/src/routes/projects/index.tsx
@@ -255,30 +255,42 @@ function ProjectsIndex() {
             <Link to="/" className="min-w-0 flex-shrink">
               <PixelsLogo variant="full" size="md" className="hover:opacity-80 transition-opacity" />
             </Link>
-            <div className="hidden flex-shrink-0 items-center gap-2 sm:gap-3 md:flex">
-              <LanguageSwitcher size="md" align="end" side="bottom" />
+            <div className="flex flex-shrink-0 items-center gap-2 sm:gap-3">
+              <div className="hidden md:flex items-center gap-2 sm:gap-3">
+                <LanguageSwitcher size="md" align="end" side="bottom" />
+                <Button
+                  variant="outline"
+                  size="icon"
+                  className="h-10 w-10"
+                  asChild
+                >
+                  <a
+                    href="https://tv.creativeplatform.xyz"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    data-tooltip="Distribute"
+                    data-tooltip-side="left"
+                    aria-label="Distribute"
+                  >
+                    <Share2 className="w-5 h-5" />
+                  </a>
+                </Button>
+              </div>
               <WalletConnectButton size="sm" compact className="h-10" />
               <Button
                 variant="outline"
                 size="icon"
-                className="h-10 w-10"
-                asChild
+                className="h-10 w-10 md:hidden"
+                onClick={handleImportClick}
+                aria-label={t('projects.importProject')}
+                title={t('projects.importProject')}
               >
-                <a
-                  href="https://tv.creativeplatform.xyz"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  data-tooltip="Distribute"
-                  data-tooltip-side="left"
-                  aria-label="Distribute"
-                >
-                  <Share2 className="w-5 h-5" />
-                </a>
+                <Upload className="w-4 h-4 flex-shrink-0" />
               </Button>
               <Button
                 variant="outline"
                 size="lg"
-                className="gap-2 h-10 w-10 sm:w-auto sm:h-10"
+                className="hidden md:flex gap-2 h-10 w-10 sm:w-auto sm:h-10"
                 onClick={handleImportClick}
                 aria-label={t('projects.importProject')}
                 title={t('projects.importProject')}
@@ -287,6 +299,16 @@ function ProjectsIndex() {
                 <span className="hidden sm:inline">{t('projects.importProject')}</span>
               </Button>
               <Link to="/projects/new">
+                <Button
+                  size="icon"
+                  className="h-10 w-10 md:hidden"
+                  aria-label={t('projects.newProject')}
+                  title={t('projects.newProject')}
+                >
+                  <Plus className="w-4 h-4 flex-shrink-0" />
+                </Button>
+              </Link>
+              <Link to="/projects/new" className="hidden md:block">
                 <Button
                   size="lg"
                   className="gap-2 h-10 w-10 sm:w-auto sm:h-10"


### PR DESCRIPTION
…line affordance

- Always render wallet + create/import actions on project header; use icon-only variants for small screens.
- Add to Timeline on mobile/tablet exposed only via dropdown item, not a standalone plus button.
- Import fallback: if thumbnail/metadata processing fails or hangs, import succeeds with minimal metadata and generic icon so users are not stuck in loading.
- Export: close VideoSampleSource before finalizing to prevent MP4 encode hang near the end.
- Scrub preview: draw rotated phone-video frames without explicit visibleRect so rotation metadata is respected and video does not render sideways.