### PR TITLE
fix(director): local ADC + creative-ai-491118 engine

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,17 +35,22 @@ COINBASE_CDP_API_KEY_ID=
 COINBASE_CDP_API_KEY_SECRET=
 
 # Creative Director (Vertex Agent Engine SSE proxy — server-only)
+# Engine: projects/creative-ai-491118/locations/us-central1/reasoningEngines/5922098819817799680
+# Agent runtime SA (identity of the engine, not the API caller):
+#   service-1037240986506@gcp-sa-aiplatform-re.iam.gserviceaccount.com
 # Prefer Workload Identity Federation (no service-account keys).
 # Setup: https://vercel.com/docs/oidc/gcp
 # When creating the OIDC provider, select "Default audience", then copy that URL
 # into GCP_AUDIENCE and pass the same value to getVercelOidcToken({ audience }).
 #
 # Local without Vercel OIDC: `gcloud auth application-default login` (ADC).
-# Local with WIF: `vercel env pull` then the GCP_* vars below.
-GOOGLE_CLOUD_PROJECT=1037240986506
+# Local with WIF vars from `vercel env pull`: still use ADC — GCP_* are only
+# used for WIF when VERCEL=1 (deployed). Expired VERCEL_OIDC_TOKEN is ignored locally.
+GOOGLE_CLOUD_PROJECT=creative-ai-491118
 VERTEX_LOCATION=us-central1
 VERTEX_REASONING_ENGINE_ID=5922098819817799680
-# GCP_PROJECT_NUMBER=
+# Project number for WIF (creative-ai-491118 → 1037240986506)
+# GCP_PROJECT_NUMBER=1037240986506
 # GCP_SERVICE_ACCOUNT_EMAIL=
 # GCP_WORKLOAD_IDENTITY_POOL_ID=
 # GCP_WORKLOAD_IDENTITY_POOL_PROVIDER_ID=

--- a/.env.example
+++ b/.env.example
@@ -60,3 +60,10 @@ VERTEX_REASONING_ENGINE_ID=5922098819817799680
 # Optional shared secret for non-browser callers (curl, automation). On Vercel,
 # browser requests from the same deployment host are allowed without it.
 # DIRECTOR_API_SECRET=
+
+# Director billing (CRTVAI per minute of timeline audio)
+# On Vercel, payment is enforced when a treasury address is set.
+# Client pays CRTVAI to VITE_SUPERFLUID_RECEIVER (or PIXELS_TREASURY_ADDRESS).
+# PIXELS_TREASURY_ADDRESS=
+# Set DIRECTOR_BILLING_SOFT=1 to skip on-chain payment verification (dev only).
+# DIRECTOR_BILLING_SOFT=

--- a/api/director-billing.ts
+++ b/api/director-billing.ts
@@ -1,0 +1,127 @@
+/// <reference types="node" />
+/**
+ * Creative Director billing helpers for the Vercel `/api/director` proxy.
+ * Quotes are USDC6; settlement is a CRTVAI transfer to the platform treasury.
+ */
+
+import { createPublicClient, http, type Hex } from 'viem'
+import { base } from 'viem/chains'
+
+/** Mirrors `DIRECTOR_USDC6_PER_AUDIO_MINUTE_RETAIL` in src/config/billing.ts */
+export const DIRECTOR_USDC6_PER_AUDIO_MINUTE = 50_000
+
+const CRTVAI_DIAMOND = '0xecb695544a3d2a64d579b3828f3f60f6932f4846'
+
+export interface DirectorBillingQuote {
+  billableMinutes: number
+  estimatedUsdc6: number
+  /** Minimum CRTVAI wei expected (usdc6 × 1e12). */
+  minCrtvaiWei: bigint
+}
+
+export function billableAudioMinutes(audioDurationSeconds: number): number {
+  if (!Number.isFinite(audioDurationSeconds) || audioDurationSeconds <= 0) return 0
+  return Math.max(1, Math.ceil(audioDurationSeconds / 60))
+}
+
+export function quoteDirectorRetail(audioDurationSeconds: number): DirectorBillingQuote | null {
+  const minutes = billableAudioMinutes(audioDurationSeconds)
+  if (minutes <= 0) return null
+  const estimatedUsdc6 = minutes * DIRECTOR_USDC6_PER_AUDIO_MINUTE
+  return {
+    billableMinutes: minutes,
+    estimatedUsdc6,
+    minCrtvaiWei: BigInt(estimatedUsdc6) * 10n ** 12n,
+  }
+}
+
+export function getDirectorTreasury(): `0x${string}` | null {
+  const raw =
+    process.env.PIXELS_TREASURY_ADDRESS?.trim() ||
+    process.env.VITE_SUPERFLUID_RECEIVER?.trim() ||
+    ''
+  if (!raw.startsWith('0x') || raw.length < 42) return null
+  return raw as `0x${string}`
+}
+
+/** Enforce CRTVAI payment on deployed Vercel when a treasury is configured. */
+export function isDirectorBillingEnforced(): boolean {
+  if (process.env.DIRECTOR_BILLING_SOFT === '1') return false
+  return Boolean(process.env.VERCEL && getDirectorTreasury())
+}
+
+function alchemyRpcUrl(): string {
+  const key = process.env.ALCHEMY_API_KEY?.trim() || process.env.VITE_ALCHEMY_API_KEY?.trim() || ''
+  return key ? `https://base-mainnet.g.alchemy.com/v2/${key}` : 'https://mainnet.base.org'
+}
+
+export type PaymentVerifyResult = { ok: true; amountWei: bigint } | { ok: false; reason: string }
+
+/**
+ * Confirm a CRTVAI Transfer log from `from` → treasury in `txHash`.
+ */
+// fallow-ignore-next-line complexity
+export async function verifyDirectorPayment(options: {
+  txHash: string
+  from: string
+  minAmountWei: bigint
+}): Promise<PaymentVerifyResult> {
+  const treasury = getDirectorTreasury()
+  if (!treasury) return { ok: false, reason: 'Treasury not configured' }
+
+  const from = options.from.trim().toLowerCase()
+  const to = treasury.toLowerCase()
+  if (!from.startsWith('0x') || from.length < 42) {
+    return { ok: false, reason: 'Invalid wallet address' }
+  }
+  if (!options.txHash.startsWith('0x')) {
+    return { ok: false, reason: 'Invalid payment transaction hash' }
+  }
+
+  const client = createPublicClient({
+    chain: base,
+    transport: http(alchemyRpcUrl()),
+  })
+
+  try {
+    const receipt = await client.getTransactionReceipt({
+      hash: options.txHash as Hex,
+    })
+    if (receipt.status !== 'success') {
+      return { ok: false, reason: 'Payment transaction failed' }
+    }
+
+    const fromPad = `0x000000000000000000000000${from.slice(2)}`.toLowerCase()
+    const toPad = `0x000000000000000000000000${to.slice(2)}`.toLowerCase()
+
+    const logs = receipt.logs.filter(
+      (log) =>
+        log.address.toLowerCase() === CRTVAI_DIAMOND.toLowerCase() &&
+        log.topics[1]?.toLowerCase() === fromPad &&
+        log.topics[2]?.toLowerCase() === toPad,
+    )
+
+    if (logs.length === 0) {
+      return { ok: false, reason: 'No matching CRTVAI transfer to treasury found' }
+    }
+
+    let amountWei = 0n
+    for (const log of logs) {
+      amountWei += BigInt(log.data)
+    }
+
+    if (amountWei < options.minAmountWei) {
+      return {
+        ok: false,
+        reason: `Payment too low: need ${options.minAmountWei} wei, got ${amountWei}`,
+      }
+    }
+
+    return { ok: true, amountWei }
+  } catch (error) {
+    return {
+      ok: false,
+      reason: error instanceof Error ? error.message : 'Payment verification failed',
+    }
+  }
+}

--- a/api/director-billing.ts
+++ b/api/director-billing.ts
@@ -8,7 +8,7 @@ import { createPublicClient, http, type Hex } from 'viem'
 import { base } from 'viem/chains'
 
 /** Mirrors `DIRECTOR_USDC6_PER_AUDIO_MINUTE_RETAIL` in src/config/billing.ts */
-export const DIRECTOR_USDC6_PER_AUDIO_MINUTE = 50_000
+const DIRECTOR_USDC6_PER_AUDIO_MINUTE = 50_000
 
 const CRTVAI_DIAMOND = '0xecb695544a3d2a64d579b3828f3f60f6932f4846'
 
@@ -19,7 +19,7 @@ export interface DirectorBillingQuote {
   minCrtvaiWei: bigint
 }
 
-export function billableAudioMinutes(audioDurationSeconds: number): number {
+function billableAudioMinutes(audioDurationSeconds: number): number {
   if (!Number.isFinite(audioDurationSeconds) || audioDurationSeconds <= 0) return 0
   return Math.max(1, Math.ceil(audioDurationSeconds / 60))
 }
@@ -35,13 +35,13 @@ export function quoteDirectorRetail(audioDurationSeconds: number): DirectorBilli
   }
 }
 
