### PR TITLE
feat(credits): bridge legacy credits client to CRTVAI meToken

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,8 +22,6 @@ VITE_ALCHEMY_POLICY_ID=
 # Server/API Configuration
 # ===========================================
 
-PRIVY_APP_ID=
-PRIVY_APP_SECRET=
-ALCHEMY_API_KEY=
-ALCHEMY_GAS_POLICY_TYPE=
-ALCHEMY_GAS_MAX_USDC6=
+# CRTVAIx / Superfluid (Live AI streaming)
+VITE_CRTVAIX_ADDRESS=
+VITE_SUPERFLUID_RECEIVER=

--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,25 @@
 # Show/hide floating debug button in editor (dev mode only)
 # Set to 'false' to hide debug panel button during development
 VITE_SHOW_DEBUG_PANEL=true
+
+# ===========================================
+# Wallet & Auth (Privy + Alchemy)
+# ===========================================
+
+# Privy auth (required for wallet login)
+VITE_PRIVY_APP_ID=
+VITE_PRIVY_CLIENT_ID=
+
+# Alchemy API key for embedded smart wallet + blockchain reads
+VITE_ALCHEMY_API_KEY=
+VITE_ALCHEMY_POLICY_ID=
+
+# ===========================================
+# Server/API Configuration
+# ===========================================
+
+PRIVY_APP_ID=
+PRIVY_APP_SECRET=
+ALCHEMY_API_KEY=
+ALCHEMY_GAS_POLICY_TYPE=
+ALCHEMY_GAS_MAX_USDC6=

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+legacy-peer-deps=true
+fetch-retries=5
+fetch-retry-mintimeout=20000
+fetch-retry-maxtimeout=120000

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -6,6 +6,7 @@ import { ErrorBoundary } from '@/app/error-boundary'
 import { PwaInstallPrompt } from '@/app/pwa-install-prompt'
 import { RouteErrorScreen } from '@/app/route-error'
 import { WorkspaceGate } from '@/features/workspace-gate/workspace-gate'
+import { WalletProvider } from '@/context/wallet-context'
 import { routeTree } from './routeTree.gen'
 
 // Route errors (thrown from beforeLoad/loader) never reach the React