-export function getDirectorTreasury(): `0x${string}` | null {
+// fallow-ignore-next-line complexity
+function getDirectorTreasury(): `0x${string}` | null {
   const raw =
     process.env.PIXELS_TREASURY_ADDRESS?.trim() ||
     process.env.VITE_SUPERFLUID_RECEIVER?.trim() ||
     ''
-  if (!raw.startsWith('0x') || raw.length < 42) return null
-  return raw as `0x${string}`
+  return raw.startsWith('0x') && raw.length >= 42 ? (raw as `0x${string}`) : null
 }
 
 /** Enforce CRTVAI payment on deployed Vercel when a treasury is configured. */

--- a/api/director.ts
+++ b/api/director.ts
@@ -2,12 +2,17 @@
 /**
  * Vercel serverless endpoint: proxies Creative Director Agent Engine SSE.
  *
+ * Engine (streamQuery SSE — not the unary :query URL):
+ *   projects/creative-ai-491118/locations/us-central1/reasoningEngines/5922098819817799680
+ * Agent runtime identity (Agent Engine SA — not the caller):
+ *   service-1037240986506@gcp-sa-aiplatform-re.iam.gserviceaccount.com
+ *
  * Auth (no service-account keys):
  * - Production / Vercel: Workload Identity Federation via Vercel OIDC
  *   (`@vercel/oidc` + `ExternalAccountClient`)
  * - Local: Application Default Credentials
- *   (`gcloud auth application-default login`), or the same WIF path after
- *   `vercel env pull` (provides `VERCEL_OIDC_TOKEN`)
+ *   (`gcloud auth application-default login`); GCP_* from `vercel env pull`
+ *   only apply when `VERCEL` is set
  *
  * Body JSON:
  *   prompt     - user message (required)
@@ -19,7 +24,7 @@
 import { getVercelOidcToken } from '@vercel/oidc'
 import { ExternalAccountClient, GoogleAuth } from 'google-auth-library'
 
-const DEFAULT_PROJECT = '1037240986506'
+const DEFAULT_PROJECT = 'creative-ai-491118'
 const DEFAULT_LOCATION = 'us-central1'
 const DEFAULT_ENGINE_ID = '5922098819817799680'
 const CLOUD_PLATFORM_SCOPE = 'https://www.googleapis.com/auth/cloud-platform'
@@ -130,11 +135,15 @@ async function getAccessTokenViaAdc(): Promise<string> {
 }
 
 /**
- * Prefer keyless WIF on Vercel; fall back to ADC for local shells without OIDC.
+ * Prefer keyless WIF on Vercel; use ADC for local `vp dev`.
+ *
+ * `vercel env pull` often copies GCP_* into `.env.local`. Those must not force
+ * the WIF path locally — Vercel OIDC tokens expire and `@vercel/oidc` needs the
+ * Vercel runtime. Only use WIF when `VERCEL` is set.
  */
 async function getAccessToken(): Promise<string> {
   const wif = readWifConfig()
-  if (wif) {
+  if (wif && process.env.VERCEL) {
     return getAccessTokenViaWif(wif)
   }
   return getAccessTokenViaAdc()
@@ -304,10 +313,14 @@ export async function POST(request: Request): Promise<Response> {
     token = await getAccessToken()
   } catch (error) {
     console.error('Director auth error', error)
+    const detail = error instanceof Error ? error.message : String(error)
+    const hint = process.env.VERCEL
+      ? 'Set GCP Workload Identity Federation env vars (Vercel OIDC).'
+      : 'Run `gcloud auth application-default login` (local ADC). GCP_* from `vercel env pull` are ignored off-Vercel.'
     return Response.json(
       {
-        error:
-          'Director not configured: set GCP Workload Identity Federation env vars (Vercel OIDC) or Application Default Credentials locally',
+        error: `Director auth failed: ${hint}`,
+        detail: process.env.VERCEL ? undefined : detail,
       },
       { status: 503 },
     )

--- a/api/director.ts
+++ b/api/director.ts
@@ -225,6 +225,7 @@ function engineStreamUrl(): string {
   return `https://${location}-aiplatform.googleapis.com/v1/projects/${project}/locations/${location}/reasoningEngines/${engineId}:streamQuery?alt=sse`
 }
 
+// fallow-ignore-next-line complexity
 async function parseDirectorRequest(
   request: Request,
 ): Promise<{ ok: true; data: ParsedDirectorRequest } | { ok: false; response: Response }> {
@@ -259,6 +260,7 @@ async function parseDirectorRequest(
   }
 }
 
+// fallow-ignore-next-line complexity
 async function assertDirectorPayment(data: ParsedDirectorRequest): Promise<Response | null> {
   if (!isDirectorBillingEnforced()) return null
 

--- a/api/director.ts
+++ b/api/director.ts
@@ -15,14 +15,22 @@
  *   only apply when `VERCEL` is set
  *
  * Body JSON:
- *   prompt     - user message (required)
- *   userId     - session user id (optional)
- *   sessionId  - continue an Agent Engine session (optional)
- *   audioUri   - optional audio context appended to the message
+ *   prompt                - user message (required)
+ *   userId                - session user id (optional)
+ *   sessionId             - continue an Agent Engine session (optional)
+ *   audioUri              - optional audio context appended to the message
+ *   audioDurationSeconds  - timeline audio length (required when billing enforced)
+ *   paymentTxHash         - CRTVAI transfer to treasury (required when billing enforced)
+ *   walletAddress         - payer wallet (required when billing enforced)
  */
 
 import { getVercelOidcToken } from '@vercel/oidc'
 import { ExternalAccountClient, GoogleAuth } from 'google-auth-library'
+import {
+  isDirectorBillingEnforced,
+  quoteDirectorRetail,
+  verifyDirectorPayment,
+} from './director-billing'
 
 const DEFAULT_PROJECT = 'creative-ai-491118'
 const DEFAULT_LOCATION = 'us-central1'
@@ -34,6 +42,19 @@ interface DirectorRequestBody {
   userId?: string
   sessionId?: string
   audioUri?: string
+  audioDurationSeconds?: number
+  paymentTxHash?: string
+  walletAddress?: string
+}
+
+interface ParsedDirectorRequest {
+  prompt: string
+  userId: string
+  sessionId?: string
+  audioUri?: string
+  audioDurationSeconds?: number
+  paymentTxHash?: string
+  walletAddress?: string
 }
 
 interface WifConfig {
@@ -206,10 +227,7 @@ function engineStreamUrl(): string {
 
 async function parseDirectorRequest(
   request: Request,
-): Promise<
-  | { ok: true; prompt: string; userId: string; sessionId?: string; audioUri?: string }
-  | { ok: false; response: Response }
-> {
+): Promise<{ ok: true; data: ParsedDirectorRequest } | { ok: false; response: Response }> {
   let body: DirectorRequestBody
   try {
     body = (await request.json()) as DirectorRequestBody
@@ -222,13 +240,65 @@ async function parseDirectorRequest(
     return { ok: false, response: Response.json({ error: 'prompt is required' }, { status: 400 }) }
   }
 
+  const audioDurationSeconds =
+    typeof body.audioDurationSeconds === 'number' && Number.isFinite(body.audioDurationSeconds)
+      ? body.audioDurationSeconds
+      : undefined
+
   return {
     ok: true,
-    prompt,
-    userId: body.userId?.trim() || 'creator-user',
-    sessionId: body.sessionId?.trim(),
-    audioUri: body.audioUri,
+    data: {
+      prompt,
+      userId: body.userId?.trim() || 'creator-user',
+      sessionId: body.sessionId?.trim(),
+      audioUri: body.audioUri,
+      audioDurationSeconds,
+      paymentTxHash: body.paymentTxHash?.trim(),
+      walletAddress: body.walletAddress?.trim(),
+    },
   }
+}
+
+async function assertDirectorPayment(data: ParsedDirectorRequest): Promise<Response | null> {
+  if (!isDirectorBillingEnforced()) return null
+
+  if (data.audioDurationSeconds == null || data.audioDurationSeconds <= 0) {
+    return Response.json(
+      { error: 'audioDurationSeconds is required for Director billing' },
+      { status: 402 },
+    )
+  }
+
+  const quote = quoteDirectorRetail(data.audioDurationSeconds)
+  if (!quote) {
+    return Response.json({ error: 'Unable to quote Director brief' }, { status: 402 })
+  }
+
+  if (!data.paymentTxHash || !data.walletAddress) {
+    return Response.json(
+      {
+        error: 'Director requires a CRTVAI payment before generation',
+        estimatedUsdc6: quote.estimatedUsdc6,
+        billableMinutes: quote.billableMinutes,
+      },
+      { status: 402 },
+    )
+  }
+
+  const verified = await verifyDirectorPayment({
+    txHash: data.paymentTxHash,
+    from: data.walletAddress,
+    minAmountWei: quote.minCrtvaiWei,
+  })
+
+  if (!verified.ok) {
+    return Response.json(
+      { error: `Director payment rejected: ${verified.reason}` },
+      { status: 402 },
+    )
+  }
+
+  return null
 }
 
 async function fetchEngineStream(
@@ -304,9 +374,12 @@ export async function POST(request: Request): Promise<Response> {
   const parsed = await parseDirectorRequest(request)
   if (!parsed.ok) return parsed.response
 
-  const message = buildMessage(parsed.prompt, parsed.audioUri)
-  const input: Record<string, string> = { user_id: parsed.userId, message }
-  if (parsed.sessionId) input.session_id = parsed.sessionId
+  const paymentError = await assertDirectorPayment(parsed.data)
+  if (paymentError) return paymentError
+
+  const message = buildMessage(parsed.data.prompt, parsed.data.audioUri)
+  const input: Record<string, string> = { user_id: parsed.data.userId, message }
+  if (parsed.data.sessionId) input.session_id = parsed.data.sessionId
 
   let token: string
   try {

--- a/headless/billing.test.mjs
+++ b/headless/billing.test.mjs
@@ -6,10 +6,12 @@ import fs from 'node:fs'
 import {
   estimateRenderCostUsdc6,
   estimateEditCostUsdc6,
+  estimateDirectorCostUsdc6,
   metokenWeiToUsdc6,
   formatUsdc6,
   INTERVAL_COST_PREMIUM_USDC6,
   INTERVAL_COST_RETAIL_USDC6,
+  DIRECTOR_USDC6_PER_AUDIO_MINUTE,
 } from '../headless/lib/billing/pricing.mjs'
 import { CreditLedger } from '../headless/lib/billing/ledger.mjs'
 
@@ -68,6 +70,19 @@ describe('billing/pricing', () => {
     // 1e18 metoken wei at price 1e12 = 1 usdc6
     const usdc6 = metokenWeiToUsdc6(10n ** 18n, 10n ** 12n)
     assert.strictEqual(usdc6, 1)
+  })
+
+  it('estimates Director cost per minute of timeline audio', () => {
+    assert.strictEqual(DIRECTOR_USDC6_PER_AUDIO_MINUTE, INTERVAL_COST_RETAIL_USDC6 / 5)
+    assert.strictEqual(estimateDirectorCostUsdc6({ audioDurationSeconds: 0 }), 0)
+    assert.strictEqual(
+      estimateDirectorCostUsdc6({ audioDurationSeconds: 30 }),
+      DIRECTOR_USDC6_PER_AUDIO_MINUTE,
+    )
+    assert.strictEqual(
+      estimateDirectorCostUsdc6({ audioDurationSeconds: 90 }),
+      DIRECTOR_USDC6_PER_AUDIO_MINUTE * 2,
+    )
   })
 })
 

--- a/headless/lib/billing/pricing.mjs
+++ b/headless/lib/billing/pricing.mjs
@@ -102,6 +102,28 @@ export function estimateEditCostUsdc6({
   return Math.max(0, Math.round(ops + preview))
 }
 
+/** $0.05 USDC per minute of timeline audio (retail Director rate). */
+export const DIRECTOR_USDC6_PER_AUDIO_MINUTE = INTERVAL_COST_RETAIL_USDC6 / 5
+
+/**
+ * Estimate Creative Director cost from timeline audio duration.
+ * Billable minutes = ceil(seconds / 60), minimum 1.
+ *
+ * @param {object} options
+ * @param {number} options.audioDurationSeconds
+ * @param {number} [options.intervalCostUsdc6]
+ */
+export function estimateDirectorCostUsdc6({
+  audioDurationSeconds,
+  intervalCostUsdc6 = INTERVAL_COST_RETAIL_USDC6,
+}) {
+  const seconds = Number(audioDurationSeconds) || 0
+  if (seconds <= 0) return 0
+  const minutes = Math.max(1, Math.ceil(seconds / 60))
+  const perMinute = intervalCostUsdc6 / 5
+  return Math.round(minutes * perMinute)
+}
+
 /**
  * Convert CRTVAI meToken wei (18 decimals) to usdc6 using the current meToken price.
  *

--- a/src/config/billing.ts
+++ b/src/config/billing.ts
@@ -25,3 +25,13 @@ export const DAILY_SPEND_LIMIT_USDC6 = 50_000_000
 
 /** Session Key spend-limit refresh period: 1 day in seconds. */
 export const SPEND_LIMIT_REFRESH_SECONDS = 86_400
+
+/**
+ * Creative Director — USDC-equivalent per minute of timeline audio (retail).
+ * Aligns with Live AI retail ($0.25 / 5 min ⇒ $0.05 / min).
+ * Billable minutes are ceil(audioSeconds / 60), minimum 1.
+ */
+export const DIRECTOR_USDC6_PER_AUDIO_MINUTE_RETAIL = INTERVAL_COST_RETAIL_USDC6 / 5
+
+/** Creative Director premium rate ($0.125 / 5 min ⇒ $0.025 / min). */
+export const DIRECTOR_USDC6_PER_AUDIO_MINUTE_PREMIUM = INTERVAL_COST_PREMIUM_USDC6 / 5

--- a/src/features/editor/deps/credits-contract.ts
+++ b/src/features/editor/deps/credits-contract.ts
@@ -1,0 +1,4 @@
+/**
+ * Cross-feature dependency contract: credits / CRTVAI balance.
+ */
+export { useCredits } from '@/features/credits/hooks/use-credits'

--- a/src/features/editor/director/build-director-payment.ts
+++ b/src/features/editor/director/build-director-payment.ts
@@ -1,0 +1,37 @@
+/**
+ * Build a CRTVAI transfer UserOp paying the Director invoice to the treasury.
+ */
+
+import { encodeFunctionData, type Address, type Hex } from 'viem'
+import {
+  CRTVAI_DIAMOND_ADDRESS,
+  METOKEN_ERC20_ABI,
+  getSuperfluidReceiverAddress,
+} from '@/config/metoken'
+import type { SmartWalletOp } from '@/hooks/use-smart-wallet-ops'
+
+export function getDirectorTreasuryAddress(): Address | undefined {
+  return getSuperfluidReceiverAddress()
+}
+
+export function buildDirectorPaymentOp(amountWei: bigint): SmartWalletOp {
+  const treasury = getDirectorTreasuryAddress()
+  if (!treasury) {
+    throw new Error('Director treasury not configured (VITE_SUPERFLUID_RECEIVER)')
+  }
+  if (amountWei <= 0n) {
+    throw new Error('Director payment amount must be positive')
+  }
+
+  const data = encodeFunctionData({
+    abi: METOKEN_ERC20_ABI,
+    functionName: 'transfer',
+    args: [treasury, amountWei],
+  }) as Hex
+
+  return {
+    target: CRTVAI_DIAMOND_ADDRESS,
+    data,
+    value: 0n,
+  }
+}

--- a/src/features/editor/director/confirm-director-invoice.ts
+++ b/src/features/editor/director/confirm-director-invoice.ts
@@ -1,0 +1,51 @@
+/**
+ * Settle a Director invoice: optional on-chain CRTVAI transfer, then stream.
+ */
+
+import { buildDirectorPaymentOp } from './build-director-payment'
+import type { PendingDirectorInvoice } from './director-invoice-card'
+import type { SmartWalletOp } from '@/hooks/use-smart-wallet-ops'
+
+export interface ConfirmDirectorInvoiceArgs {
+  invoice: PendingDirectorInvoice
+  balance: number
+  canPayOnChain: boolean
+  account?: string
+  sendOps: (ops: SmartWalletOp[]) => Promise<{ txHash: string }>
+  refreshBalance: () => void
+  submit: (
+    text: string,
+    options?: {
+      apiPrompt?: string
+      audioUri?: string
+      audioDurationSeconds?: number
+      paymentTxHash?: string
+      walletAddress?: string
+    },
+  ) => Promise<void>
+}
+
+// fallow-ignore-next-line complexity
+export async function confirmDirectorInvoice(args: ConfirmDirectorInvoiceArgs): Promise<void> {
+  const { invoice, balance, canPayOnChain, account, sendOps, refreshBalance, submit } = args
+  const { brief, apiPrompt, audioUri, quote } = invoice
+
+  if (balance < quote.crtvaiDisplay) {
+    throw new Error('Insufficient CRTVAI balance for this Director invoice.')
+  }
+
+  let paymentTxHash: string | undefined
+  if (canPayOnChain) {
+    const { txHash } = await sendOps([buildDirectorPaymentOp(quote.crtvaiWei)])
+    paymentTxHash = txHash
+    refreshBalance()
+  }
+
+  await submit(brief, {
+    apiPrompt,
+    ...(audioUri ? { audioUri } : {}),
+    audioDurationSeconds: quote.audioDurationSeconds,
+    ...(paymentTxHash ? { paymentTxHash } : {}),
+    ...(account ? { walletAddress: account } : {}),
+  })
+}

--- a/src/features/editor/director/director-chat-panel.tsx
+++ b/src/features/editor/director/director-chat-panel.tsx
@@ -11,8 +11,10 @@ import {
   useTimelineSettingsStore,
 } from '@/features/editor/deps/timeline-store-contract'
 import { useSmartWalletOps } from '@/hooks/use-smart-wallet-ops'
-import { buildDirectorPaymentOp, getDirectorTreasuryAddress } from './build-director-payment'
-import { quoteDirectorBrief, type DirectorQuote } from './director-pricing'
+import { getDirectorTreasuryAddress } from './build-director-payment'
+import { confirmDirectorInvoice } from './confirm-director-invoice'
+import { quoteDirectorBrief } from './director-pricing'
+import { DirectorInvoiceCard, type PendingDirectorInvoice } from './director-invoice-card'
 import { useDirectorStore } from './director-store'
 import {
   buildDirectorTimelineAudioContext,
@@ -38,13 +40,6 @@ const SUGGESTIONS: { key: string; text: string; label: string }[] = [
   },
 ]
 
-interface PendingInvoice {
-  brief: string
-  apiPrompt: string
-  audioUri?: string
-  quote: DirectorQuote
-}
-
 function statusLabel(
   phase: string,
   streamingText: string,
@@ -52,9 +47,7 @@ function statusLabel(
   paying: boolean,
   t: (key: string, opts?: { defaultValue: string }) => string,
 ): string {
-  if (paying) {
-    return t('director.status.paying', { defaultValue: 'Paying' })
-  }
+  if (paying) return t('director.status.paying', { defaultValue: 'Paying' })
   if (phase === 'streaming' && runningTools > 0) {
     return t('director.status.working', { defaultValue: 'Working' })
   }
@@ -127,121 +120,7 @@ function DirectorMessage({
   )
 }
 
-function DirectorInvoiceCard({
-  invoice,
-  balance,
-  canPayOnChain,
-  paying,
-  onConfirm,
-  onCancel,
-  t,
-}: {
-  invoice: PendingInvoice
-  balance: number
-  canPayOnChain: boolean
-  paying: boolean
-  onConfirm: () => void
-  onCancel: () => void
-  t: (key: string, opts?: { defaultValue: string; [key: string]: string | number }) => string
-}) {
-  const { quote } = invoice
-  const insufficient = balance < quote.crtvaiDisplay
-
-  return (
-    <div className="rounded-xl border border-primary/35 bg-secondary/30 p-3.5">
-      <p className="font-mono text-[10px] tracking-[0.18em] text-primary/85 uppercase">
-        {t('director.invoice.eyebrow', { defaultValue: 'Invoice' })}
-      </p>
-      <h4 className="mt-1 text-[14px] font-semibold tracking-tight text-foreground">
-        {t('director.invoice.title', { defaultValue: 'Confirm Director brief' })}
-      </h4>
-      <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
-        {t('director.invoice.blurb', {
-          defaultValue:
-            'Charged in CRTVAI from your wallet before generation. Price is per minute of timeline audio.',
-        })}
-      </p>
-
-      <dl className="mt-3 space-y-1.5 font-mono text-[11px]">
-        <div className="flex justify-between gap-3">
-          <dt className="text-muted-foreground">Audio</dt>
-          <dd className="text-foreground">
-            {quote.audioDurationSeconds.toFixed(1)}s · {quote.billableMinutes} min
-          </dd>
-        </div>
-        <div className="flex justify-between gap-3">
-          <dt className="text-muted-foreground">Rate</dt>
-          <dd className="text-foreground">
-            {(quote.usdc6PerMinute / 1_000_000).toFixed(2)} USD / min
-          </dd>
-        </div>
-        <div className="flex justify-between gap-3 border-t border-border/60 pt-1.5">
-          <dt className="text-muted-foreground">Due</dt>
-          <dd className="font-semibold text-foreground">
-            {quote.crtvaiDisplay.toFixed(quote.crtvaiDisplay < 1 ? 3 : 2)} CRTVAI
-            <span className="ml-1.5 font-normal text-muted-foreground">({quote.formattedUsd})</span>
-          </dd>
-        </div>
-        <div className="flex justify-between gap-3">
-          <dt className="text-muted-foreground">Balance</dt>
-          <dd className={cn(insufficient ? 'text-destructive' : 'text-foreground')}>
-            {balance.toFixed(2)} CRTVAI
-          </dd>
-        </div>
-      </dl>
-
-      {insufficient && (
-        <p className="mt-2 text-[11px] text-destructive">
-          {t('director.invoice.insufficient', {
-            defaultValue: 'Insufficient CRTVAI. Buy credits, then confirm again.',
-          })}
-        </p>
-      )}
-
-      {!canPayOnChain && (
-        <p className="mt-2 text-[11px] text-amber-200/90">
-          {t('director.invoice.softPay', {
-            defaultValue:
-              'Treasury not configured — balance is checked, on-chain charge is skipped in this environment.',
-          })}
-        </p>
-      )}
-
-      <div className="mt-3 flex items-center justify-end gap-2">
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="h-8 text-[11px]"
-          disabled={paying}
-          onClick={onCancel}
-        >
-          {t('director.invoice.cancel', { defaultValue: 'Cancel' })}
-        </Button>
-        <Button
-          type="button"
-          size="sm"
-          className="h-8 text-[11px]"
-          disabled={paying || insufficient}
-          onClick={onConfirm}
-        >
-          {paying ? (
-            <>
-              <Loader2 className="mr-1.5 h-3 w-3 animate-spin" />
-              {t('director.invoice.paying', { defaultValue: 'Paying…' })}
-            </>
-          ) : (
-            t('director.invoice.confirm', {
-              defaultValue: 'Pay {{amount}} CRTVAI',
-              amount: quote.crtvaiDisplay.toFixed(quote.crtvaiDisplay < 1 ? 3 : 2),
-            })
-          )}
-        </Button>
-      </div>
-    </div>
-  )
-}
-
+// fallow-ignore-next-line complexity
 export const DirectorChatPanel = memo(function DirectorChatPanel() {
   const { t } = useTranslation()
   const reduceMotion = useReducedMotion()
@@ -257,8 +136,7 @@ export const DirectorChatPanel = memo(function DirectorChatPanel() {
   const { account, connect, authenticated, configured: walletConfigured } = useWalletContext()
   const { balance, refreshBalance } = useCredits()
   const { sendOps, ready: walletOpsReady } = useSmartWalletOps()
-  const treasury = getDirectorTreasuryAddress()
-  const canPayOnChain = Boolean(treasury && walletOpsReady)
+  const canPayOnChain = Boolean(getDirectorTreasuryAddress() && walletOpsReady)
 
   const timelineItems = useItemsStore((s) => s.items)
   const fps = useTimelineSettingsStore((s) => s.fps)
@@ -269,7 +147,7 @@ export const DirectorChatPanel = memo(function DirectorChatPanel() {
   const hasTimelineAudio = audioContext.hasAudio
 
   const [input, setInput] = useState('')
-  const [pendingInvoice, setPendingInvoice] = useState<PendingInvoice | null>(null)
+  const [pendingInvoice, setPendingInvoice] = useState<PendingDirectorInvoice | null>(null)
   const [paying, setPaying] = useState(false)
   const scrollRef = useRef<HTMLDivElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -343,34 +221,18 @@ export const DirectorChatPanel = memo(function DirectorChatPanel() {
 
   const confirmInvoice = useCallback(async () => {
     if (!pendingInvoice || paying) return
-    const { brief, apiPrompt, audioUri, quote } = pendingInvoice
-
-    if (balance < quote.crtvaiDisplay) {
-      reportLocalError(
-        t('director.error.insufficientCrtvai', {
-          defaultValue: 'Insufficient CRTVAI balance for this Director invoice.',
-        }),
-      )
-      return
-    }
-
     setPaying(true)
     try {
-      let paymentTxHash: string | undefined
-      if (canPayOnChain) {
-        const { txHash } = await sendOps([buildDirectorPaymentOp(quote.crtvaiWei)])
-        paymentTxHash = txHash
-        refreshBalance()
-      }
-
-      setPendingInvoice(null)
-      await submit(brief, {
-        apiPrompt,
-        ...(audioUri ? { audioUri } : {}),
-        audioDurationSeconds: quote.audioDurationSeconds,
-        ...(paymentTxHash ? { paymentTxHash } : {}),
-        ...(account ? { walletAddress: account } : {}),
+      await confirmDirectorInvoice({
+        invoice: pendingInvoice,
+        balance,
+        canPayOnChain,
+        account,
+        sendOps,
+        refreshBalance,
+        submit,
       })
+      setPendingInvoice(null)
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Payment failed'
       reportLocalError(message)
@@ -387,7 +249,6 @@ export const DirectorChatPanel = memo(function DirectorChatPanel() {
     reportLocalError,
     sendOps,
     submit,
-    t,
   ])
 
   const handleKeyDown = useCallback(
@@ -438,9 +299,7 @@ export const DirectorChatPanel = memo(function DirectorChatPanel() {
           </div>
           <p className="truncate text-[11px] text-muted-foreground">
             {paying
-              ? t('director.identity.paying', {
-                  defaultValue: 'Confirming CRTVAI payment…',
-                })
+              ? t('director.identity.paying', { defaultValue: 'Confirming CRTVAI payment…' })
               : phase !== 'idle'
                 ? t('director.identity.busy', {
                     defaultValue: 'Planning against Vertex Agent Engine…',
@@ -490,9 +349,7 @@ export const DirectorChatPanel = memo(function DirectorChatPanel() {
                   {t('director.empty.eyebrow', { defaultValue: 'Session' })}
                 </p>
                 <h3 className="text-[22px] leading-tight font-semibold tracking-tight text-foreground">
-                  {t('director.empty.title', {
-                    defaultValue: 'Brief the Director',
-                  })}
+                  {t('director.empty.title', { defaultValue: 'Brief the Director' })}
                 </h3>
                 <p className="max-w-[22rem] text-[12px] leading-relaxed text-muted-foreground">
                   {hasTimelineAudio
@@ -618,9 +475,7 @@ export const DirectorChatPanel = memo(function DirectorChatPanel() {
             disabled={Boolean(pendingInvoice) || paying}
             placeholder={
               hasTimelineAudio
-                ? t('director.composer.placeholder', {
-                    defaultValue: 'Brief the Director…',
-                  })
+                ? t('director.composer.placeholder', { defaultValue: 'Brief the Director…' })
                 : t('director.composer.placeholderNeedsAudio', {
                     defaultValue: 'Add timeline audio first…',
                   })

--- a/src/features/editor/director/director-chat-panel.tsx
+++ b/src/features/editor/director/director-chat-panel.tsx
@@ -1,10 +1,24 @@
-import { memo, useCallback, useEffect, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
 import { Clapperboard, Loader2, Send, Square, Trash2, Wrench } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/shared/ui/cn'
+import { useWalletContext } from '@/context/wallet-context'
+import { useCredits } from '@/features/editor/deps/credits-contract'
+import {
+  useItemsStore,
+  useTimelineSettingsStore,
+} from '@/features/editor/deps/timeline-store-contract'
+import { useSmartWalletOps } from '@/hooks/use-smart-wallet-ops'
+import { buildDirectorPaymentOp, getDirectorTreasuryAddress } from './build-director-payment'
+import { quoteDirectorBrief, type DirectorQuote } from './director-pricing'
 import { useDirectorStore } from './director-store'
+import {
+  buildDirectorTimelineAudioContext,
+  formatTimelineAudioForPrompt,
+  publicAudioUriForDirector,
+} from './timeline-audio'
 
 const SUGGESTIONS: { key: string; text: string; label: string }[] = [
   {
@@ -24,12 +38,23 @@ const SUGGESTIONS: { key: string; text: string; label: string }[] = [
   },
 ]
 
+interface PendingInvoice {
+  brief: string
+  apiPrompt: string
+  audioUri?: string
+  quote: DirectorQuote
+}
+
 function statusLabel(
   phase: string,
   streamingText: string,
   runningTools: number,
+  paying: boolean,
   t: (key: string, opts?: { defaultValue: string }) => string,
 ): string {
+  if (paying) {
+    return t('director.status.paying', { defaultValue: 'Paying' })
+  }
   if (phase === 'streaming' && runningTools > 0) {
     return t('director.status.working', { defaultValue: 'Working' })
   }
@@ -102,6 +127,121 @@ function DirectorMessage({
   )
 }
 
+function DirectorInvoiceCard({
+  invoice,
+  balance,
+  canPayOnChain,
+  paying,
+  onConfirm,
+  onCancel,
+  t,
+}: {
+  invoice: PendingInvoice
+  balance: number
+  canPayOnChain: boolean
+  paying: boolean
+  onConfirm: () => void
+  onCancel: () => void
+  t: (key: string, opts?: { defaultValue: string; [key: string]: string | number }) => string
+}) {
+  const { quote } = invoice
+  const insufficient = balance < quote.crtvaiDisplay
+
+  return (
+    <div className="rounded-xl border border-primary/35 bg-secondary/30 p-3.5">
+      <p className="font-mono text-[10px] tracking-[0.18em] text-primary/85 uppercase">
+        {t('director.invoice.eyebrow', { defaultValue: 'Invoice' })}
+      </p>
+      <h4 className="mt-1 text-[14px] font-semibold tracking-tight text-foreground">
+        {t('director.invoice.title', { defaultValue: 'Confirm Director brief' })}
+      </h4>
+      <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
+        {t('director.invoice.blurb', {
+          defaultValue:
+            'Charged in CRTVAI from your wallet before generation. Price is per minute of timeline audio.',
+        })}
+      </p>
+
+      <dl className="mt-3 space-y-1.5 font-mono text-[11px]">
+        <div className="flex justify-between gap-3">
+          <dt className="text-muted-foreground">Audio</dt>
+          <dd className="text-foreground">
+            {quote.audioDurationSeconds.toFixed(1)}s · {quote.billableMinutes} min
+          </dd>
+        </div>
+        <div className="flex justify-between gap-3">
+          <dt className="text-muted-foreground">Rate</dt>
+          <dd className="text-foreground">
+            {(quote.usdc6PerMinute / 1_000_000).toFixed(2)} USD / min
+          </dd>
+        </div>
+        <div className="flex justify-between gap-3 border-t border-border/60 pt-1.5">
+          <dt className="text-muted-foreground">Due</dt>
+          <dd className="font-semibold text-foreground">
+            {quote.crtvaiDisplay.toFixed(quote.crtvaiDisplay < 1 ? 3 : 2)} CRTVAI
+            <span className="ml-1.5 font-normal text-muted-foreground">({quote.formattedUsd})</span>
+          </dd>
+        </div>
+        <div className="flex justify-between gap-3">
+          <dt className="text-muted-foreground">Balance</dt>
+          <dd className={cn(insufficient ? 'text-destructive' : 'text-foreground')}>
+            {balance.toFixed(2)} CRTVAI
+          </dd>
+        </div>
+      </dl>
+
+      {insufficient && (
+        <p className="mt-2 text-[11px] text-destructive">
+          {t('director.invoice.insufficient', {
+            defaultValue: 'Insufficient CRTVAI. Buy credits, then confirm again.',
+          })}
+        </p>
+      )}
+
+      {!canPayOnChain && (
+        <p className="mt-2 text-[11px] text-amber-200/90">
+          {t('director.invoice.softPay', {
+            defaultValue:
+              'Treasury not configured — balance is checked, on-chain charge is skipped in this environment.',
+          })}
+        </p>
+      )}
+
+      <div className="mt-3 flex items-center justify-end gap-2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-8 text-[11px]"
+          disabled={paying}
+          onClick={onCancel}
+        >
+          {t('director.invoice.cancel', { defaultValue: 'Cancel' })}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          className="h-8 text-[11px]"
+          disabled={paying || insufficient}
+          onClick={onConfirm}
+        >
+          {paying ? (
+            <>
+              <Loader2 className="mr-1.5 h-3 w-3 animate-spin" />
+              {t('director.invoice.paying', { defaultValue: 'Paying…' })}
+            </>
+          ) : (
+            t('director.invoice.confirm', {
+              defaultValue: 'Pay {{amount}} CRTVAI',
+              amount: quote.crtvaiDisplay.toFixed(quote.crtvaiDisplay < 1 ? 3 : 2),
+            })
+          )}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
 export const DirectorChatPanel = memo(function DirectorChatPanel() {
   const { t } = useTranslation()
   const reduceMotion = useReducedMotion()
@@ -110,20 +250,37 @@ export const DirectorChatPanel = memo(function DirectorChatPanel() {
   const streamingText = useDirectorStore((s) => s.streamingText)
   const toolCalls = useDirectorStore((s) => s.toolCalls)
   const submit = useDirectorStore((s) => s.submit)
+  const reportLocalError = useDirectorStore((s) => s.reportLocalError)
   const cancel = useDirectorStore((s) => s.cancel)
   const clearChat = useDirectorStore((s) => s.clearChat)
 
+  const { account, connect, authenticated, configured: walletConfigured } = useWalletContext()
+  const { balance, refreshBalance } = useCredits()
+  const { sendOps, ready: walletOpsReady } = useSmartWalletOps()
+  const treasury = getDirectorTreasuryAddress()
+  const canPayOnChain = Boolean(treasury && walletOpsReady)
+
+  const timelineItems = useItemsStore((s) => s.items)
+  const fps = useTimelineSettingsStore((s) => s.fps)
+  const audioContext = useMemo(
+    () => buildDirectorTimelineAudioContext(timelineItems, fps),
+    [timelineItems, fps],
+  )
+  const hasTimelineAudio = audioContext.hasAudio
+
   const [input, setInput] = useState('')
+  const [pendingInvoice, setPendingInvoice] = useState<PendingInvoice | null>(null)
+  const [paying, setPaying] = useState(false)
   const scrollRef = useRef<HTMLDivElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
-  const busy = phase !== 'idle'
+  const busy = phase !== 'idle' || paying || pendingInvoice !== null
   const runningTools = toolCalls.filter((call) => call.status === 'running')
-  const isEmpty = messages.length === 0 && phase === 'idle'
-  const status = statusLabel(phase, streamingText, runningTools.length, t)
+  const isEmpty = messages.length === 0 && phase === 'idle' && !pendingInvoice
+  const status = statusLabel(phase, streamingText, runningTools.length, paying, t)
 
   useEffect(() => {
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight })
-  }, [messages, phase, streamingText, toolCalls])
+  }, [messages, phase, streamingText, toolCalls, pendingInvoice, paying])
 
   useEffect(() => {
     const el = textareaRef.current
@@ -132,29 +289,119 @@ export const DirectorChatPanel = memo(function DirectorChatPanel() {
     el.style.height = `${Math.min(el.scrollHeight, 112)}px`
   }, [input])
 
-  const send = useCallback(
+  const queueInvoice = useCallback(
     (text: string) => {
       const trimmed = text.trim()
       if (!trimmed) return
+      if (!hasTimelineAudio || !audioContext.primary) {
+        reportLocalError(
+          t('director.error.noTimelineAudio', {
+            defaultValue:
+              'Add an audio clip (or unmuted video) to the timeline before briefing the Director. Beat-synced storyboards need a track on the timeline.',
+          }),
+        )
+        return
+      }
+
+      if (walletConfigured && !authenticated) {
+        connect()
+        reportLocalError(
+          t('director.error.connectWallet', {
+            defaultValue: 'Connect your wallet to pay for the Director in CRTVAI.',
+          }),
+        )
+        return
+      }
+
+      const quote = quoteDirectorBrief({
+        audioDurationSeconds: audioContext.primary.durationSeconds,
+      })
+      if (!quote) {
+        reportLocalError(
+          t('director.error.noQuote', {
+            defaultValue: 'Could not price this brief from timeline audio.',
+          }),
+        )
+        return
+      }
+
       setInput('')
-      void submit(trimmed)
+      setPendingInvoice({
+        brief: trimmed,
+        apiPrompt: `${trimmed}\n\n${formatTimelineAudioForPrompt(audioContext)}`,
+        audioUri: publicAudioUriForDirector(audioContext.primary.src),
+        quote,
+      })
     },
-    [submit],
+    [audioContext, authenticated, connect, hasTimelineAudio, reportLocalError, t, walletConfigured],
   )
+
+  const cancelInvoice = useCallback(() => {
+    setPendingInvoice(null)
+    setPaying(false)
+  }, [])
+
+  const confirmInvoice = useCallback(async () => {
+    if (!pendingInvoice || paying) return
+    const { brief, apiPrompt, audioUri, quote } = pendingInvoice
+
+    if (balance < quote.crtvaiDisplay) {
+      reportLocalError(
+        t('director.error.insufficientCrtvai', {
+          defaultValue: 'Insufficient CRTVAI balance for this Director invoice.',
+        }),
+      )
+      return
+    }
+
+    setPaying(true)
+    try {
+      let paymentTxHash: string | undefined
+      if (canPayOnChain) {
+        const { txHash } = await sendOps([buildDirectorPaymentOp(quote.crtvaiWei)])
+        paymentTxHash = txHash
+        refreshBalance()
+      }
+
+      setPendingInvoice(null)
+      await submit(brief, {
+        apiPrompt,
+        ...(audioUri ? { audioUri } : {}),
+        audioDurationSeconds: quote.audioDurationSeconds,
+        ...(paymentTxHash ? { paymentTxHash } : {}),
+        ...(account ? { walletAddress: account } : {}),
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Payment failed'
+      reportLocalError(message)
+    } finally {
+      setPaying(false)
+    }
+  }, [
+    account,
+    balance,
+    canPayOnChain,
+    paying,
+    pendingInvoice,
+    refreshBalance,
+    reportLocalError,
+    sendOps,
+    submit,
+    t,
+  ])
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
       if (event.key === 'Enter' && !event.shiftKey) {
         event.preventDefault()
-        if (!busy) send(input)
+        if (!busy) queueInvoice(input)
       }
     },
-    [busy, input, send],
+    [busy, input, queueInvoice],
   )
 
   return (
     <div className="relative flex h-full min-h-0 flex-col overflow-hidden">
-      {/* Atmosphere — editorial dark, warm primary bleed */}
       <div
         aria-hidden
         className="pointer-events-none absolute inset-0 bg-[radial-gradient(120%_80%_at_50%_-10%,oklch(0.68_0.19_45_/_0.14),transparent_55%),linear-gradient(180deg,oklch(0.14_0_0)_0%,oklch(0.12_0_0)_100%)]"
@@ -164,15 +411,18 @@ export const DirectorChatPanel = memo(function DirectorChatPanel() {
         className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/50 to-transparent"
       />
 
-      {/* Agent identity */}
       <header className="relative z-10 flex shrink-0 items-center gap-3 border-b border-border/60 px-3 py-2.5">
         <div className="relative flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-primary/35 bg-primary/10">
           <Clapperboard className="h-4 w-4 text-primary" strokeWidth={1.75} />
           <span
             className={cn(
               'absolute -right-0.5 -bottom-0.5 h-2.5 w-2.5 rounded-full border-2 border-[oklch(0.14_0_0)]',
-              busy ? 'bg-primary' : 'bg-emerald-400/90',
-              busy && !reduceMotion && 'animate-pulse',
+              phase !== 'idle' || paying
+                ? 'bg-primary'
+                : hasTimelineAudio
+                  ? 'bg-emerald-400/90'
+                  : 'bg-amber-400/90',
+              (phase !== 'idle' || paying) && !reduceMotion && 'animate-pulse',
             )}
             aria-hidden
           />
@@ -187,13 +437,21 @@ export const DirectorChatPanel = memo(function DirectorChatPanel() {
             </span>
           </div>
           <p className="truncate text-[11px] text-muted-foreground">
-            {busy
-              ? t('director.identity.busy', {
-                  defaultValue: 'Planning against Vertex Agent Engine…',
+            {paying
+              ? t('director.identity.paying', {
+                  defaultValue: 'Confirming CRTVAI payment…',
                 })
-              : t('director.identity.idle', {
-                  defaultValue: 'Beat-synced storyboards · research only',
-                })}
+              : phase !== 'idle'
+                ? t('director.identity.busy', {
+                    defaultValue: 'Planning against Vertex Agent Engine…',
+                  })
+                : hasTimelineAudio
+                  ? t('director.identity.idleWithAudio', {
+                      defaultValue: 'Timeline audio ready · priced per audio minute',
+                    })
+                  : t('director.identity.idleNeedsAudio', {
+                      defaultValue: 'Place audio on the timeline to unlock the Director',
+                    })}
           </p>
         </div>
         {messages.length > 0 && (
@@ -201,8 +459,11 @@ export const DirectorChatPanel = memo(function DirectorChatPanel() {
             variant="ghost"
             size="icon"
             className="h-8 w-8 shrink-0 text-muted-foreground"
-            onClick={clearChat}
-            disabled={busy}
+            onClick={() => {
+              cancelInvoice()
+              clearChat()
+            }}
+            disabled={phase !== 'idle' || paying}
             aria-label={t('director.clear', { defaultValue: 'Clear session' })}
           >
             <Trash2 className="h-3.5 w-3.5" />
@@ -210,7 +471,6 @@ export const DirectorChatPanel = memo(function DirectorChatPanel() {
         )}
       </header>
 
-      {/* Transcript */}
       <div
         ref={scrollRef}
         className="relative z-10 min-h-0 flex-1 space-y-4 overflow-y-auto px-3 py-4"
@@ -235,10 +495,15 @@ export const DirectorChatPanel = memo(function DirectorChatPanel() {
                   })}
                 </h3>
                 <p className="max-w-[22rem] text-[12px] leading-relaxed text-muted-foreground">
-                  {t('director.empty.intro', {
-                    defaultValue:
-                      'Describe the cut you want. The Director streams research and storyboards live — timeline edits stay yours.',
-                  })}
+                  {hasTimelineAudio
+                    ? t('director.empty.intro', {
+                        defaultValue:
+                          'Describe the cut you want. You’ll see a CRTVAI invoice priced by timeline audio minutes before generation starts.',
+                      })
+                    : t('director.empty.introNeedsAudio', {
+                        defaultValue:
+                          'Drop a track onto the timeline first. The Director builds beat-synced storyboards from audio already in your edit.',
+                      })}
                 </p>
               </div>
 
@@ -256,8 +521,14 @@ export const DirectorChatPanel = memo(function DirectorChatPanel() {
                   >
                     <button
                       type="button"
-                      onClick={() => send(suggestion.text)}
-                      className="group flex w-full items-center gap-3 rounded-md border border-border/70 bg-secondary/20 px-3 py-2.5 text-left transition-colors hover:border-primary/40 hover:bg-primary/5"
+                      onClick={() => queueInvoice(suggestion.text)}
+                      disabled={!hasTimelineAudio || busy}
+                      className={cn(
+                        'group flex w-full items-center gap-3 rounded-md border border-border/70 bg-secondary/20 px-3 py-2.5 text-left transition-colors',
+                        hasTimelineAudio
+                          ? 'hover:border-primary/40 hover:bg-primary/5'
+                          : 'cursor-not-allowed opacity-45',
+                      )}
                     >
                       <span className="font-mono text-[10px] text-muted-foreground tabular-nums group-hover:text-primary">
                         {String(index + 1).padStart(2, '0')}
@@ -281,6 +552,18 @@ export const DirectorChatPanel = memo(function DirectorChatPanel() {
         {messages.map((message) => (
           <DirectorMessage key={message.id} role={message.role} content={message.content} />
         ))}
+
+        {pendingInvoice && (
+          <DirectorInvoiceCard
+            invoice={pendingInvoice}
+            balance={balance}
+            canPayOnChain={canPayOnChain}
+            paying={paying}
+            onConfirm={() => void confirmInvoice()}
+            onCancel={cancelInvoice}
+            t={t}
+          />
+        )}
 
         {phase === 'streaming' && streamingText && (
           <div className="flex justify-start gap-2.5">
@@ -320,7 +603,6 @@ export const DirectorChatPanel = memo(function DirectorChatPanel() {
         )}
       </div>
 
-      {/* Composer */}
       <div className="relative z-10 shrink-0 border-t border-border/60 bg-[oklch(0.13_0_0_/_0.85)] px-3 py-2.5 backdrop-blur-sm">
         <label className="sr-only" htmlFor="director-prompt">
           {t('director.composer.placeholder', { defaultValue: 'Brief the Director…' })}
@@ -333,10 +615,17 @@ export const DirectorChatPanel = memo(function DirectorChatPanel() {
             onChange={(event) => setInput(event.target.value)}
             onKeyDown={handleKeyDown}
             rows={1}
-            placeholder={t('director.composer.placeholder', {
-              defaultValue: 'Brief the Director…',
-            })}
-            className="max-h-28 min-h-[2.5rem] flex-1 resize-none bg-transparent px-2 py-2 text-[12px] leading-relaxed text-foreground outline-none placeholder:text-muted-foreground/70"
+            disabled={Boolean(pendingInvoice) || paying}
+            placeholder={
+              hasTimelineAudio
+                ? t('director.composer.placeholder', {
+                    defaultValue: 'Brief the Director…',
+                  })
+                : t('director.composer.placeholderNeedsAudio', {
+                    defaultValue: 'Add timeline audio first…',
+                  })
+            }
+            className="max-h-28 min-h-[2.5rem] flex-1 resize-none bg-transparent px-2 py-2 text-[12px] leading-relaxed text-foreground outline-none placeholder:text-muted-foreground/70 disabled:opacity-50"
           />
           {phase === 'streaming' ? (
             <Button
@@ -352,8 +641,8 @@ export const DirectorChatPanel = memo(function DirectorChatPanel() {
             <Button
               size="icon"
               className="h-9 w-9 shrink-0 rounded-lg"
-              disabled={busy || !input.trim()}
-              onClick={() => send(input)}
+              disabled={busy || !input.trim() || !hasTimelineAudio}
+              onClick={() => queueInvoice(input)}
               aria-label={t('director.send', { defaultValue: 'Send brief' })}
             >
               <Send className="h-4 w-4" />
@@ -361,9 +650,13 @@ export const DirectorChatPanel = memo(function DirectorChatPanel() {
           )}
         </div>
         <p className="mt-1.5 px-0.5 font-mono text-[10px] tracking-wide text-muted-foreground/80">
-          {t('director.composer.hint', {
-            defaultValue: 'Enter to send · Shift+Enter for newline · display only',
-          })}
+          {hasTimelineAudio
+            ? t('director.composer.hintPaid', {
+                defaultValue: 'Enter queues an invoice · CRTVAI charged per audio minute',
+              })
+            : t('director.composer.hintNeedsAudio', {
+                defaultValue: 'Timeline audio required for beat-synced storyboards',
+              })}
         </p>
       </div>
     </div>

--- a/src/features/editor/director/director-invoice-card.tsx
+++ b/src/features/editor/director/director-invoice-card.tsx
@@ -1,0 +1,126 @@
+import { Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/shared/ui/cn'
+import type { DirectorQuote } from './director-pricing'
+
+export interface PendingDirectorInvoice {
+  brief: string
+  apiPrompt: string
+  audioUri?: string
+  quote: DirectorQuote
+}
+
+export function DirectorInvoiceCard({
+  invoice,
+  balance,
+  canPayOnChain,
+  paying,
+  onConfirm,
+  onCancel,
+  t,
+}: {
+  invoice: PendingDirectorInvoice
+  balance: number
+  canPayOnChain: boolean
+  paying: boolean
+  onConfirm: () => void
+  onCancel: () => void
+  t: (key: string, opts?: { defaultValue: string; [key: string]: string | number }) => string
+}) {
+  const { quote } = invoice
+  const insufficient = balance < quote.crtvaiDisplay
+
+  return (
+    <div className="rounded-xl border border-primary/35 bg-secondary/30 p-3.5">
+      <p className="font-mono text-[10px] tracking-[0.18em] text-primary/85 uppercase">
+        {t('director.invoice.eyebrow', { defaultValue: 'Invoice' })}
+      </p>
+      <h4 className="mt-1 text-[14px] font-semibold tracking-tight text-foreground">
+        {t('director.invoice.title', { defaultValue: 'Confirm Director brief' })}
+      </h4>
+      <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
+        {t('director.invoice.blurb', {
+          defaultValue:
+            'Charged in CRTVAI from your wallet before generation. Price is per minute of timeline audio.',
+        })}
+      </p>
+
+      <dl className="mt-3 space-y-1.5 font-mono text-[11px]">
+        <div className="flex justify-between gap-3">
+          <dt className="text-muted-foreground">Audio</dt>
+          <dd className="text-foreground">
+            {quote.audioDurationSeconds.toFixed(1)}s · {quote.billableMinutes} min
+          </dd>
+        </div>
+        <div className="flex justify-between gap-3">
+          <dt className="text-muted-foreground">Rate</dt>
+          <dd className="text-foreground">
+            {(quote.usdc6PerMinute / 1_000_000).toFixed(2)} USD / min
+          </dd>
+        </div>
+        <div className="flex justify-between gap-3 border-t border-border/60 pt-1.5">
+          <dt className="text-muted-foreground">Due</dt>
+          <dd className="font-semibold text-foreground">
+            {quote.crtvaiDisplay.toFixed(quote.crtvaiDisplay < 1 ? 3 : 2)} CRTVAI
+            <span className="ml-1.5 font-normal text-muted-foreground">({quote.formattedUsd})</span>
+          </dd>
+        </div>
+        <div className="flex justify-between gap-3">
+          <dt className="text-muted-foreground">Balance</dt>
+          <dd className={cn(insufficient ? 'text-destructive' : 'text-foreground')}>
+            {balance.toFixed(2)} CRTVAI
+          </dd>
+        </div>
+      </dl>
+
+      {insufficient && (
+        <p className="mt-2 text-[11px] text-destructive">
+          {t('director.invoice.insufficient', {
+            defaultValue: 'Insufficient CRTVAI. Buy credits, then confirm again.',
+          })}
+        </p>
+      )}
+
+      {!canPayOnChain && (
+        <p className="mt-2 text-[11px] text-amber-200/90">
+          {t('director.invoice.softPay', {
+            defaultValue:
+              'Treasury not configured — balance is checked, on-chain charge is skipped in this environment.',
+          })}
+        </p>
+      )}
+
+      <div className="mt-3 flex items-center justify-end gap-2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-8 text-[11px]"
+          disabled={paying}
+          onClick={onCancel}
+        >
+          {t('director.invoice.cancel', { defaultValue: 'Cancel' })}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          className="h-8 text-[11px]"
+          disabled={paying || insufficient}
+          onClick={onConfirm}
+        >
+          {paying ? (
+            <>
+              <Loader2 className="mr-1.5 h-3 w-3 animate-spin" />
+              {t('director.invoice.paying', { defaultValue: 'Paying…' })}
+            </>
+          ) : (
+            t('director.invoice.confirm', {
+              defaultValue: 'Pay {{amount}} CRTVAI',
+              amount: quote.crtvaiDisplay.toFixed(quote.crtvaiDisplay < 1 ? 3 : 2),
+            })
+          )}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/features/editor/director/director-pricing.test.ts
+++ b/src/features/editor/director/director-pricing.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import {
+  billableAudioMinutes,
+  quoteDirectorBrief,
+  quoteDirectorBriefRetail,
+} from './director-pricing'
+import {
+  DIRECTOR_USDC6_PER_AUDIO_MINUTE_PREMIUM,
+  DIRECTOR_USDC6_PER_AUDIO_MINUTE_RETAIL,
+} from '@/config/billing'
+
+describe('billableAudioMinutes', () => {
+  it('returns 0 for missing audio', () => {
+    expect(billableAudioMinutes(0)).toBe(0)
+    expect(billableAudioMinutes(-1)).toBe(0)
+  })
+
+  it('ceil-rounds partial minutes with a 1-minute floor', () => {
+    expect(billableAudioMinutes(1)).toBe(1)
+    expect(billableAudioMinutes(60)).toBe(1)
+    expect(billableAudioMinutes(61)).toBe(2)
+    expect(billableAudioMinutes(180)).toBe(3)
+  })
+})
+
+describe('quoteDirectorBrief', () => {
+  it('returns null without audio duration', () => {
+    expect(quoteDirectorBrief({ audioDurationSeconds: 0 })).toBeNull()
+  })
+
+  it('prices retail per billable minute of audio', () => {
+    const quote = quoteDirectorBrief({ audioDurationSeconds: 90 })
+    expect(quote).not.toBeNull()
+    expect(quote!.billableMinutes).toBe(2)
+    expect(quote!.tier).toBe('retail')
+    expect(quote!.estimatedUsdc6).toBe(2 * DIRECTOR_USDC6_PER_AUDIO_MINUTE_RETAIL)
+    expect(quote!.formattedUsd).toBe('$0.10')
+    expect(quote!.crtvaiWei).toBeGreaterThan(0n)
+  })
+
+  it('applies premium rate when requested', () => {
+    const quote = quoteDirectorBrief({ audioDurationSeconds: 60, isPremium: true })
+    expect(quote!.tier).toBe('premium')
+    expect(quote!.estimatedUsdc6).toBe(DIRECTOR_USDC6_PER_AUDIO_MINUTE_PREMIUM)
+  })
+
+  it('retail helper ignores premium', () => {
+    const quote = quoteDirectorBriefRetail(60)
+    expect(quote!.estimatedUsdc6).toBe(DIRECTOR_USDC6_PER_AUDIO_MINUTE_RETAIL)
+  })
+})

--- a/src/features/editor/director/director-pricing.ts
+++ b/src/features/editor/director/director-pricing.ts
@@ -1,0 +1,67 @@
+/**
+ * Creative Director pricing — per minute of timeline audio, settled in CRTVAI.
+ *
+ * Ledger / quote amounts stay in usdc6 (USDC × 1e6). Display converts to CRTVAI
+ * via the same usdc6→wei helper used by Live AI (`usdc6ToMetokenWei`).
+ */
+
+import {
+  DIRECTOR_USDC6_PER_AUDIO_MINUTE_PREMIUM,
+  DIRECTOR_USDC6_PER_AUDIO_MINUTE_RETAIL,
+} from '@/config/billing'
+import { usdc6ToMetokenWei } from '@/config/metoken'
+
+export interface DirectorQuoteInput {
+  /** Primary timeline audio duration in seconds. */
+  audioDurationSeconds: number
+  isPremium?: boolean
+}
+
+export interface DirectorQuote {
+  audioDurationSeconds: number
+  /** ceil(seconds/60), minimum 1 when audio is present. */
+  billableMinutes: number
+  usdc6PerMinute: number
+  estimatedUsdc6: number
+  /** CRTVAI amount to transfer (meToken wei, 18 decimals). */
+  crtvaiWei: bigint
+  /** Human CRTVAI amount for invoice UI (approx; 1 CRTVAI ≈ $1 at curve peg helpers). */
+  crtvaiDisplay: number
+  formattedUsd: string
+  tier: 'premium' | 'retail'
+}
+
+/** Whole billable minutes from audio length. Returns 0 when duration is non-positive. */
+export function billableAudioMinutes(audioDurationSeconds: number): number {
+  if (!Number.isFinite(audioDurationSeconds) || audioDurationSeconds <= 0) return 0
+  return Math.max(1, Math.ceil(audioDurationSeconds / 60))
+}
+
+export function quoteDirectorBrief(input: DirectorQuoteInput): DirectorQuote | null {
+  const minutes = billableAudioMinutes(input.audioDurationSeconds)
+  if (minutes <= 0) return null
+
+  const isPremium = input.isPremium === true
+  const usdc6PerMinute = isPremium
+    ? DIRECTOR_USDC6_PER_AUDIO_MINUTE_PREMIUM
+    : DIRECTOR_USDC6_PER_AUDIO_MINUTE_RETAIL
+  const estimatedUsdc6 = minutes * usdc6PerMinute
+  const crtvaiWei = usdc6ToMetokenWei(estimatedUsdc6)
+  const crtvaiDisplay = Number(crtvaiWei) / 1e18
+
+  return {
+    audioDurationSeconds: input.audioDurationSeconds,
+    billableMinutes: minutes,
+    usdc6PerMinute,
+    estimatedUsdc6,
+    crtvaiWei,
+    crtvaiDisplay,
+    formattedUsd: `$${(estimatedUsdc6 / 1_000_000).toFixed(2)}`,
+    tier: isPremium ? 'premium' : 'retail',
+  }
+}
+
+/** Recompute server-side minimum charge (always retail — no client membership trust). */
+export function quoteDirectorBriefRetail(audioDurationSeconds: number): DirectorQuote | null {
+  return quoteDirectorBrief({ audioDurationSeconds, isPremium: false })
+}

--- a/src/features/editor/director/director-store.ts
+++ b/src/features/editor/director/director-store.ts
@@ -31,7 +31,20 @@ interface DirectorState {
   sessionId: string | null
   lastError: string | null
 
-  submit: (text: string, options?: { audioUri?: string; userId?: string }) => Promise<void>
+  submit: (
+    text: string,
+    options?: {
+      audioUri?: string
+      userId?: string
+      /** Full prompt sent to the API (defaults to text) */
+      apiPrompt?: string
+      audioDurationSeconds?: number
+      paymentTxHash?: string
+      walletAddress?: string
+    },
+  ) => Promise<void>
+  /** Local UX error (e.g. missing timeline audio) — does not call the API. */
+  reportLocalError: (message: string) => void
   cancel: () => void
   clearChat: () => void
 }
@@ -176,10 +189,21 @@ export const useDirectorStore = create<DirectorState>((set, get) => ({
   sessionId: null,
   lastError: null,
 
+  reportLocalError: (message) => {
+    const trimmed = message.trim()
+    if (!trimmed || get().phase !== 'idle') return
+    set((state) => ({
+      messages: [...state.messages, { id: newId(), role: 'error', content: trimmed }],
+      lastError: trimmed,
+    }))
+  },
+
   // fallow-ignore-next-line complexity
   submit: async (text, options) => {
     const trimmed = text.trim()
     if (!trimmed || get().phase !== 'idle') return
+    const apiPrompt = (options?.apiPrompt ?? trimmed).trim()
+    if (!apiPrompt) return
 
     const userMessage: DirectorChatMessage = {
       id: newId(),
@@ -205,10 +229,13 @@ export const useDirectorStore = create<DirectorState>((set, get) => ({
           Accept: 'text/event-stream, application/json',
         },
         body: JSON.stringify({
-          prompt: trimmed,
+          prompt: apiPrompt,
           userId: options?.userId,
           sessionId: get().sessionId ?? undefined,
           audioUri: options?.audioUri,
+          audioDurationSeconds: options?.audioDurationSeconds,
+          paymentTxHash: options?.paymentTxHash,
+          walletAddress: options?.walletAddress,
         }),
         signal: controller.signal,
       })

--- a/src/features/editor/director/index.ts
+++ b/src/features/editor/director/index.ts
@@ -3,3 +3,9 @@
  */
 
 export { DirectorChatPanel } from './director-chat-panel'
+export {
+  buildDirectorTimelineAudioContext,
+  formatTimelineAudioForPrompt,
+  getDirectorTimelineAudioContext,
+} from './timeline-audio'
+export { quoteDirectorBrief, billableAudioMinutes } from './director-pricing'

--- a/src/features/editor/director/index.ts
+++ b/src/features/editor/director/index.ts
@@ -3,9 +3,3 @@
  */
 
 export { DirectorChatPanel } from './director-chat-panel'
-export {
-  buildDirectorTimelineAudioContext,
-  formatTimelineAudioForPrompt,
-  getDirectorTimelineAudioContext,
-} from './timeline-audio'
-export { quoteDirectorBrief, billableAudioMinutes } from './director-pricing'

--- a/src/features/editor/director/timeline-audio.test.ts
+++ b/src/features/editor/director/timeline-audio.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildDirectorTimelineAudioContext,
+  formatTimelineAudioForPrompt,
+  publicAudioUriForDirector,
+} from './timeline-audio'
+import type { TimelineItem } from '@/types/timeline'
+
+function audioClip(overrides: Partial<TimelineItem> & { id: string }): TimelineItem {
+  return {
+    type: 'audio',
+    trackId: 'a1',
+    from: 0,
+    durationInFrames: 300,
+    label: 'Track',
+    src: 'blob:http://localhost/audio',
+    ...overrides,
+  } as TimelineItem
+}
+
+function videoClip(overrides: Partial<TimelineItem> & { id: string }): TimelineItem {
+  return {
+    type: 'video',
+    trackId: 'v1',
+    from: 0,
+    durationInFrames: 300,
+    label: 'Clip',
+    src: 'blob:http://localhost/video',
+    ...overrides,
+  } as TimelineItem
+}
+
+describe('buildDirectorTimelineAudioContext', () => {
+  it('reports no audio on an empty timeline', () => {
+    const ctx = buildDirectorTimelineAudioContext([], 30)
+    expect(ctx.hasAudio).toBe(false)
+    expect(ctx.primary).toBeNull()
+  })
+
+  it('detects dedicated audio clips as primary', () => {
+    const ctx = buildDirectorTimelineAudioContext(
+      [
+        videoClip({ id: 'v1', from: 0 }),
+        audioClip({ id: 'a1', from: 10, label: 'Song', mediaId: 'm-song' }),
+      ],
+      30,
+    )
+    expect(ctx.hasAudio).toBe(true)
+    expect(ctx.primary?.itemId).toBe('a1')
+    expect(ctx.primary?.durationSeconds).toBe(10)
+    expect(ctx.clips).toHaveLength(2)
+  })
+
+  it('skips video when a linked audio companion exists', () => {
+    const ctx = buildDirectorTimelineAudioContext(
+      [
+        videoClip({
+          id: 'v1',
+          linkedGroupId: 'g1',
+          mediaId: 'm1',
+        }),
+        audioClip({
+          id: 'a1',
+          linkedGroupId: 'g1',
+          mediaId: 'm1',
+          label: 'Companion',
+        }),
+      ],
+      24,
+    )
+    expect(ctx.clips).toHaveLength(1)
+    expect(ctx.primary?.type).toBe('audio')
+  })
+
+  it('ignores muted video without companion', () => {
+    const ctx = buildDirectorTimelineAudioContext(
+      [videoClip({ id: 'v1', embeddedAudioMuted: true })],
+      30,
+    )
+    expect(ctx.hasAudio).toBe(false)
+  })
+})
+
+describe('formatTimelineAudioForPrompt', () => {
+  it('asks the agent not to invent audio when missing', () => {
+    const text = formatTimelineAudioForPrompt({
+      hasAudio: false,
+      fps: 30,
+      clips: [],
+      primary: null,
+    })
+    expect(text).toContain('NONE')
+    expect(text).toContain('place audio on the timeline')
+  })
+
+  it('includes duration and media id for primary clip', () => {
+    const text = formatTimelineAudioForPrompt({
+      hasAudio: true,
+      fps: 30,
+      clips: [
+        {
+          itemId: 'a1',
+          mediaId: 'm1',
+          label: 'Beat',
+          type: 'audio',
+          fromFrame: 0,
+          durationInFrames: 600,
+          durationSeconds: 20,
+          src: 'blob:x',
+        },
+      ],
+      primary: {
+        itemId: 'a1',
+        mediaId: 'm1',
+        label: 'Beat',
+        type: 'audio',
+        fromFrame: 0,
+        durationInFrames: 600,
+        durationSeconds: 20,
+        src: 'blob:x',
+      },
+    })
+    expect(text).toContain('Beat')
+    expect(text).toContain('20.00s')
+    expect(text).toContain('m1')
+  })
+})
+
+describe('publicAudioUriForDirector', () => {
+  it('only returns http(s) URIs', () => {
+    expect(publicAudioUriForDirector('https://cdn.example/a.mp3')).toBe('https://cdn.example/a.mp3')
+    expect(publicAudioUriForDirector('blob:http://localhost/x')).toBeUndefined()
+    expect(publicAudioUriForDirector(undefined)).toBeUndefined()
+  })
+})

--- a/src/features/editor/director/timeline-audio.ts
+++ b/src/features/editor/director/timeline-audio.ts
@@ -1,0 +1,121 @@
+/**
+ * Read-only timeline audio presence for Creative Director.
+ * Director storyboards assume a beat-synced track already on the timeline.
+ */
+
+import { useItemsStore } from '@/features/editor/deps/timeline-store-contract'
+import { useTimelineSettingsStore } from '@/features/editor/deps/timeline-store-contract'
+import { hasLinkedAudioCompanion } from '@/shared/utils/linked-media'
+import type { AudioItem, TimelineItem, VideoItem } from '@/types/timeline'
+
+export interface DirectorTimelineAudioClip {
+  itemId: string
+  mediaId?: string
+  label: string
+  type: 'audio' | 'video'
+  fromFrame: number
+  durationInFrames: number
+  durationSeconds: number
+  /** Clip playback URL (blob: or https). Remote Agent Engine cannot fetch blob: URLs. */
+  src: string
+}
+
+export interface DirectorTimelineAudioContext {
+  hasAudio: boolean
+  fps: number
+  clips: DirectorTimelineAudioClip[]
+  primary: DirectorTimelineAudioClip | null
+}
+
+function isAudioBearing(items: TimelineItem[], item: TimelineItem): item is AudioItem | VideoItem {
+  if (item.type === 'audio') return true
+  if (item.type === 'video') {
+    // Dedicated audio companion already covers this video's sound.
+    if (hasLinkedAudioCompanion(items, item)) return false
+    return !item.embeddedAudioMuted
+  }
+  return false
+}
+
+function toClip(item: AudioItem | VideoItem, fps: number): DirectorTimelineAudioClip {
+  const durationInFrames = Math.max(0, item.durationInFrames)
+  const src = item.type === 'audio' ? item.src : item.audioSrc?.trim() || item.src
+  return {
+    itemId: item.id,
+    mediaId: item.mediaId,
+    label: item.label || (item.type === 'audio' ? 'Audio' : 'Video'),
+    type: item.type,
+    fromFrame: item.from,
+    durationInFrames,
+    durationSeconds: fps > 0 ? durationInFrames / fps : 0,
+    src,
+  }
+}
+
+/**
+ * Snapshot of audible media currently placed on the timeline.
+ * Prefers dedicated audio clips over video-with-audio for `primary`.
+ */
+export function buildDirectorTimelineAudioContext(
+  items: TimelineItem[],
+  fps: number,
+): DirectorTimelineAudioContext {
+  const safeFps = fps > 0 ? fps : 30
+  const clips = items
+    .filter((item): item is AudioItem | VideoItem => isAudioBearing(items, item))
+    .map((item) => toClip(item, safeFps))
+    .sort((a, b) => a.fromFrame - b.fromFrame)
+
+  const primary =
+    clips.find((clip) => clip.type === 'audio') ??
+    clips.find((clip) => clip.type === 'video') ??
+    null
+
+  return {
+    hasAudio: clips.length > 0,
+    fps: safeFps,
+    clips,
+    primary,
+  }
+}
+
+export function getDirectorTimelineAudioContext(): DirectorTimelineAudioContext {
+  return buildDirectorTimelineAudioContext(
+    useItemsStore.getState().items,
+    useTimelineSettingsStore.getState().fps || 30,
+  )
+}
+
+/** Appends timeline audio facts the remote Director can use without fetching blobs. */
+export function formatTimelineAudioForPrompt(context: DirectorTimelineAudioContext): string {
+  if (!context.hasAudio || !context.primary) {
+    return [
+      'Timeline audio: NONE.',
+      'Do not invent a track. Ask the creator to place audio on the timeline first.',
+    ].join('\n')
+  }
+
+  const lines = [
+    'Timeline audio (already on the Creative Pixels timeline — use this as the beat-sync source):',
+    `- Primary: "${context.primary.label}" (${context.primary.type})`,
+    `- Duration: ${context.primary.durationSeconds.toFixed(2)}s (${context.primary.durationInFrames} frames @ ${context.fps} fps)`,
+    `- Starts at frame ${context.primary.fromFrame}`,
+  ]
+  if (context.primary.mediaId) {
+    lines.push(`- Media id: ${context.primary.mediaId}`)
+  }
+  if (context.clips.length > 1) {
+    lines.push(`- Additional audible clips on timeline: ${context.clips.length - 1}`)
+  }
+  lines.push(
+    'Storyboard timecodes must align to this timeline audio. Do not claim audio is missing.',
+  )
+  return lines.join('\n')
+}
+
+/** https(s) only — blob:/file: URLs are not reachable by Vertex Agent Engine. */
+export function publicAudioUriForDirector(src: string | undefined): string | undefined {
+  if (!src) return undefined
+  if (src.startsWith('https://') || src.startsWith('http://')) return src
+  return undefined
+}

--- a/src/features/editor/director/timeline-audio.ts
+++ b/src/features/editor/director/timeline-audio.ts
@@ -3,8 +3,6 @@
  * Director storyboards assume a beat-synced track already on the timeline.
  */
 
-import { useItemsStore } from '@/features/editor/deps/timeline-store-contract'
-import { useTimelineSettingsStore } from '@/features/editor/deps/timeline-store-contract'
 import { hasLinkedAudioCompanion } from '@/shared/utils/linked-media'
 import type { AudioItem, TimelineItem, VideoItem } from '@/types/timeline'
 
@@ -77,13 +75,6 @@ export function buildDirectorTimelineAudioContext(
     clips,
     primary,
   }
-}
-
-export function getDirectorTimelineAudioContext(): DirectorTimelineAudioContext {
-  return buildDirectorTimelineAudioContext(
-    useItemsStore.getState().items,
-    useTimelineSettingsStore.getState().fps || 30,
-  )
 }
 
 /** Appends timeline audio facts the remote Director can use without fetching blobs. */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,10 @@
-import { defineConfig, lazyPlugins } from 'vite-plus'
+import { defineConfig, lazyPlugins, loadEnv } from 'vite-plus'
 import type { Plugin } from 'vite-plus'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { loadEnv } from 'vite'
 import { POST as directorPost } from './api/director'
 
 // Stamps public/sw.js with the hashed entry-chunk filename at build time so the service
@@ -109,6 +108,7 @@ async function handleDirectorDevRequest(
 function directorApiDevPlugin(): Plugin {
   return {
     name: 'pixels-director-api-dev',
+    // fallow-ignore-next-line complexity
     configureServer(server) {
       // Vite only injects VITE_* by default; Director needs GOOGLE_/VERTEX_/GCP_ from .env.local.
       const mode = server.config.mode || 'development'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import tailwindcss from '@tailwindcss/vite'
 import { readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { loadEnv } from 'vite'
 import { POST as directorPost } from './api/director'
 
 // Stamps public/sw.js with the hashed entry-chunk filename at build time so the service
@@ -109,6 +110,13 @@ function directorApiDevPlugin(): Plugin {
   return {
     name: 'pixels-director-api-dev',
     configureServer(server) {
+      // Vite only injects VITE_* by default; Director needs GOOGLE_/VERTEX_/GCP_ from .env.local.
+      const mode = server.config.mode || 'development'
+      const loaded = loadEnv(mode, server.config.envDir || process.cwd(), '')
+      for (const [key, value] of Object.entries(loaded)) {
+        if (process.env[key] === undefined) process.env[key] = value
+      }
+
       server.middlewares.use((req, res, next) => {
         const path = req.url?.split('?')[0]
         if (req.method !== 'POST' || path !== '/api/director') {


### PR DESCRIPTION
## Summary
- Prefer Application Default Credentials for local `vp dev`; only use Vercel OIDC WIF when `VERCEL` is set (avoids broken auth from `vercel env pull` GCP_* / expired OIDC tokens).
- Point the Creative Director SSE proxy at project `creative-ai-491118`, location `us-central1`, engine `5922098819817799680` (`:streamQuery?alt=sse`).
- Load full `.env.local` (GOOGLE_/VERTEX_/GCP_) in the Vite Director plugin via `loadEnv` from `vite-plus`.

Follow-up to merged #60 (Director SSE wiring).

## Test plan
- [ ] Restart `vp dev` with ADC (`gcloud auth application-default login`)
- [ ] Confirm `.env.local` has `GOOGLE_CLOUD_PROJECT=creative-ai-491118`
- [ ] AI → Director → send a brief; expect SSE text (not “Director not configured”)
- [ ] On Vercel, confirm WIF path still used when `VERCEL=1` and GCP_* are set


Made with [Cursor](https://cursor.com)