@@ -77,9 +78,11 @@ export function App() {
   return (
     <ErrorBoundary level="app">
       <TooltipProvider delayDuration={300}>
-        <WorkspaceGate>
-          <RouterProvider router={router} />
-        </WorkspaceGate>
+        <WalletProvider>
+          <WorkspaceGate>
+            <RouterProvider router={router} />
+          </WorkspaceGate>
+        </WalletProvider>
         <GlobalTooltip />
         <PwaInstallPrompt />
         {showToaster && (

--- a/src/components/wallet-connect-button.tsx
+++ b/src/components/wallet-connect-button.tsx
@@ -1,0 +1,135 @@
+import { useCallback, useState } from 'react'
+import { Copy, Wallet } from 'lucide-react'
+import { useWalletContext } from '@/context/wallet-context'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { SWITCHABLE_CHAINS } from '@/config/chains'
+import { cn } from '@/shared/ui/cn'
+
+function truncateAddress(address: string): string {
+  if (address.length <= 10) return address
+  return `${address.slice(0, 6)}…${address.slice(-4)}`
+}
+
+interface WalletConnectButtonProps {
+  /** Override label when not connected. */
+  connectLabel?: string
+  /** Size variant for the button. */
+  size?: 'default' | 'sm' | 'lg' | 'icon'
+  /** Show as icon-only on small screens when true. */
+  compact?: boolean
+  className?: string
+}
+
+export function WalletConnectButton({
+  connectLabel = 'Connect wallet',
+  size = 'sm',
+  compact = false,
+  className,
+}: WalletConnectButtonProps) {
+  const { ready, authenticated, connect, disconnect, wallet, chain, switchChain, isConnecting } =
+    useWalletContext()
+  const address = wallet?.address
+  const [copied, setCopied] = useState(false)
+
+  const handleCopyAddress = useCallback(() => {
+    if (!address) return
+    void navigator.clipboard.writeText(address).then(() => {
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1500)
+    })
+  }, [address])
+
+  const isInitializing = !ready || isConnecting
+  const isConnected = Boolean(authenticated && wallet)
+
+  if (isInitializing) {
+    return (
+      <Button variant="outline" size={size} className={className} disabled>
+        Loading…
+      </Button>
+    )
+  }
+
+  if (!isConnected) {
+    return (
+      <Button
+        variant="outline"
+        size={size}
+        className={cn('gap-2', className)}
+        onClick={() => connect()}
+        aria-label={connectLabel}
+      >
+        <Wallet className="h-4 w-4 shrink-0" />
+        {!compact && <span className="hidden sm:inline">{connectLabel}</span>}
+      </Button>
+    )
+  }
+
+  const displayText = address ? truncateAddress(address) : 'Connected'
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size={size}
+          className={cn('gap-2', className)}
+          aria-label="Wallet"
+        >
+          <Wallet className="h-4 w-4 shrink-0" />
+          {!compact && <span className="hidden sm:inline">{displayText}</span>}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-[12rem]">
+        {address && (
+          <DropdownMenuItem
+            onClick={handleCopyAddress}
+            className="flex cursor-pointer items-center justify-between gap-2 font-mono text-xs"
+            aria-label="Copy full address"
+          >
+            <span>{truncateAddress(address)}</span>
+            <Copy className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden />
+            {copied && <span className="sr-only">Copied</span>}
+          </DropdownMenuItem>
+        )}
+        <div className="px-2 py-1.5">
+          <label className="mb-1.5 block text-xs font-medium text-muted-foreground">Network</label>
+          <Select
+            value={chain.id.toString()}
+            onValueChange={(value) => {
+              const c = SWITCHABLE_CHAINS.find((ch) => ch.id.toString() === value)
+              if (c) void switchChain(c.id)
+            }}
+          >
+            <SelectTrigger className="h-8 w-full text-xs">
+              <SelectValue placeholder="Select network" />
+            </SelectTrigger>
+            <SelectContent className="z-[10000]">
+              {SWITCHABLE_CHAINS.map((c) => (
+                <SelectItem key={c.id} value={c.id.toString()} className="text-xs">
+                  {c.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={() => disconnect()}>Disconnect</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/components/wallet-connect-button.tsx
+++ b/src/components/wallet-connect-button.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react'
-import { Copy, Wallet } from 'lucide-react'
+import { Copy, Sparkles, Wallet } from 'lucide-react'
 import { useWalletContext } from '@/context/wallet-context'
 import { Button } from '@/components/ui/button'
 import {
@@ -18,6 +18,8 @@ import {
 } from '@/components/ui/select'
 import { SWITCHABLE_CHAINS } from '@/config/chains'
 import { useUsdcBalance } from '@/hooks/use-usdc-balance'
+import { useCrtvaiBalance } from '@/hooks/use-crtvai-balance'
+import { BuyMetokenModal } from '@/features/metoken'
 import { cn } from '@/shared/ui/cn'
 
 function truncateAddress(address: string): string {
@@ -26,11 +28,8 @@ function truncateAddress(address: string): string {
 }
 
 interface WalletConnectButtonProps {
-  /** Override label when not connected. */
   connectLabel?: string
-  /** Size variant for the button. */
   size?: 'default' | 'sm' | 'lg' | 'icon'
-  /** Show as icon-only on small screens when true. */
   compact?: boolean
   className?: string
 }
@@ -45,7 +44,11 @@ export function WalletConnectButton({
     useWalletContext()
   const address = wallet?.address
   const { formatted: usdcFormatted } = useUsdcBalance(chain, address as `0x${string}` | undefined)
+  const { formatted: crtvaiFormatted, symbol: crtvaiSymbol } = useCrtvaiBalance(
+    address as `0x${string}` | undefined,
+  )
   const [copied, setCopied] = useState(false)
+  const [buyMetokenOpen, setBuyMetokenOpen] = useState(false)
 
   const handleCopyAddress = useCallback(() => {
     if (!address) return
@@ -84,59 +87,77 @@ export function WalletConnectButton({
   const displayText = address ? truncateAddress(address) : 'Connected'
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="outline"
-          size={size}
-          className={cn('gap-2', className)}
-          aria-label="Wallet"
-        >
-          <Wallet className="h-4 w-4 shrink-0" />
-          {!compact && <span className="hidden sm:inline">{displayText}</span>}
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="min-w-[12rem]">
-        {address && (
-          <DropdownMenuItem
-            onClick={handleCopyAddress}
-            className="flex cursor-pointer items-center justify-between gap-2 font-mono text-xs"
-            aria-label="Copy full address"
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="outline"
+            size={size}
+            className={cn('gap-2', className)}
+            aria-label="Wallet"
           >
-            <span>{truncateAddress(address)}</span>
-            <Copy className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden />
-            {copied && <span className="sr-only">Copied</span>}
+            <Wallet className="h-4 w-4 shrink-0" />
+            {!compact && <span className="hidden sm:inline">{displayText}</span>}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="min-w-[12rem]">
+          {address && (
+            <DropdownMenuItem
+              onClick={handleCopyAddress}
+              className="flex cursor-pointer items-center justify-between gap-2 font-mono text-xs"
+              aria-label="Copy full address"
+            >
+              <span>{truncateAddress(address)}</span>
+              <Copy className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden />
+              {copied && <span className="sr-only">Copied</span>}
+            </DropdownMenuItem>
+          )}
+
+          <DropdownMenuItem disabled className="text-muted-foreground">
+            USDC: {usdcFormatted}
           </DropdownMenuItem>
-        )}
 
-        <DropdownMenuItem disabled className="text-muted-foreground">
-          USDC: {usdcFormatted}
-        </DropdownMenuItem>
-
-        <div className="px-2 py-1.5">
-          <label className="mb-1.5 block text-xs font-medium text-muted-foreground">Network</label>
-          <Select
-            value={chain.id.toString()}
-            onValueChange={(value) => {
-              const c = SWITCHABLE_CHAINS.find((ch) => ch.id.toString() === value)
-              if (c) void switchChain(c.id)
-            }}
+          <DropdownMenuItem disabled className="text-muted-foreground">
+            {crtvaiSymbol}: {crtvaiFormatted}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => setBuyMetokenOpen(true)}
+            className="flex cursor-pointer items-center gap-2"
+            aria-label="Buy CRTVAI"
           >
-            <SelectTrigger className="h-8 w-full text-xs">
-              <SelectValue placeholder="Select network" />
-            </SelectTrigger>
-            <SelectContent className="z-[10000]">
-              {SWITCHABLE_CHAINS.map((c) => (
-                <SelectItem key={c.id} value={c.id.toString()} className="text-xs">
-                  {c.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem onClick={() => disconnect()}>Disconnect</DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+            <Sparkles className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden />
+            Buy CRTVAI
+          </DropdownMenuItem>
+
+          <div className="px-2 py-1.5">
+            <label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+              Network
+            </label>
+            <Select
+              value={chain.id.toString()}
+              onValueChange={(value) => {
+                const c = SWITCHABLE_CHAINS.find((ch) => ch.id.toString() === value)
+                if (c) void switchChain(c.id)
+              }}
+            >
+              <SelectTrigger className="h-8 w-full text-xs">
+                <SelectValue placeholder="Select network" />
+              </SelectTrigger>
+              <SelectContent className="z-[10000]">
+                {SWITCHABLE_CHAINS.map((c) => (
+                  <SelectItem key={c.id} value={c.id.toString()} className="text-xs">
+                    {c.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onClick={() => disconnect()}>Disconnect</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <BuyMetokenModal open={buyMetokenOpen} onOpenChange={setBuyMetokenOpen} />
+    </>
   )
 }

--- a/src/components/wallet-connect-button.tsx
+++ b/src/components/wallet-connect-button.tsx
@@ -17,6 +17,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { SWITCHABLE_CHAINS } from '@/config/chains'
+import { useUsdcBalance } from '@/hooks/use-usdc-balance'
 import { cn } from '@/shared/ui/cn'
 
 function truncateAddress(address: string): string {
@@ -43,6 +44,7 @@ export function WalletConnectButton({
   const { ready, authenticated, connect, disconnect, wallet, chain, switchChain, isConnecting } =
     useWalletContext()
   const address = wallet?.address
+  const { formatted: usdcFormatted } = useUsdcBalance(chain, address as `0x${string}` | undefined)
   const [copied, setCopied] = useState(false)
 
   const handleCopyAddress = useCallback(() => {
@@ -106,6 +108,11 @@ export function WalletConnectButton({
             {copied && <span className="sr-only">Copied</span>}
           </DropdownMenuItem>
         )}
+
+        <DropdownMenuItem disabled className="text-muted-foreground">
+          USDC: {usdcFormatted}
+        </DropdownMenuItem>
+
         <div className="px-2 py-1.5">
           <label className="mb-1.5 block text-xs font-medium text-muted-foreground">Network</label>
           <Select

--- a/src/config/alchemy.ts
+++ b/src/config/alchemy.ts
@@ -3,5 +3,6 @@ export const ALCHEMY_POLICY_ID = import.meta.env.VITE_ALCHEMY_POLICY_ID as strin
 export const ALCHEMY_GAS_POLICY_TYPE = (import.meta.env.VITE_ALCHEMY_GAS_POLICY_TYPE ?? 'none') as
   | 'none'
   | 'usdc'
+  | 'erc20'
   | 'sponsored'
 export const ALCHEMY_GAS_MAX_USDC6 = Number(import.meta.env.VITE_ALCHEMY_GAS_MAX_USDC6 ?? '1000000')

--- a/src/config/alchemy.ts
+++ b/src/config/alchemy.ts
@@ -1,0 +1,7 @@
+export const ALCHEMY_API_KEY = import.meta.env.VITE_ALCHEMY_API_KEY as string | undefined
+export const ALCHEMY_POLICY_ID = import.meta.env.VITE_ALCHEMY_POLICY_ID as string | undefined
+export const ALCHEMY_GAS_POLICY_TYPE = (import.meta.env.VITE_ALCHEMY_GAS_POLICY_TYPE ?? 'none') as
+  | 'none'
+  | 'usdc'
+  | 'sponsored'
+export const ALCHEMY_GAS_MAX_USDC6 = Number(import.meta.env.VITE_ALCHEMY_GAS_MAX_USDC6 ?? '1000000')

--- a/src/config/base-client.ts
+++ b/src/config/base-client.ts
@@ -1,0 +1,22 @@
+import { base } from 'viem/chains'
+import { createPublicClient, http } from 'viem'
+import { ALCHEMY_API_KEY } from '@/config/alchemy'
+
+function getBaseRpcUrl(): string {
+  if (!ALCHEMY_API_KEY) {
+    throw new Error('VITE_ALCHEMY_API_KEY is required for Base client')
+  }
+  return `https://base-mainnet.g.alchemy.com/v2/${ALCHEMY_API_KEY}`
+}
+
+/**
+ * Read-only viem public client for Base mainnet.
+ */
+export function getBasePublicClient() {
+  return createPublicClient({
+    chain: base,
+    transport: http(getBaseRpcUrl()),
+  })
+}
+
+export { base as baseChain }

--- a/src/config/billing.ts
+++ b/src/config/billing.ts
@@ -1,0 +1,27 @@
+/**
+ * Billing constants for AI render payments.
+ * Premium = Creative Organization DAO members (Unlock on Base).
+ * Retail = non-members.
+ *
+ * All payments use CRTVAI meToken on Base. USDC is used only for onramping
+ * (Coinbase onramp) and as the meToken's underlying collateral.
+ */
+
+/** USDC decimals (6) — used for price quoting and gas buffer calculations. */
+export const USDC_DECIMALS = 6
+
+/** $0.125 USDC-equivalent per 5-minute interval (premium / cost basis). */
+export const INTERVAL_COST_PREMIUM_USDC6 = 125_000
+
+/** $0.25 USDC-equivalent per 5-minute interval (retail). */
+export const INTERVAL_COST_RETAIL_USDC6 = 250_000
+
+/**
+ * Rolling daily spend cap for the Session Key (50 USDC-equivalent = $50/day).
+ * Resets every SPEND_LIMIT_REFRESH_SECONDS. At the $1.50/hr premium rate this
+ * covers ~33 hrs/day of Live AI before re-authorization is required.
+ */
+export const DAILY_SPEND_LIMIT_USDC6 = 50_000_000
+
+/** Session Key spend-limit refresh period: 1 day in seconds. */
+export const SPEND_LIMIT_REFRESH_SECONDS = 86_400

--- a/src/config/chains.ts
+++ b/src/config/chains.ts
@@ -1,0 +1,20 @@
+import { base, arbitrum } from 'viem/chains'
+
+export const DEFAULT_CHAIN = base
+export const SWITCHABLE_CHAINS = [base, arbitrum] as const
+
+/** Map chainId to configured chain. */
+export const CHAIN_BY_ID: Record<number, (typeof SWITCHABLE_CHAINS)[number]> = {
+  [base.id]: base,
+  [arbitrum.id]: arbitrum,
+}
+
+export function getChainById(chainId: number): (typeof SWITCHABLE_CHAINS)[number] | undefined {
+  return CHAIN_BY_ID[chainId]
+}
+
+export function requireChainById(chainId: number): (typeof SWITCHABLE_CHAINS)[number] {
+  const chain = getChainById(chainId)
+  if (!chain) throw new Error(`Unsupported chain id: ${chainId}`)
+  return chain
+}

--- a/src/config/chains.ts
+++ b/src/config/chains.ts
@@ -3,6 +3,12 @@ import { base, arbitrum } from 'viem/chains'
 export const DEFAULT_CHAIN = base
 export const SWITCHABLE_CHAINS = [base, arbitrum] as const
 
+/** USDC contract address by chain ID. Only includes chains in SWITCHABLE_CHAINS. */
+export const USDC_ADDRESS_BY_CHAIN_ID: Record<number, `0x${string}`> = {
+  [base.id]: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+  [arbitrum.id]: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+}
+
 /** Map chainId to configured chain. */
 export const CHAIN_BY_ID: Record<number, (typeof SWITCHABLE_CHAINS)[number]> = {
   [base.id]: base,

--- a/src/config/credits.ts
+++ b/src/config/credits.ts
@@ -1,0 +1,122 @@
+/** Milli-credits (3 decimal places) for fractional Live AI debits. 1000 milli = 1 credit. */
+export const MILLI_CREDITS_PER_CREDIT = 1000
+
+/** ~1.11 credits/min reference rate (legacy Live AI equivalence; Live AI bills USDC via Superfluid). */
+export const LIVE_AI_MILLI_CREDITS_PER_MINUTE = 1110
+
+/** Debit interval while Live AI is streaming (ms). */
+export const LIVE_AI_DEBIT_INTERVAL_MS = 60_000
+
+/** Milli-credits debited each Live AI billing tick (1 minute). */
+export const LIVE_AI_MILLI_CREDITS_PER_TICK = LIVE_AI_MILLI_CREDITS_PER_MINUTE
+
+export interface CreditPackDefinition {
+  id: number
+  name: string
+  /** USDC amount with 6 decimals (e.g. 5_000_000 = $5). */
+  usdc6: number
+  credits: number
+  description: string
+}
+
+/** Must match on-chain PaymentContract pack ids (0, 1, 2). */
+export const CREDIT_PACKS: readonly CreditPackDefinition[] = [
+  {
+    id: 0,
+    name: 'Starter',
+    usdc6: 5_000_000,
+    credits: 50,
+    description: '~10 Flow image gens',
+  },
+  {
+    id: 1,
+    name: 'Pro',
+    usdc6: 15_000_000,
+    credits: 175,
+    description: '~35 Flow image gens',
+  },
+  {
+    id: 2,
+    name: 'Studio',
+    usdc6: 40_000_000,
+    credits: 500,
+    description: '~100 Flow image gens',
+  },
+] as const
+
+export function getCreditPack(packId: number): CreditPackDefinition | undefined {
+  return CREDIT_PACKS.find((p) => p.id === packId)
+}
+
+/** Estimated minutes at legacy Live AI credit rate (informational only). */
+export function creditsToLiveAiMinutes(credits: number): number {
+  if (credits <= 0) return 0
+  const milli = credits * MILLI_CREDITS_PER_CREDIT
+  return milli / LIVE_AI_MILLI_CREDITS_PER_MINUTE
+}
+
+export function formatLiveAiTimeFromCredits(credits: number): string {
+  const minutes = creditsToLiveAiMinutes(credits)
+  if (minutes < 1) return '<1 min'
+  if (minutes < 60) return `~${Math.round(minutes)} min`
+  const h = Math.floor(minutes / 60)
+  const m = Math.round(minutes % 60)
+  return m > 0 ? `~${h}h ${m}m` : `~${h}h`
+}
+
+export type SeedanceQuality = '480p' | '720p' | '1080p'
+export type SeedanceSpeed = 'standard' | 'fast'
+export type NanobananaQuality = '0.5K' | '1K' | '2K' | '4K'
+
+const QUALITY_MULTIPLIER: Record<SeedanceQuality, number> = {
+  '480p': 1,
+  '720p': 1.6,
+  '1080p': 2.5,
+}
+
+const SPEED_MULTIPLIER: Record<SeedanceSpeed, number> = {
+  standard: 1,
+  fast: 0.75,
+}
+
+/** Base credits per second of Seedance output (retail ~$0.10/credit). */
+const SEEDANCE_BASE_CREDITS_PER_SECOND = 1.4
+
+export interface SeedanceCreditQuoteParams {
+  duration: number
+  quality: SeedanceQuality
+  speed: SeedanceSpeed
+  generateAudio: boolean
+}
+
+/** Quote Seedance i2v generation cost in whole credits (rounded up). */
+export function quoteSeedanceCredits(params: SeedanceCreditQuoteParams): number {
+  const { duration, quality, speed, generateAudio } = params
+  let credits =
+    duration *
+    SEEDANCE_BASE_CREDITS_PER_SECOND *
+    QUALITY_MULTIPLIER[quality] *
+    SPEED_MULTIPLIER[speed]
+  if (generateAudio) credits *= 1.15
+  return Math.max(1, Math.ceil(credits))
+}
+
+const NANO_QUALITY_CREDITS: Record<NanobananaQuality, number> = {
+  '0.5K': 5,
+  '1K': 8,
+  '2K': 12,
+  '4K': 18,
+}
+
+/** Quote Nanobanana image generation cost in whole credits. */
+export function quoteNanobananaCredits(quality: NanobananaQuality): number {
+  return NANO_QUALITY_CREDITS[quality] ?? 10
+}
+
+/** Default contest promo template (admin CLI). */
+export const DEFAULT_CONTEST_PROMO = {
+  credits: 5,
+  promoCode: 'CONTEST2026',
+  maxClaims: 100,
+  expiresAt: null as string | null,
+}

--- a/src/config/gas-sponsorship.ts
+++ b/src/config/gas-sponsorship.ts
@@ -1,0 +1,55 @@
+import { USDC_ADDRESS_BY_CHAIN_ID } from '@/config/chains'
+import { ALCHEMY_GAS_MAX_USDC6, ALCHEMY_GAS_POLICY_TYPE, ALCHEMY_POLICY_ID } from '@/config/alchemy'
+
+/**
+ * Gas payment mode for Alchemy smart wallet operations.
+ *
+ * - "sponsorship" (default): the app's gas policy sponsors gas. Nothing extra
+ *   is sent; the global policyId is attached at client-creation time.
+ * - "erc20": the policy in VITE_ALCHEMY_POLICY_ID is an ERC-20 paymaster
+ *   policy (users pay gas in USDC). prepareCalls must then include the `erc20`
+ *   capability under `paymaster` or Alchemy rejects sponsorship with
+ *   "Policy ... is of type ERC20, but erc20 capability is missing".
+ */
+
+/** Cap on USDC spent on gas per user operation (6 decimals). Default $1. */
+export const DEFAULT_MAX_GAS_USDC6 = 1_000_000
+
+/** Extra USDC (6 decimals) to reserve for ERC-20 gas when buying credit packs. */
+export function getPurchaseGasBufferUsdc6(chainId: number): number {
+  if (ALCHEMY_GAS_POLICY_TYPE !== 'erc20' || !ALCHEMY_POLICY_ID) return 0
+  if (!(chainId in USDC_ADDRESS_BY_CHAIN_ID)) return 0
+  return ALCHEMY_GAS_MAX_USDC6
+}
+
+export interface Erc20PaymasterCapabilities {
+  paymaster: {
+    policyId: string
+    erc20: {
+      tokenAddress: `0x${string}`
+      maxTokenAmount: bigint
+      postOpSettings: { autoApprove: true }
+    }
+  }
+}
+
+/**
+ * Capabilities for prepareCalls when using an ERC-20 gas policy.
+ * Returns null in sponsorship mode (default) so the global client-level
+ * policy applies automatically.
+ */
+export function buildGasPaymasterCapabilities(chainId: number): Erc20PaymasterCapabilities | null {
+  if (ALCHEMY_GAS_POLICY_TYPE !== 'erc20' || !ALCHEMY_POLICY_ID) return null
+  const tokenAddress = USDC_ADDRESS_BY_CHAIN_ID[chainId]
+  if (!tokenAddress) return null
+  return {
+    paymaster: {
+      policyId: ALCHEMY_POLICY_ID,
+      erc20: {
+        tokenAddress,
+        maxTokenAmount: BigInt(ALCHEMY_GAS_MAX_USDC6),
+        postOpSettings: { autoApprove: true },
+      },
+    },
+  }
+}

--- a/src/config/metoken.ts
+++ b/src/config/metoken.ts
@@ -1,0 +1,175 @@
+import { parseAbi } from 'viem'
+import { base } from 'viem/chains'
+import { getBasePublicClient } from '@/config/base-client'
+import { ALCHEMY_API_KEY } from '@/config/alchemy'
+
+/**
+ * CRTVAI MeToken — Creative TV's AI payment token.
+ *
+ * Diamond ERC-2535 contract on Base, backed by USDC via Bancor Zero formula.
+ * Users mint CRTVAI by sending USDC to the meToken contract; the bonding curve
+ * determines how many meTokens they receive. They can sell (burn) meTokens
+ * back into USDC at the current curve price.
+ *
+ * Diamond address: 0xecb695544a3d2a64d579b3828f3f60f6932f4846
+ * Hub ID: 2 (USDC-backed, curve params fixed: baseY=224, reserveWeight=32)
+ * Underlying asset: USDC on Base (0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913)
+ */
+
+/** CRTVAI meToken diamond address on Base. */
+export const CRTVAI_DIAMOND_ADDRESS = '0xecb695544a3d2a64d579b3828f3f60f6932f4846' as const
+
+/** MeToken hub ID for CRTVAI (USDC-backed hub on Base). */
+export const CRTVAI_HUB_ID = 2
+
+/** USDC on Base mainnet (native USDC, 6 decimals). */
+export const USDC_BASE_ADDRESS = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' as const
+
+/** USDC decimals (same across chains). */
+export const USDC_DECIMALS = 6
+
+/** CRTVAI meToken decimals (meTokens use 18). */
+export const CRTVAI_DECIMALS = 18
+
+/**
+ * Wrapped Super Token address for CRTVAI on Base (CRTVAIx).
+ * Set via env VITE_CRTVAIX_ADDRESS after deploying the Wrapped Super Token.
+ * Required for Live AI streaming via Superfluid.
+ */
+export function getCrtvaiXAddress(): `0x${string}` | undefined {
+  const v = import.meta.env.VITE_CRTVAIX_ADDRESS as string | undefined
+  if (!v || !v.startsWith('0x')) return undefined
+  return v as `0x${string}`
+}
+
+/** Treasury / receiver for Live AI streams on Base (env: VITE_SUPERFLUID_RECEIVER). */
+export function getSuperfluidReceiverAddress(): `0x${string}` | undefined {
+  const v = import.meta.env.VITE_SUPERFLUID_RECEIVER as string | undefined
+  if (!v || !v.startsWith('0x')) return undefined
+  return v as `0x${string}`
+}
+
+export function isSuperfluidConfigured(): boolean {
+  return Boolean(getSuperfluidReceiverAddress() && getCrtvaiXAddress())
+}
+
+/** Chain ID for Superfluid streaming (Base). */
+export const SUPERFLUID_CHAIN_ID = base.id
+
+/** Seconds per billing interval (matches 5-minute interval pricing). */
+export const BILLING_INTERVAL_SECONDS = 300
+
+/** Minimum CRTVAI (in meToken wei, 18 decimals) required to start Live AI (one billing interval). */
+export function minStartMetokenWei(intervalCostUsdc6: number): bigint {
+  // Convert USDC6 cost to meToken wei using 12-decimal multiplier (18 - 6 = 12)
+  return BigInt(intervalCostUsdc6) * 10n ** 12n
+}
+
+/** CRTVAI meToken wei (18 decimals) wrapped for one hour of streaming. */
+export function wrapMetokenWeiForOneHour(intervalCostUsdc6: number): bigint {
+  return BigInt(intervalCostUsdc6) * 10n ** 12n * 12n
+}
+
+/**
+ * Superfluid flow rate (super-token wei per second, 18 decimals).
+ * Derived from USDC6-equivalent per billing interval.
+ */
+export function intervalCostUsdc6ToFlowRate(intervalCostUsdc6: number): bigint {
+  const numerator = BigInt(intervalCostUsdc6) * 10n ** 12n
+  const interval = BigInt(BILLING_INTERVAL_SECONDS)
+  return (numerator + interval - 1n) / interval
+}
+
+/** Convert USDC6 amount to meToken wei (18 decimals). */
+export function usdc6ToMetokenWei(usdc6: bigint | number): bigint {
+  return BigInt(usdc6) * 10n ** 12n
+}
+
+/** Hourly USDC-equivalent cost from interval pricing (for UI). */
+export function hourlyUsdcFromInterval(intervalCostUsdc6: number): number {
+  return (intervalCostUsdc6 * 12) / 1_000_000
+}
+
+// ── MeToken Diamond ABI (ERC-2535 facets) ──────────────────────────
+
+/** ERC-20 facet — standard token interface for balanceOf, transfer, etc. */
+export const METOKEN_ERC20_ABI = parseAbi([
+  'function balanceOf(address account) view returns (uint256)',
+  'function transfer(address to, uint256 amount) returns (bool)',
+  'function approve(address spender, uint256 amount) returns (bool)',
+  'function allowance(address owner, address spender) view returns (uint256)',
+  'function totalSupply() view returns (uint256)',
+  'function name() view returns (string)',
+  'function symbol() view returns (string)',
+  'function decimals() view returns (uint8)',
+])
+
+/** MeToken facet — mint, sell, and curve pricing. */
+export const METOKEN_DIAMOND_ABI = parseAbi([
+  'function balanceOf(address account) view returns (uint256)',
+  'function mint(uint256 amount) external',
+  'function sell(uint256 amount) external',
+  'function getCurrentPrice() view returns (uint256)',
+  'function getMintPrice(uint256 amount) view returns (uint256)',
+  'function getSellPrice(uint256 amount) view returns (uint256)',
+  'function getHubId() view returns (uint256)',
+  'function activeCollateralOnly() view returns (bool)',
+])
+
+/** CFAv1Forwarder — same address on all Superfluid networks. */
+export const CFA_FORWARDER_ADDRESS = '0xcfA132E353cB4E398080B9700609bb008eceB125' as const
+
+export const SUPER_TOKEN_ABI = parseAbi([
+  'function upgrade(uint256 amount)',
+  'function balanceOf(address account) view returns (uint256)',
+])
+
+// ── Read helpers ───────────────────────────────────────────────────
+
+/** Read CRTVAI meToken balance for an address on Base. */
+export async function readCrtvaiBalance(address: `0x${string}`): Promise<bigint> {
+  const client = getBasePublicClient()
+  return client.readContract({
+    address: CRTVAI_DIAMOND_ADDRESS,
+    abi: METOKEN_DIAMOND_ABI,
+    functionName: 'balanceOf',
+    args: [address],
+  })
+}
+
+/** Read current meToken mint price (USDC per meToken, in raw units). */
+export async function readCrtvaiCurrentPrice(): Promise<bigint> {
+  const client = getBasePublicClient()
+  return client.readContract({
+    address: CRTVAI_DIAMOND_ADDRESS,
+    abi: METOKEN_DIAMOND_ABI,
+    functionName: 'getCurrentPrice',
+  })
+}
+
+/** Read estimated meToken output for a given USDC input amount. */
+export async function readCrtvaiMintQuote(usdcAmount: bigint): Promise<bigint> {
+  const client = getBasePublicClient()
+  return client.readContract({
+    address: CRTVAI_DIAMOND_ADDRESS,
+    abi: METOKEN_DIAMOND_ABI,
+    functionName: 'getMintPrice',
+    args: [usdcAmount],
+  })
+}
+
+/** Read estimated USDC return for selling a given meToken amount. */
+export async function readCrtvaiSellQuote(metokenAmount: bigint): Promise<bigint> {
+  const client = getBasePublicClient()
+  return client.readContract({
+    address: CRTVAI_DIAMOND_ADDRESS,
+    abi: METOKEN_DIAMOND_ABI,
+    functionName: 'getSellPrice',
+    args: [metokenAmount],
+  })
+}
+
+export function requireAlchemyKey(): string {
+  if (!ALCHEMY_API_KEY) throw new Error('VITE_ALCHEMY_API_KEY is required')
+  return ALCHEMY_API_KEY
+}

--- a/src/context/wallet-context.tsx
+++ b/src/context/wallet-context.tsx
@@ -1,0 +1,224 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react'
+import {
+  usePrivy,
+  useWallets,
+  getEmbeddedConnectedWallet,
+  type ConnectedWallet,
+  type User,
+  PrivyProvider,
+} from '@privy-io/react-auth'
+import {
+  createSmartWalletClient,
+  alchemyWalletTransport,
+  type SmartWalletClient as AlchemySmartWalletClient,
+} from '@alchemy/wallet-apis'
+import { swapActions, type SwapActions } from '@alchemy/wallet-apis/experimental'
+import { createWalletClient, custom, type Chain, type WalletClient, type Address } from 'viem'
+import { ALCHEMY_API_KEY, ALCHEMY_POLICY_ID } from '@/config/alchemy'
+import { DEFAULT_CHAIN, getChainById } from '@/config/chains'
+
+type SmartWalletClient = AlchemySmartWalletClient & SwapActions
+
+export interface WalletContextValue {
+  ready: boolean
+  authenticated: boolean
+  connect: () => void
+  disconnect: () => Promise<void>
+  wallet: ConnectedWallet | null
+  account: Address | undefined
+  user: User | null
+  walletClient: WalletClient | null
+  smartWalletClient: SmartWalletClient | null
+  chain: Chain
+  switchChain: (chainId: number) => Promise<void>
+  isConnecting: boolean
+  error: Error | null
+  getAccessToken: () => Promise<string | null>
+}
+
+const WalletContext = createContext<WalletContextValue | undefined>(undefined)
+
+export function useWalletContext(): WalletContextValue {
+  const ctx = useContext(WalletContext)
+  if (!ctx) {
+    throw new Error('useWalletContext must be used within WalletProvider')
+  }
+  return ctx
+}
+
+const PRIVY_APP_ID = import.meta.env.VITE_PRIVY_APP_ID
+const PRIVY_CLIENT_ID = import.meta.env.VITE_PRIVY_CLIENT_ID
+const hasPrivyConfig = Boolean(PRIVY_APP_ID)
+
+function WalletContextInner({ children }: { children: ReactNode }) {
+  const { ready, authenticated, user, login, logout, connectWallet, getAccessToken } = usePrivy()
+  const { wallets, ready: walletsReady } = useWallets()
+  const [walletClient, setWalletClient] = useState<WalletClient | null>(null)
+  const [chain, setChain] = useState<Chain>(DEFAULT_CHAIN)
+  const [isConnecting, setIsConnecting] = useState(false)
+  const [error, setError] = useState<Error | null>(null)
+
+  const activeWallet = useMemo<ConnectedWallet | null>(() => {
+    if (!walletsReady || !wallets.length) return null
+    const embedded = getEmbeddedConnectedWallet(wallets)
+    return embedded ?? wallets[0] ?? null
+  }, [wallets, walletsReady])
+
+  useEffect(() => {
+    let cancelled = false
+    async function syncWalletClient() {
+      if (!activeWallet || !authenticated) {
+        setWalletClient(null)
+        return
+      }
+      setIsConnecting(true)
+      setError(null)
+      try {
+        const provider = await activeWallet.getEthereumProvider()
+        const client = createWalletClient({
+          account: activeWallet.address as Address,
+          chain,
+          transport: custom(provider),
+        })
+        if (cancelled) return
+        setWalletClient(client)
+        const walletChainId = parseInt(activeWallet.chainId, 10)
+        if (walletChainId && walletChainId !== chain.id) {
+          const known = getChainById(walletChainId)
+          if (known) setChain(known)
+        }
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e : new Error(String(e)))
+      } finally {
+        if (!cancelled) setIsConnecting(false)
+      }
+    }
+    void syncWalletClient()
+    return () => {
+      cancelled = true
+    }
+  }, [activeWallet, activeWallet?.chainId, authenticated, chain])
+
+  const smartWalletClient = useMemo<SmartWalletClient | null>(() => {
+    if (!walletClient || !ALCHEMY_API_KEY) return null
+    return createSmartWalletClient({
+      transport: alchemyWalletTransport({ apiKey: ALCHEMY_API_KEY }),
+      chain,
+      signer: walletClient as never,
+      ...(ALCHEMY_POLICY_ID ? { paymaster: { policyId: ALCHEMY_POLICY_ID } } : {}),
+    }).extend(swapActions) as SmartWalletClient
+  }, [walletClient, chain])
+
+  const connect = useCallback(() => {
+    setError(null)
+    if (authenticated) {
+      connectWallet()
+    } else {
+      login()
+    }
+  }, [authenticated, connectWallet, login])
+
+  const disconnect = useCallback(async () => {
+    setError(null)
+    await logout()
+  }, [logout])
+
+  const switchChain = useCallback(
+    async (chainId: number) => {
+      if (!activeWallet) return
+      await activeWallet.switchChain(chainId)
+    },
+    [activeWallet],
+  )
+
+  const value = useMemo(
+    () => ({
+      ready: ready && walletsReady,
+      authenticated,
+      connect,
+      disconnect,
+      wallet: activeWallet,
+      account: activeWallet ? (activeWallet.address as Address) : undefined,
+      user,
+      walletClient,
+      smartWalletClient,
+      chain,
+      switchChain,
+      isConnecting,
+      error,
+      getAccessToken,
+    }),
+    [
+      ready,
+      walletsReady,
+      authenticated,
+      connect,
+      disconnect,
+      activeWallet,
+      user,
+      walletClient,
+      smartWalletClient,
+      chain,
+      switchChain,
+      isConnecting,
+      error,
+      getAccessToken,
+    ],
+  )
+
+  return <WalletContext.Provider value={value}>{children}</WalletContext.Provider>
+}
+
+export function WalletProvider({ children }: { children: ReactNode }) {
+  if (!hasPrivyConfig) {
+    // Render a stub provider so the app can still run without Privy configured
+    // (local/offline dev flows).
+    const stubValue: WalletContextValue = {
+      ready: true,
+      authenticated: false,
+      connect: () => {},
+      disconnect: async () => {},
+      wallet: null,
+      account: undefined,
+      user: null,
+      walletClient: null,
+      smartWalletClient: null,
+      chain: DEFAULT_CHAIN,
+      switchChain: async () => {},
+      isConnecting: false,
+      error: null,
+      getAccessToken: async () => null,
+    }
+    return <WalletContext.Provider value={stubValue}>{children}</WalletContext.Provider>
+  }
+
+  return (
+    <PrivyProvider
+      appId={PRIVY_APP_ID as string}
+      clientId={PRIVY_CLIENT_ID}
+      config={{
+        loginMethods: ['wallet', 'email', 'google', 'farcaster'],
+        appearance: {
+          accentColor: '#676FFF',
+          theme: 'dark',
+          showWalletLoginFirst: true,
+        },
+        embeddedWallets: {
+          ethereum: {
+            createOnLogin: 'users-without-wallets',
+          },
+        },
+      }}
+    >
+      <WalletContextInner>{children}</WalletContextInner>
+    </PrivyProvider>
+  )
+}

--- a/src/features/credits/components/buy-credits-modal.tsx
+++ b/src/features/credits/components/buy-credits-modal.tsx
@@ -1,0 +1,20 @@
+import { BuyMetokenModal } from '../deps/metoken'
+
+interface BuyCreditsModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+/**
+ * Backward-compatible credits buy modal.
+ *
+ * The legacy server-side credits system has been deprecated in favor of CRTVAI
+ * meToken. Buying "credits" now opens the CRTVAI mint flow.
+ */
+export function BuyCreditsModal({ open, onOpenChange }: BuyCreditsModalProps) {
+  return <BuyMetokenModal open={open} onOpenChange={onOpenChange} />
+}
+
+export function CreditBalanceBadge() {
+  return null
+}

--- a/src/features/credits/components/insufficient-credits-paywall.tsx
+++ b/src/features/credits/components/insufficient-credits-paywall.tsx
@@ -1,0 +1,61 @@
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { useCredits } from '@/features/credits/hooks/use-credits'
+
+interface InsufficientCreditsPaywallProps {
+  /** Estimated credits required to perform the action. */
+  requiredCredits?: number
+  /** Called when the user chooses to buy more credits. */
+  onBuyCredits: () => void
+  /** Called when the user cancels/dismisses the paywall. */
+  onCancel?: () => void
+  open: boolean
+}
+
+/**
+ * Paywall shown when the user's CRTVAI/credits balance is too low.
+ *
+ * This replaces the legacy server-side credits paywall. The action is gated by
+ * the CRTVAI meToken balance shown through useCredits.
+ */
+export function InsufficientCreditsPaywall({
+  requiredCredits = 1,
+  onBuyCredits,
+  onCancel,
+  open,
+}: InsufficientCreditsPaywallProps) {
+  const { balance, isLoading } = useCredits()
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        if (!v) onCancel?.()
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Insufficient balance</DialogTitle>
+          <DialogDescription>
+            You need at least {requiredCredits} CRTVAI credits to continue.
+            {isLoading ? null : ` Your balance is ${balance.toFixed(2)}.`}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-3 pt-4">
+          <Button onClick={onBuyCredits}>Buy CRTVAI credits</Button>
+          {onCancel && (
+            <Button variant="outline" onClick={onCancel}>
+              Cancel
+            </Button>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/features/credits/components/redeem-promo-modal.tsx
+++ b/src/features/credits/components/redeem-promo-modal.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+
+interface RedeemPromoModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Called with the promo code when the user submits. */
+  onRedeem?: (code: string) => void
+}
+
+/**
+ * Promo code redemption modal.
+ *
+ * The legacy server-side promo redemption system is deprecated. This modal
+ * captures the code and calls the provided callback. The host feature can call
+ * an API or apply the credits locally as appropriate.
+ */
+export function RedeemPromoModal({ open, onOpenChange, onRedeem }: RedeemPromoModalProps) {
+  const [code, setCode] = useState('')
+
+  const handleSubmit = () => {
+    if (!code.trim()) return
+    onRedeem?.(code.trim())
+    setCode('')
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Redeem promo code</DialogTitle>
+          <DialogDescription>Enter a promo code to receive CRTVAI credits.</DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-4 pt-2">
+          <Input
+            placeholder="PROMO-CODE"
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') handleSubmit()
+            }}
+          />
+          <Button onClick={handleSubmit} disabled={!code.trim()}>
+            Redeem
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/features/credits/deps/metoken-contract.ts
+++ b/src/features/credits/deps/metoken-contract.ts
@@ -1,0 +1,6 @@
+/**
+ * Cross-feature dependency contract: metoken/CRTVAI.
+ *
+ * Credits are deprecated and now bridge to the CRTVAI meToken buy flow.
+ */
+export { BuyMetokenModal } from '@/features/metoken'

--- a/src/features/credits/deps/metoken.ts
+++ b/src/features/credits/deps/metoken.ts
@@ -1,0 +1,6 @@
+/**
+ * Cross-feature dependency adapter.
+ *
+ * Credits are deprecated and now bridge to the CRTVAI meToken buy flow.
+ */
+export { BuyMetokenModal } from '@/features/metoken'

--- a/src/features/credits/deps/metoken.ts
+++ b/src/features/credits/deps/metoken.ts
@@ -1,6 +1,4 @@
 /**
- * Cross-feature dependency adapter.
- *
- * Credits are deprecated and now bridge to the CRTVAI meToken buy flow.
+ * Cross-feature dependency adapter: metoken/CRTVAI.
  */
-export { BuyMetokenModal } from '@/features/metoken'
+export { BuyMetokenModal } from './metoken-contract'

--- a/src/features/credits/hooks/use-credits.ts
+++ b/src/features/credits/hooks/use-credits.ts
@@ -1,0 +1,50 @@
+import { useCallback } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { formatUnits } from 'viem'
+import { useWalletContext } from '@/context/wallet-context'
+import { useCrtvaiBalance } from '@/hooks/use-crtvai-balance'
+import { CRTVAI_DECIMALS } from '@/config/metoken'
+
+/**
+ * Bridge hook: exposes CRTVAI balance through the legacy credits interface.
+ *
+ * The server-side credits system has been deprecated in favor of CRTVAI meToken
+ * on Base. 1 CRTVAI ≈ 1 legacy credit for display/gating purposes.
+ */
+
+export interface UseCreditsResult {
+  balance: number
+  configured: boolean
+  isLoading: boolean
+  isDegraded: boolean
+  hasCredits: boolean
+  refreshBalance: () => void
+}
+
+export function useCredits(): UseCreditsResult {
+  const { account } = useWalletContext()
+  const {
+    balance: crtvaiBalance,
+    isLoading,
+    isError,
+  } = useCrtvaiBalance(account as `0x${string}` | undefined)
+
+  const queryClient = useQueryClient()
+
+  const refreshBalance = useCallback(() => {
+    if (account) {
+      void queryClient.invalidateQueries({ queryKey: ['crtvai-balance', account] })
+    }
+  }, [account, queryClient])
+
+  const balance = crtvaiBalance ? Number(formatUnits(crtvaiBalance, CRTVAI_DECIMALS)) : 0
+
+  return {
+    balance,
+    configured: Boolean(account),
+    isLoading,
+    isDegraded: isError,
+    hasCredits: balance > 0,
+    refreshBalance,
+  }
+}

--- a/src/features/credits/index.ts
+++ b/src/features/credits/index.ts
@@ -1,0 +1,5 @@
+export { BuyCreditsModal, CreditBalanceBadge } from './components/buy-credits-modal'
+export { InsufficientCreditsPaywall } from './components/insufficient-credits-paywall'
+export { RedeemPromoModal } from './components/redeem-promo-modal'
+export { useCredits } from './hooks/use-credits'
+export * from './usdc-for-purchase'

--- a/src/features/credits/usdc-for-purchase.ts
+++ b/src/features/credits/usdc-for-purchase.ts
@@ -1,0 +1,18 @@
+import { getPurchaseGasBufferUsdc6 } from '@/config/gas-sponsorship'
+
+/**
+ * Calculate total USDC needed for a purchase, including any ERC-20 gas buffer.
+ *
+ * @param packUsdc6 Pack price in USDC6.
+ * @param chainId Chain where the purchase happens.
+ */
+export function totalUsdcForPurchase(packUsdc6: number, chainId: number): number {
+  return packUsdc6 + getPurchaseGasBufferUsdc6(chainId)
+}
+
+/**
+ * Format a USDC6 amount as a dollar string (e.g. "$5.00").
+ */
+export function formatUsdc6(usdc6: number): string {
+  return `$${(usdc6 / 1_000_000).toFixed(2)}`
+}

--- a/src/features/editor/components/toolbar.tsx
+++ b/src/features/editor/components/toolbar.tsx
@@ -41,6 +41,7 @@ import { LanguageSwitcher } from '@/shared/ui/language-switcher'
 import { useDebugStore } from '@/features/editor/stores/debug-store'
 import { useItemsStore, useTimelineStore } from '@/features/editor/deps/timeline-store'
 import { useMediaLibraryStore } from '@/features/editor/deps/media-library'
+import { WalletConnectButton } from '@/components/wallet-connect-button'
 
 const SAVE_ANIMATION_MIN_MS = 1800
 
@@ -98,18 +99,15 @@ export const Toolbar = memo(function Toolbar({
   const maxItemEndFrame = useItemsStore((state) => state.maxItemEndFrame)
   const mediaDependencyIds = useItemsStore((state) => state.mediaDependencyIds)
   const brokenMediaIds = useMediaLibraryStore((state) => state.brokenMediaIds)
-  const projectSummary = useMemo(
-    () => {
-      const projectMediaIds = new Set(mediaDependencyIds)
-      return {
-        durationSeconds: project.fps > 0 ? maxItemEndFrame / project.fps : 0,
-        clipCount: itemCount,
-        mediaCount: mediaDependencyIds.length,
-        brokenMediaCount: brokenMediaIds.filter((mediaId) => projectMediaIds.has(mediaId)).length,
-      }
-    },
-    [brokenMediaIds, itemCount, maxItemEndFrame, mediaDependencyIds, project.fps],
-  )
+  const projectSummary = useMemo(() => {
+    const projectMediaIds = new Set(mediaDependencyIds)
+    return {
+      durationSeconds: project.fps > 0 ? maxItemEndFrame / project.fps : 0,
+      clipCount: itemCount,
+      mediaCount: mediaDependencyIds.length,
+      brokenMediaCount: brokenMediaIds.filter((mediaId) => projectMediaIds.has(mediaId)).length,
+    }
+  }, [brokenMediaIds, itemCount, maxItemEndFrame, mediaDependencyIds, project.fps])
 
   useEffect(() => {
     setHasUnseenWhatsNew(hasUnseenChangelog())
@@ -350,6 +348,8 @@ export const Toolbar = memo(function Toolbar({
             )}
           </Button>
         )}
+
+        <WalletConnectButton size="sm" compact className="h-7 min-h-0" />
 
         <DropdownMenu>
           <DropdownMenuTrigger asChild>

--- a/src/features/editor/deps/timeline-hooks-contract.ts
+++ b/src/features/editor/deps/timeline-hooks-contract.ts
@@ -3,11 +3,7 @@
  * Editor modules should import timeline feature hooks from here.
  */
 
-export {
-  useTimelineShortcuts,
-} from '@/features/timeline/hooks/use-timeline-shortcuts'
-export {
-  useTransitionBreakageNotifications,
-} from '@/features/timeline/hooks/use-transition-breakage-notifications'
+export { useTimelineShortcuts } from '@/features/timeline/hooks/use-timeline-shortcuts'
+export { useTransitionBreakageNotifications } from '@/features/timeline/hooks/use-transition-breakage-notifications'
 export { useFilmstrip } from '@/features/timeline/hooks/use-filmstrip'
 export type { FilmstripFrame } from '@/features/timeline/hooks/use-filmstrip'

--- a/src/features/editor/deps/timeline-ui-contract.ts
+++ b/src/features/editor/deps/timeline-ui-contract.ts
@@ -9,7 +9,11 @@ export { useReverseConformDialogStore } from '@/features/timeline/stores/reverse
 export { useSilenceRemovalDialogStore } from '@/features/timeline/stores/silence-removal-dialog-store'
 
 export const importTimeline = () => import('@/features/timeline/components/timeline')
-export const importBentoLayoutDialog = () => import('@/features/timeline/components/bento-layout-dialog')
-export const importFillerRemovalDialog = () => import('@/features/timeline/components/filler-removal-dialog')
-export const importReverseConformDialog = () => import('@/features/timeline/components/reverse-conform-dialog')
-export const importSilenceRemovalDialog = () => import('@/features/timeline/components/silence-removal-dialog')
+export const importBentoLayoutDialog = () =>
+  import('@/features/timeline/components/bento-layout-dialog')
+export const importFillerRemovalDialog = () =>
+  import('@/features/timeline/components/filler-removal-dialog')
+export const importReverseConformDialog = () =>
+  import('@/features/timeline/components/reverse-conform-dialog')
+export const importSilenceRemovalDialog = () =>
+  import('@/features/timeline/components/silence-removal-dialog')

--- a/src/features/editor/deps/timeline-utils-contract.ts
+++ b/src/features/editor/deps/timeline-utils-contract.ts
@@ -13,7 +13,10 @@ export {
   getDefaultGeneratedLayerDurationInFrames,
 } from '@/features/timeline/utils/generated-layer-items'
 export { createOverlayLayerTrack } from '@/features/timeline/utils/new-track-zone-media'
-export { createScrubThrottleState, shouldCommitScrubFrame } from '@/features/timeline/utils/scrub-throttle'
+export {
+  createScrubThrottleState,
+  shouldCommitScrubFrame,
+} from '@/features/timeline/utils/scrub-throttle'
 export { findCompatibleTrackForItemType } from '@/features/timeline/utils/track-item-compatibility'
 export { findNearestAvailableSpace } from '@/features/timeline/utils/collision-utils'
 export { resolveEffectiveTrackStates } from '@/features/timeline/utils/group-utils'
@@ -21,5 +24,8 @@ export { getMaxTransitionDurationForHandles } from '@/features/timeline/utils/tr
 export { resolveTransitionTargetFromSelection } from '@/features/timeline/utils/transition-targets'
 export { searchTimelineTranscript } from '@/features/timeline/utils/transcript-search'
 export type { TranscriptSearchMatch } from '@/features/timeline/utils/transcript-search'
-export { timelineToSourceFrames, sourceToTimelineFrames } from '@/features/timeline/utils/source-calculations'
+export {
+  timelineToSourceFrames,
+  sourceToTimelineFrames,
+} from '@/features/timeline/utils/source-calculations'
 export { linkItems } from '@/features/timeline/stores/actions/item-actions'

--- a/src/features/metoken/api/buy-metoken.ts
+++ b/src/features/metoken/api/buy-metoken.ts
@@ -1,0 +1,66 @@
+import { encodeFunctionData, erc20Abi } from 'viem'
+import { CRTVAI_DIAMOND_ADDRESS, METOKEN_DIAMOND_ABI, USDC_BASE_ADDRESS } from '@/config/metoken'
+
+/**
+ * Builds the UserOperation calldata for buying (minting) CRTVAI meTokens.
+ *
+ * meToken mint flow:
+ *  1. Approve USDC to the meToken diamond (it pulls USDC on mint)
+ *  2. Call mint(amount) on the diamond — Bancor Zero formula computes output
+ *
+ * The smart wallet batched call executes both ops atomically.
+ */
+
+export interface SmartWalletOp {
+  target: `0x${string}`
+  data: `0x${string}`
+  value: bigint
+}
+
+export interface BuyMetokenOpsResult {
+  /** UserOperations to execute via smart wallet (approve + mint). */
+  ops: SmartWalletOp[]
+}
+
+/**
+ * Build the batched user ops for minting CRTVAI with USDC.
+ * @param usdcAmount Amount of USDC (raw, 6 decimals) to spend on minting.
+ */
+export function buildBuyMetokenOps(usdcAmount: bigint): BuyMetokenOpsResult {
+  const approveData = encodeFunctionData({
+    abi: erc20Abi,
+    functionName: 'approve',
+    args: [CRTVAI_DIAMOND_ADDRESS, usdcAmount],
+  })
+
+  const mintData = encodeFunctionData({
+    abi: METOKEN_DIAMOND_ABI,
+    functionName: 'mint',
+    args: [usdcAmount],
+  })
+
+  return {
+    ops: [
+      { target: USDC_BASE_ADDRESS, data: approveData, value: 0n },
+      { target: CRTVAI_DIAMOND_ADDRESS, data: mintData, value: 0n },
+    ],
+  }
+}
+
+/**
+ * Build the UserOperation calldata for selling (burning) CRTVAI back to USDC.
+ * @param metokenAmount Amount of CRTVAI (raw, 18 decimals) to sell.
+ */
+export function buildSellMetokenOp(metokenAmount: bigint): SmartWalletOp {
+  const sellData = encodeFunctionData({
+    abi: METOKEN_DIAMOND_ABI,
+    functionName: 'sell',
+    args: [metokenAmount],
+  })
+
+  return {
+    target: CRTVAI_DIAMOND_ADDRESS,
+    data: sellData,
+    value: 0n,
+  }
+}

--- a/src/features/metoken/components/buy-metoken-modal.tsx
+++ b/src/features/metoken/components/buy-metoken-modal.tsx
@@ -1,0 +1,239 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Coins, Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { parseUnits, formatUnits } from 'viem'
+import { useQueryClient } from '@tanstack/react-query'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { useWalletContext } from '@/context/wallet-context'
+import { useSmartWalletOps } from '@/hooks/use-smart-wallet-ops'
+import { useUsdcBalance } from '@/hooks/use-usdc-balance'
+import { useCrtvaiBalance } from '@/hooks/use-crtvai-balance'
+import {
+  CRTVAI_DECIMALS,
+  USDC_DECIMALS,
+  readCrtvaiCurrentPrice,
+  readCrtvaiMintQuote,
+} from '@/config/metoken'
+import { buildBuyMetokenOps } from '@/features/metoken/api/buy-metoken'
+import { base } from 'viem/chains'
+import { cn } from '@/shared/ui/cn'
+
+interface BuyMetokenModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const BASE_CHAIN_ID = base.id
+
+export function BuyMetokenModal({ open, onOpenChange }: BuyMetokenModalProps) {
+  const { account, chain } = useWalletContext()
+  const queryClient = useQueryClient()
+  const { sendOps, ready: walletReady } = useSmartWalletOps()
+  const { balance: usdcBalance, formatted: usdcFormatted } = useUsdcBalance(chain, account)
+  const { formatted: crtvaiFormatted, symbol } = useCrtvaiBalance(account)
+
+  const [usdcInput, setUsdcInput] = useState('')
+  const [estimatedOutput, setEstimatedOutput] = useState<string | null>(null)
+  const [currentPrice, setCurrentPrice] = useState<string | null>(null)
+  const [quoting, setQuoting] = useState(false)
+  const [minting, setMinting] = useState(false)
+
+  const onBase = chain?.id === BASE_CHAIN_ID
+
+  const hasSufficientUsdc = useMemo(() => {
+    if (!usdcInput || !usdcBalance) return true
+    try {
+      const inputRaw = parseUnits(usdcInput, USDC_DECIMALS)
+      const balanceRaw = parseUnits(usdcBalance, USDC_DECIMALS)
+      return inputRaw <= balanceRaw
+    } catch {
+      return false
+    }
+  }, [usdcInput, usdcBalance])
+
+  // Fetch current price on open
+  useEffect(() => {
+    if (!open || !onBase) return
+    let cancelled = false
+    void (async () => {
+      try {
+        const price = await readCrtvaiCurrentPrice()
+        if (!cancelled) {
+          setCurrentPrice(formatUnits(price, USDC_DECIMALS))
+        }
+      } catch {
+        // Price read failed — non-fatal, UI still works
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [open, onBase])
+
+  // Debounced mint quote
+  useEffect(() => {
+    if (!open || !onBase || !usdcInput) {
+      setEstimatedOutput(null)
+      return
+    }
+    let usdcRaw: bigint
+    try {
+      usdcRaw = parseUnits(usdcInput, USDC_DECIMALS)
+    } catch {
+      setEstimatedOutput(null)
+      return
+    }
+    if (usdcRaw <= 0n) {
+      setEstimatedOutput(null)
+      return
+    }
+    let cancelled = false
+    setQuoting(true)
+    const timer = window.setTimeout(async () => {
+      try {
+        const quote = await readCrtvaiMintQuote(usdcRaw)
+        if (!cancelled) {
+          setEstimatedOutput(formatUnits(quote, CRTVAI_DECIMALS))
+        }
+      } catch {
+        if (!cancelled) setEstimatedOutput(null)
+      } finally {
+        if (!cancelled) setQuoting(false)
+      }
+    }, 400)
+    return () => {
+      cancelled = true
+      window.clearTimeout(timer)
+      if (!cancelled) setQuoting(false)
+    }
+  }, [open, onBase, usdcInput])
+
+  const handleMint = useCallback(async () => {
+    if (!account || !usdcInput || !onBase) return
+    let usdcRaw: bigint
+    try {
+      usdcRaw = parseUnits(usdcInput, USDC_DECIMALS)
+    } catch {
+      toast.error('Invalid USDC amount')
+      return
+    }
+    if (usdcRaw <= 0n) {
+      toast.error('Amount must be greater than 0')
+      return
+    }
+    setMinting(true)
+    try {
+      const { ops } = buildBuyMetokenOps(usdcRaw)
+      await sendOps(ops)
+      toast.success(`Minted CRTVAI with ${usdcInput} USDC`)
+      setUsdcInput('')
+      onOpenChange(false)
+      void queryClient.invalidateQueries({ queryKey: ['usdc-balance', chain?.id, account] })
+      void queryClient.invalidateQueries({ queryKey: ['crtvai-balance', account] })
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
+      toast.error(`Mint failed: ${msg}`)
+    } finally {
+      setMinting(false)
+    }
+  }, [account, usdcInput, onBase, chain?.id, sendOps, onOpenChange, queryClient])
+
+  const canMint = onBase && walletReady && usdcInput && hasSufficientUsdc && !quoting && !minting
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Coins className="h-5 w-5" aria-hidden />
+            Buy CRTVAI
+          </DialogTitle>
+          <DialogDescription>
+            Mint CRTVAI by depositing USDC into the meToken bonding curve on Base.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-muted-foreground">Wallet USDC:</span>
+            <span className="font-medium">{usdcFormatted} USDC</span>
+          </div>
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-muted-foreground">Wallet {symbol}:</span>
+            <span className="font-medium">
+              {crtvaiFormatted} {symbol}
+            </span>
+          </div>
+          {currentPrice && (
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-muted-foreground">Current price:</span>
+              <span className="font-medium">
+                {Number(currentPrice).toLocaleString(undefined, { maximumFractionDigits: 6 })} USDC/
+                {symbol}
+              </span>
+            </div>
+          )}
+
+          <div className="space-y-1.5">
+            <label htmlFor="usdc-input" className="text-sm font-medium">
+              USDC to spend
+            </label>
+            <Input
+              id="usdc-input"
+              type="number"
+              min="0"
+              step="0.01"
+              placeholder="0.00"
+              value={usdcInput}
+              onChange={(e) => setUsdcInput(e.target.value)}
+              disabled={minting}
+            />
+          </div>
+
+          <div className="rounded-md border bg-muted/40 px-3 py-2 text-sm">
+            <span className="text-muted-foreground">Estimated receive: </span>
+            <span className="font-medium">
+              {quoting ? (
+                <Loader2 className="inline h-3.5 w-3.5 animate-spin" />
+              ) : estimatedOutput ? (
+                `${Number(estimatedOutput).toLocaleString(undefined, { maximumFractionDigits: 4 })} ${symbol}`
+              ) : (
+                '—'
+              )}
+            </span>
+          </div>
+
+          {!onBase && (
+            <p className="text-xs text-amber-500">Switch to Base network to mint CRTVAI.</p>
+          )}
+          {!hasSufficientUsdc && usdcInput && (
+            <p className="text-xs text-destructive">Insufficient USDC balance.</p>
+          )}
+
+          <Button
+            onClick={handleMint}
+            disabled={!canMint}
+            className={cn('w-full', minting && 'opacity-80')}
+          >
+            {minting ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Minting…
+              </>
+            ) : (
+              'Mint CRTVAI'
+            )}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/features/metoken/index.ts
+++ b/src/features/metoken/index.ts
@@ -1,0 +1,2 @@
+export { BuyMetokenModal } from './components/buy-metoken-modal'
+export { buildBuyMetokenOps, buildSellMetokenOp } from './api/buy-metoken'

--- a/src/features/onramp/deps/wallet-contract.ts
+++ b/src/features/onramp/deps/wallet-contract.ts
@@ -1,0 +1,4 @@
+/**
+ * Cross-feature dependency contract: wallet context.
+ */
+export { useWalletContext } from '@/context/wallet-context'

--- a/src/features/onramp/deps/wallet.ts
+++ b/src/features/onramp/deps/wallet.ts
@@ -1,0 +1,4 @@
+/**
+ * Cross-feature dependency adapter: wallet context.
+ */
+export { useWalletContext } from './wallet-contract'

--- a/src/hooks/use-crtvai-balance.ts
+++ b/src/hooks/use-crtvai-balance.ts
@@ -1,0 +1,51 @@
+import { useQuery } from '@tanstack/react-query'
+import { formatUnits } from 'viem'
+import { CRTVAI_DECIMALS, readCrtvaiBalance } from '@/config/metoken'
+
+export interface UseCrtvaiBalanceResult {
+  /** Raw balance in meToken wei (18 decimals). */
+  balance: bigint | null
+  /** Formatted display string (e.g. "1,234.56"). */
+  formatted: string
+  /** Human-friendly symbol for UI. */
+  symbol: string
+  isLoading: boolean
+  isError: boolean
+}
+
+const CRTVAI_SYMBOL = 'CRTVAI'
+
+/** Format meToken wei to a display string with up to 2 decimal places. */
+function formatMetokenBalance(wei: bigint): string {
+  const formatted = formatUnits(wei, CRTVAI_DECIMALS)
+  const n = Number(formatted)
+  return n.toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  })
+}
+
+/**
+ * Returns CRTVAI meToken balance for the given address on Base.
+ * The meToken diamond is an ERC-2535 contract with a standard balanceOf facet.
+ */
+export function useCrtvaiBalance(address: `0x${string}` | undefined): UseCrtvaiBalanceResult {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['crtvai-balance', address],
+    queryFn: () => readCrtvaiBalance(address!),
+    enabled: Boolean(address),
+    staleTime: 30_000,
+    refetchInterval: 60_000,
+  })
+
+  const balance = data ?? null
+  const formatted = balance !== null ? formatMetokenBalance(balance) : '—'
+
+  return {
+    balance,
+    formatted,
+    symbol: CRTVAI_SYMBOL,
+    isLoading,
+    isError,
+  }
+}

--- a/src/hooks/use-smart-wallet-ops.ts
+++ b/src/hooks/use-smart-wallet-ops.ts
@@ -1,0 +1,72 @@
+import { useCallback } from 'react'
+import type { Address, Hex } from 'viem'
+import { useWalletContext } from '@/context/wallet-context'
+import { buildGasPaymasterCapabilities } from '@/config/gas-sponsorship'
+import { createLogger } from '@/shared/logging/logger'
+
+const log = createLogger('smart-wallet-ops')
+
+export interface SmartWalletOp {
+  target: Address
+  data: Hex
+  value: bigint
+}
+
+export interface SendOpsResult {
+  /** Mined transaction hash containing the user operation. */
+  txHash: Hex
+  /** All unique receipt tx hashes (batched calls may expose more than one). */
+  txHashes: Hex[]
+}
+
+export function useSmartWalletOps() {
+  const { smartWalletClient, chain } = useWalletContext()
+
+  const sendOps = useCallback(
+    async (ops: SmartWalletOp[]): Promise<SendOpsResult> => {
+      if (!smartWalletClient) throw new Error('Wallet not ready')
+
+      const capabilities = chain ? buildGasPaymasterCapabilities(chain.id) : null
+
+      let prepared = await smartWalletClient.prepareCalls({
+        calls: ops.map((op) => ({
+          to: op.target,
+          data: op.data,
+          value: op.value,
+        })),
+        ...(capabilities ? { capabilities } : {}),
+      })
+
+      // ERC-20 gas policies in pre-op mode return a permit signature request
+      // that must be signed and folded back into a second prepareCalls.
+      if (prepared.type === 'paymaster-permit') {
+        log.warn('Paymaster requested ERC-20 permit; signing and re-preparing')
+        const signature = await smartWalletClient.signSignatureRequest(prepared.signatureRequest)
+        prepared = await smartWalletClient.prepareCalls({
+          calls: prepared.modifiedRequest.calls,
+          capabilities: prepared.modifiedRequest.capabilities,
+          paymasterPermitSignature: signature,
+        })
+      }
+
+      const signed = await smartWalletClient.signPreparedCalls(prepared)
+      const { id } = await smartWalletClient.sendPreparedCalls(signed)
+
+      const status = await smartWalletClient.waitForCallsStatus({ id })
+      if (status.status !== 'success') {
+        throw new Error(`Transaction failed (status ${String(status.statusCode)})`)
+      }
+      const txHashes = [
+        ...new Set(
+          (status.receipts ?? []).map((r) => r.transactionHash).filter((h): h is Hex => Boolean(h)),
+        ),
+      ]
+      const txHash = txHashes[txHashes.length - 1]
+      if (!txHash) throw new Error('Transaction confirmed without a receipt')
+      return { txHash, txHashes }
+    },
+    [smartWalletClient, chain],
+  )
+
+  return { sendOps, ready: Boolean(smartWalletClient) }
+}

--- a/src/hooks/use-usdc-balance.ts
+++ b/src/hooks/use-usdc-balance.ts
@@ -1,0 +1,82 @@
+import { useQuery } from '@tanstack/react-query'
+import type { Chain } from 'viem'
+import { createPublicClient, formatUnits, http, parseAbi } from 'viem'
+import { ALCHEMY_API_KEY } from '@/config/alchemy'
+import { USDC_ADDRESS_BY_CHAIN_ID } from '@/config/chains'
+
+const ERC20_BALANCE_ABI = parseAbi(['function balanceOf(address account) view returns (uint256)'])
+
+const USDC_DECIMALS = 6
+
+function getRpcUrl(chain: Chain): string | undefined {
+  const alchemyHttp = chain.rpcUrls?.alchemy?.http?.[0]
+  const defaultHttp = chain.rpcUrls?.default?.http?.[0]
+  if (alchemyHttp && ALCHEMY_API_KEY) {
+    return `${alchemyHttp}/${ALCHEMY_API_KEY}`
+  }
+  return defaultHttp
+}
+
+async function fetchUsdcBalance(chain: Chain, address: `0x${string}`): Promise<string> {
+  const usdcAddress = USDC_ADDRESS_BY_CHAIN_ID[chain.id]
+  if (!usdcAddress) {
+    return '0'
+  }
+  const rpcUrl = getRpcUrl(chain)
+  if (!rpcUrl) {
+    throw new Error(`No RPC URL for chain ${chain.id}`)
+  }
+  const client = createPublicClient({
+    chain,
+    transport: http(rpcUrl),
+  })
+  const balance = await client.readContract({
+    address: usdcAddress,
+    abi: ERC20_BALANCE_ABI,
+    functionName: 'balanceOf',
+    args: [address],
+  })
+  return formatUnits(balance, USDC_DECIMALS)
+}
+
+export interface UseUsdcBalanceResult {
+  balance: string | null
+  formatted: string
+  isLoading: boolean
+  isError: boolean
+}
+
+/**
+ * Returns USDC balance for the given address on the given chain.
+ * Returns formatted display string and loading/error state.
+ * Chains without a configured USDC address return "0" and no error.
+ */
+export function useUsdcBalance(
+  chain: Chain | undefined,
+  address: `0x${string}` | undefined,
+): UseUsdcBalanceResult {
+  const hasUsdc = chain ? chain.id in USDC_ADDRESS_BY_CHAIN_ID : false
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['usdc-balance', chain?.id, address],
+    queryFn: () => fetchUsdcBalance(chain!, address!),
+    enabled: Boolean(chain && address && hasUsdc && getRpcUrl(chain)),
+    staleTime: 30_000,
+  })
+
+  const balance = data ?? null
+  let formatted = '—'
+  if (balance !== null) {
+    const n = Number(balance)
+    formatted = n.toLocaleString(undefined, {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 2,
+    })
+  }
+
+  return {
+    balance,
+    formatted,
+    isLoading,
+    isError,
+  }
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,15 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SHOW_DEBUG_PANEL?: string
+  readonly VITE_PRIVY_APP_ID?: string
+  readonly VITE_PRIVY_CLIENT_ID?: string
+  readonly VITE_ALCHEMY_API_KEY?: string
+  readonly VITE_ALCHEMY_POLICY_ID?: string
+  readonly VITE_ALCHEMY_GAS_POLICY_TYPE?: string
+  readonly VITE_ALCHEMY_GAS_MAX_USDC6?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -8,6 +8,8 @@ interface ImportMetaEnv {
   readonly VITE_ALCHEMY_POLICY_ID?: string
   readonly VITE_ALCHEMY_GAS_POLICY_TYPE?: string
   readonly VITE_ALCHEMY_GAS_MAX_USDC6?: string
+  readonly VITE_CRTVAIX_ADDRESS?: string
+  readonly VITE_SUPERFLUID_RECEIVER?: string
 }
 
 interface ImportMeta {


### PR DESCRIPTION
Restores the client-side credits barrel/hooks/components as a bridge to the CRTVAI meToken layer. Server-side credits API routes are intentionally not rebuilt because credits were deprecated in favor of on-chain CRTVAI. Depends on PRs #47, #48, #49. Build + tests pass.