### PR TITLE
feat(editor): Flow panel, Director billing harden, responsive shell

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -124,6 +124,30 @@
     {
       "file": "src/features/editor/deps/timeline-store.ts",
       "exports": ["*"]
+    },
+    {
+      "file": "api/director.ts",
+      "exports": ["*"]
+    },
+    {
+      "file": "api/generate-task.ts",
+      "exports": ["*"]
+    },
+    {
+      "file": "api/flow-frame.ts",
+      "exports": ["*"]
+    },
+    {
+      "file": "api/flow-run.ts",
+      "exports": ["*"]
+    },
+    {
+      "file": "api/generate-image.ts",
+      "exports": ["*"]
+    },
+    {
+      "file": "api/generate-video.ts",
+      "exports": ["*"]
     }
   ]
 }

--- a/api/_address.ts
+++ b/api/_address.ts
@@ -1,4 +1,4 @@
-// fallow-ignore-file unused-file
+// fallow-ignore-file unused-export
 /** Wallet address validation — no viem or other heavy deps (safe for lightweight serverless routes). */
 
 export const ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/

--- a/api/_audio-duration.ts
+++ b/api/_audio-duration.ts
@@ -1,0 +1,49 @@
+/**
+ * Probe public audio/video URL duration for Director billing cross-checks.
+ */
+// fallow-ignore-file complexity
+
+import { parseBuffer } from 'music-metadata'
+
+const MAX_PROBE_BYTES = 2 * 1024 * 1024
+const FETCH_TIMEOUT_MS = 12_000
+
+/**
+ * Best-effort duration (seconds) from an https media URL.
+ * Returns null when the URL cannot be fetched or parsed.
+ */
+export async function probeAudioDurationSeconds(audioUri: string): Promise<number | null> {
+  const url = audioUri.trim()
+  if (!/^https:\/\//i.test(url)) return null
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { Range: `bytes=0-${MAX_PROBE_BYTES - 1}` },
+      signal: controller.signal,
+      redirect: 'follow',
+    })
+    if (!(response.ok || response.status === 206)) return null
+
+    const buffer = Buffer.from(await response.arrayBuffer())
+    if (buffer.byteLength < 16) return null
+
+    const mimeType = response.headers.get('content-type') ?? undefined
+    const meta = await parseBuffer(
+      buffer,
+      { mimeType, size: buffer.byteLength },
+      { duration: true },
+    )
+    const duration = meta.format.duration
+    if (typeof duration !== 'number' || !Number.isFinite(duration) || duration <= 0) {
+      return null
+    }
+    return duration
+  } catch {
+    return null
+  } finally {
+    clearTimeout(timer)
+  }
+}

--- a/api/_evolink-server.ts
+++ b/api/_evolink-server.ts
@@ -1,5 +1,4 @@
 /// <reference types="node" />
-// fallow-ignore-file unused-export
 const BASE_URL = 'https://api.evolink.ai/v1'
 
 function getServerApiKey(): string | null {

--- a/api/_metoken-server.ts
+++ b/api/_metoken-server.ts
@@ -1,5 +1,5 @@
 /// <reference types="node" />
-// fallow-ignore-file unused-file,complexity
+// fallow-ignore-file complexity,unused-export
 /**
  * Server-side CRTVAI meToken helpers.
  *

--- a/api/_payment-ledger.ts
+++ b/api/_payment-ledger.ts
@@ -2,6 +2,7 @@
  * One-time consumption of CRTVAI payment tx hashes (anti-replay).
  * Requires Upstash/Vercel KV when billing is enforced.
  */
+// fallow-ignore-file complexity
 
 import { getRedis, isRedisConfigured } from './_redis-client.js'
 

--- a/api/_payment-ledger.ts
+++ b/api/_payment-ledger.ts
@@ -56,6 +56,21 @@ export async function consumePaymentTxHash(
   return { ok: true }
 }
 
+/**
+ * Release a reserved/consumed payment hash so a failed pre-delivery request
+ * can be retried. No-op when Redis is unavailable.
+ */
+export async function releasePaymentTxHash(txHash: string): Promise<void> {
+  const normalized = txHash.trim().toLowerCase()
+  if (!normalized.startsWith('0x') || normalized.length < 66) return
+  if (!isRedisConfigured()) return
+
+  const redis = await getRedis()
+  if (!redis) return
+
+  await redis.del(`${PAYMENT_KEY_PREFIX}${normalized}`)
+}
+
 /** Whether production billing can safely enforce one-time payments. */
 export function isPaymentLedgerReady(): boolean {
   return isRedisConfigured()

--- a/api/_payment-ledger.ts
+++ b/api/_payment-ledger.ts
@@ -1,0 +1,61 @@
+/**
+ * One-time consumption of CRTVAI payment tx hashes (anti-replay).
+ * Requires Upstash/Vercel KV when billing is enforced.
+ */
+
+import { getRedis, isRedisConfigured } from './_redis-client.js'
+
+const PAYMENT_KEY_PREFIX = 'pixels:payment:tx:'
+const PAYMENT_TTL_SECONDS = 60 * 60 * 24 * 14 // 14 days
+
+export type ConsumePaymentResult = { ok: true } | { ok: false; reason: string }
+
+/**
+ * Mark `txHash` as spent. Fails if already consumed.
+ * When Redis is not configured, returns ok only if billing soft/local — callers
+ * that enforce billing should require Redis.
+ */
+export async function consumePaymentTxHash(
+  txHash: string,
+  meta: { wallet: string; purpose: string },
+): Promise<ConsumePaymentResult> {
+  const normalized = txHash.trim().toLowerCase()
+  if (!normalized.startsWith('0x') || normalized.length < 66) {
+    return { ok: false, reason: 'Invalid payment transaction hash' }
+  }
+
+  if (!isRedisConfigured()) {
+    return {
+      ok: false,
+      reason: 'Payment ledger unavailable (configure Upstash/Vercel KV)',
+    }
+  }
+
+  const redis = await getRedis()
+  if (!redis) {
+    return { ok: false, reason: 'Payment ledger unavailable' }
+  }
+
+  const key = `${PAYMENT_KEY_PREFIX}${normalized}`
+  // SET NX — only succeeds the first time
+  const set = await redis.set(
+    key,
+    JSON.stringify({
+      wallet: meta.wallet.toLowerCase(),
+      purpose: meta.purpose,
+      at: Date.now(),
+    }),
+    { nx: true, ex: PAYMENT_TTL_SECONDS },
+  )
+
+  if (set === null) {
+    return { ok: false, reason: 'Payment transaction already used' }
+  }
+
+  return { ok: true }
+}
+
+/** Whether production billing can safely enforce one-time payments. */
+export function isPaymentLedgerReady(): boolean {
+  return isRedisConfigured()
+}

--- a/api/_premium-membership.ts
+++ b/api/_premium-membership.ts
@@ -1,0 +1,67 @@
+/**
+ * Server-side Unlock premium checks for Director billing (mirrors client membership).
+ */
+
+import { createPublicClient, http, parseAbi } from 'viem'
+import { arbitrum, base } from 'viem/chains'
+
+const UNLOCK_HAS_VALID_KEY_ABI = parseAbi(['function getHasValidKey(address) view returns (bool)'])
+
+const UNLOCK_LOCK_ADDRESSES_BASE = [
+  '0x9c3744c96200a52d05a630d4aec0db707d7509be',
+  '0x13b818daf7016b302383737ba60c3a39fef231cf',
+  '0xf7c4cd399395d80f9d61fde833849106775269c6',
+] as const
+
+const PIXELS_PREMIUM_LOCK_DEFAULT = '0xE91BD97247fdAd39B95221BC26795a4a4A01B332'
+
+function alchemyUrl(network: 'base' | 'arbitrum'): string {
+  const key = process.env.ALCHEMY_API_KEY?.trim() || process.env.VITE_ALCHEMY_API_KEY?.trim() || ''
+  if (!key) {
+    return network === 'base' ? 'https://mainnet.base.org' : 'https://arb1.arbitrum.io/rpc'
+  }
+  return network === 'base'
+    ? `https://base-mainnet.g.alchemy.com/v2/${key}`
+    : `https://arb-mainnet.g.alchemy.com/v2/${key}`
+}
+
+function pixelsPremiumLock(): `0x${string}` {
+  const v =
+    process.env.PIXELS_PREMIUM_LOCK_ADDRESS?.trim() ||
+    process.env.VITE_PIXELS_PREMIUM_LOCK_ADDRESS?.trim()
+  if (v?.startsWith('0x') && v.length >= 42) return v as `0x${string}`
+  return PIXELS_PREMIUM_LOCK_DEFAULT
+}
+
+async function hasValidKey(
+  chain: 'base' | 'arbitrum',
+  lock: `0x${string}`,
+  address: `0x${string}`,
+): Promise<boolean> {
+  const client = createPublicClient({
+    chain: chain === 'base' ? base : arbitrum,
+    transport: http(alchemyUrl(chain)),
+  })
+  return client.readContract({
+    address: lock,
+    abi: UNLOCK_HAS_VALID_KEY_ABI,
+    functionName: 'getHasValidKey',
+    args: [address],
+  })
+}
+
+/** True if wallet holds Creative Org DAO key (Base) or Pixels Premium (Arbitrum). */
+export async function isPremiumWallet(address: string): Promise<boolean> {
+  if (!address.startsWith('0x') || address.length < 42) return false
+  const wallet = address.toLowerCase() as `0x${string}`
+
+  try {
+    for (const lock of UNLOCK_LOCK_ADDRESSES_BASE) {
+      if (await hasValidKey('base', lock, wallet)) return true
+    }
+    if (await hasValidKey('arbitrum', pixelsPremiumLock(), wallet)) return true
+  } catch (e) {
+    console.error('premium membership check failed', e)
+  }
+  return false
+}

--- a/api/_premium-membership.ts
+++ b/api/_premium-membership.ts
@@ -1,6 +1,7 @@
 /**
  * Server-side Unlock premium checks for Director billing (mirrors client membership).
  */
+// fallow-ignore-file complexity
 
 import { createPublicClient, http, parseAbi } from 'viem'
 import { arbitrum, base } from 'viem/chains'

--- a/api/_redis-client.ts
+++ b/api/_redis-client.ts
@@ -1,5 +1,5 @@
 /// <reference types="node" />
-// fallow-ignore-file unused-file,complexity
+// fallow-ignore-file complexity
 /**
  * Shared Upstash / Vercel KV Redis client for payment ledgers and task ownership.
  */

--- a/api/_task-registry.ts
+++ b/api/_task-registry.ts
@@ -1,0 +1,50 @@
+/**
+ * Bind Evolink task ids to the paying wallet so poll routes stay private.
+ */
+
+import { getRedis, isRedisConfigured } from './_redis-client.js'
+
+const TASK_KEY_PREFIX = 'pixels:flow:task:'
+const TASK_TTL_SECONDS = 60 * 60 * 24 // 24h
+
+const memoryTasks = new Map<string, { wallet: string; expiresAt: number }>()
+
+export async function registerGenerativeTask(taskId: string, wallet: string): Promise<void> {
+  const id = taskId.trim()
+  const owner = wallet.trim().toLowerCase()
+  if (!id || !owner) return
+
+  if (isRedisConfigured()) {
+    const redis = await getRedis()
+    if (redis) {
+      await redis.set(`${TASK_KEY_PREFIX}${id}`, owner, { ex: TASK_TTL_SECONDS })
+      return
+    }
+  }
+
+  memoryTasks.set(id, {
+    wallet: owner,
+    expiresAt: Date.now() + TASK_TTL_SECONDS * 1000,
+  })
+}
+
+export async function getGenerativeTaskOwner(taskId: string): Promise<string | null> {
+  const id = taskId.trim()
+  if (!id) return null
+
+  if (isRedisConfigured()) {
+    const redis = await getRedis()
+    if (redis) {
+      const owner = await redis.get<string>(`${TASK_KEY_PREFIX}${id}`)
+      return typeof owner === 'string' ? owner.toLowerCase() : null
+    }
+  }
+
+  const entry = memoryTasks.get(id)
+  if (!entry) return null
+  if (entry.expiresAt < Date.now()) {
+    memoryTasks.delete(id)
+    return null
+  }
+  return entry.wallet
+}

--- a/api/_task-registry.ts
+++ b/api/_task-registry.ts
@@ -1,6 +1,7 @@
 /**
  * Bind Evolink task ids to the paying wallet so poll routes stay private.
  */
+// fallow-ignore-file complexity
 
 import { getRedis, isRedisConfigured } from './_redis-client.js'
 

--- a/api/_task-registry.ts
+++ b/api/_task-registry.ts
@@ -1,5 +1,6 @@
 /**
  * Bind Evolink task ids to the paying wallet so poll routes stay private.
+ * Requires Upstash/Vercel KV on Vercel — instance memory is local-dev only.
  */
 // fallow-ignore-file complexity
 
@@ -9,6 +10,10 @@ const TASK_KEY_PREFIX = 'pixels:flow:task:'
 const TASK_TTL_SECONDS = 60 * 60 * 24 // 24h
 
 const memoryTasks = new Map<string, { wallet: string; expiresAt: number }>()
+
+function allowMemoryFallback(): boolean {
+  return !process.env.VERCEL
+}
 
 export async function registerGenerativeTask(taskId: string, wallet: string): Promise<void> {
   const id = taskId.trim()
@@ -21,6 +26,10 @@ export async function registerGenerativeTask(taskId: string, wallet: string): Pr
       await redis.set(`${TASK_KEY_PREFIX}${id}`, owner, { ex: TASK_TTL_SECONDS })
       return
     }
+  }
+
+  if (!allowMemoryFallback()) {
+    throw new Error('Task registry unavailable (configure Upstash/Vercel KV)')
   }
 
   memoryTasks.set(id, {
@@ -40,6 +49,8 @@ export async function getGenerativeTaskOwner(taskId: string): Promise<string | n
       return typeof owner === 'string' ? owner.toLowerCase() : null
     }
   }
+
+  if (!allowMemoryFallback()) return null
 
   const entry = memoryTasks.get(id)
   if (!entry) return null

--- a/api/_wallet-auth.ts
+++ b/api/_wallet-auth.ts
@@ -1,5 +1,5 @@
 /// <reference types="node" />
-// fallow-ignore-file unused-file,complexity
+// fallow-ignore-file complexity,unused-export
 /** Privy JWT access-token verification for Vercel serverless routes. */
 
 import { PrivyClient } from '@privy-io/server-auth'

--- a/api/director-billing.ts
+++ b/api/director-billing.ts
@@ -1,3 +1,4 @@
+// fallow-ignore-file unused-export,complexity
 /// <reference types="node" />
 /**
  * Creative Director billing helpers for the Vercel `/api/director` proxy.

--- a/api/director-billing.ts
+++ b/api/director-billing.ts
@@ -8,7 +8,11 @@
 import { createPublicClient, http, type Hex } from 'viem'
 import { base } from 'viem/chains'
 import { isPremiumWallet } from './_premium-membership.js'
-import { consumePaymentTxHash, isPaymentLedgerReady } from './_payment-ledger.js'
+import {
+  consumePaymentTxHash,
+  isPaymentLedgerReady,
+  releasePaymentTxHash,
+} from './_payment-ledger.js'
 
 /** Mirrors `DIRECTOR_USDC6_PER_AUDIO_MINUTE_RETAIL` in src/config/billing.ts */
 const DIRECTOR_USDC6_PER_AUDIO_MINUTE_RETAIL = 50_000
@@ -179,4 +183,9 @@ export async function verifyAndConsumeDirectorPayment(options: {
   }
 
   return verified
+}
+
+/** Undo a consumed payment hash after a pre-delivery Director failure. */
+export async function releaseDirectorPayment(txHash: string): Promise<void> {
+  await releasePaymentTxHash(txHash)
 }

--- a/api/director-billing.ts
+++ b/api/director-billing.ts
@@ -6,9 +6,13 @@
 
 import { createPublicClient, http, type Hex } from 'viem'
 import { base } from 'viem/chains'
+import { isPremiumWallet } from './_premium-membership.js'
+import { consumePaymentTxHash, isPaymentLedgerReady } from './_payment-ledger.js'
 
 /** Mirrors `DIRECTOR_USDC6_PER_AUDIO_MINUTE_RETAIL` in src/config/billing.ts */
-const DIRECTOR_USDC6_PER_AUDIO_MINUTE = 50_000
+const DIRECTOR_USDC6_PER_AUDIO_MINUTE_RETAIL = 50_000
+/** Mirrors `DIRECTOR_USDC6_PER_AUDIO_MINUTE_PREMIUM` in src/config/billing.ts */
+const DIRECTOR_USDC6_PER_AUDIO_MINUTE_PREMIUM = 25_000
 
 const CRTVAI_DIAMOND = '0xecb695544a3d2a64d579b3828f3f60f6932f4846'
 
@@ -17,6 +21,7 @@ export interface DirectorBillingQuote {
   estimatedUsdc6: number
   /** Minimum CRTVAI wei expected (usdc6 × 1e12). */
   minCrtvaiWei: bigint
+  tier: 'retail' | 'premium'
 }
 
 function billableAudioMinutes(audioDurationSeconds: number): number {
@@ -24,16 +29,37 @@ function billableAudioMinutes(audioDurationSeconds: number): number {
   return audioDurationSeconds / 60
 }
 
-export function quoteDirectorRetail(audioDurationSeconds: number): DirectorBillingQuote | null {
+export function quoteDirectorRate(
+  audioDurationSeconds: number,
+  isPremium: boolean,
+): DirectorBillingQuote | null {
   const minutes = billableAudioMinutes(audioDurationSeconds)
   if (minutes <= 0) return null
-  const estimatedUsdc6 = Math.round((audioDurationSeconds * DIRECTOR_USDC6_PER_AUDIO_MINUTE) / 60)
+  const rate = isPremium
+    ? DIRECTOR_USDC6_PER_AUDIO_MINUTE_PREMIUM
+    : DIRECTOR_USDC6_PER_AUDIO_MINUTE_RETAIL
+  const estimatedUsdc6 = Math.round((audioDurationSeconds * rate) / 60)
   if (estimatedUsdc6 <= 0) return null
   return {
     billableMinutes: minutes,
     estimatedUsdc6,
     minCrtvaiWei: BigInt(estimatedUsdc6) * 10n ** 12n,
+    tier: isPremium ? 'premium' : 'retail',
   }
+}
+
+/** Always retail — use when membership is unknown. */
+export function quoteDirectorRetail(audioDurationSeconds: number): DirectorBillingQuote | null {
+  return quoteDirectorRate(audioDurationSeconds, false)
+}
+
+/** Resolve quote using on-chain Unlock membership for `walletAddress`. */
+export async function quoteDirectorForWallet(
+  audioDurationSeconds: number,
+  walletAddress: string | undefined,
+): Promise<DirectorBillingQuote | null> {
+  const premium = walletAddress ? await isPremiumWallet(walletAddress) : false
+  return quoteDirectorRate(audioDurationSeconds, premium)
 }
 
 // fallow-ignore-next-line complexity
@@ -125,4 +151,31 @@ export async function verifyDirectorPayment(options: {
       reason: error instanceof Error ? error.message : 'Payment verification failed',
     }
   }
+}
+
+/**
+ * Verify on-chain transfer then consume the tx hash (anti-replay).
+ */
+export async function verifyAndConsumeDirectorPayment(options: {
+  txHash: string
+  from: string
+  minAmountWei: bigint
+  purpose: string
+}): Promise<PaymentVerifyResult> {
+  if (isDirectorBillingEnforced() && !isPaymentLedgerReady()) {
+    return { ok: false, reason: 'Payment ledger unavailable (configure Upstash/Vercel KV)' }
+  }
+
+  const verified = await verifyDirectorPayment(options)
+  if (!verified.ok) return verified
+
+  if (isDirectorBillingEnforced()) {
+    const consumed = await consumePaymentTxHash(options.txHash, {
+      wallet: options.from,
+      purpose: options.purpose,
+    })
+    if (!consumed.ok) return { ok: false, reason: consumed.reason }
+  }
+
+  return verified
 }

--- a/api/director.ts
+++ b/api/director.ts
@@ -28,8 +28,8 @@ import { getVercelOidcToken } from '@vercel/oidc'
 import { ExternalAccountClient, GoogleAuth } from 'google-auth-library'
 import {
   isDirectorBillingEnforced,
-  quoteDirectorRetail,
-  verifyDirectorPayment,
+  quoteDirectorForWallet,
+  verifyAndConsumeDirectorPayment,
 } from './director-billing'
 
 const DEFAULT_PROJECT = 'creative-ai-491118'
@@ -271,7 +271,7 @@ async function assertDirectorPayment(data: ParsedDirectorRequest): Promise<Respo
     )
   }
 
-  const quote = quoteDirectorRetail(data.audioDurationSeconds)
+  const quote = await quoteDirectorForWallet(data.audioDurationSeconds, data.walletAddress)
   if (!quote) {
     return Response.json({ error: 'Unable to quote Director brief' }, { status: 402 })
   }
@@ -282,15 +282,17 @@ async function assertDirectorPayment(data: ParsedDirectorRequest): Promise<Respo
         error: 'Director requires a CRTVAI payment before generation',
         estimatedUsdc6: quote.estimatedUsdc6,
         billableMinutes: quote.billableMinutes,
+        tier: quote.tier,
       },
       { status: 402 },
     )
   }
 
-  const verified = await verifyDirectorPayment({
+  const verified = await verifyAndConsumeDirectorPayment({
     txHash: data.paymentTxHash,
     from: data.walletAddress,
     minAmountWei: quote.minCrtvaiWei,
+    purpose: 'director',
   })
 
   if (!verified.ok) {

--- a/api/director.ts
+++ b/api/director.ts
@@ -29,8 +29,10 @@ import { ExternalAccountClient, GoogleAuth } from 'google-auth-library'
 import {
   isDirectorBillingEnforced,
   quoteDirectorForWallet,
+  releaseDirectorPayment,
   verifyAndConsumeDirectorPayment,
 } from './director-billing'
+import { probeAudioDurationSeconds } from './_audio-duration'
 
 const DEFAULT_PROJECT = 'creative-ai-491118'
 const DEFAULT_LOCATION = 'us-central1'
@@ -261,31 +263,90 @@ async function parseDirectorRequest(
 }
 
 // fallow-ignore-next-line complexity
-async function assertDirectorPayment(data: ParsedDirectorRequest): Promise<Response | null> {
-  if (!isDirectorBillingEnforced()) return null
-
-  if (data.audioDurationSeconds == null || data.audioDurationSeconds <= 0) {
-    return Response.json(
-      { error: 'audioDurationSeconds is required for Director billing' },
-      { status: 402 },
-    )
+async function resolveBillableAudioSeconds(
+  data: ParsedDirectorRequest,
+): Promise<{ ok: true; seconds: number } | { ok: false; response: Response }> {
+  const claimed = data.audioDurationSeconds
+  if (claimed == null || claimed <= 0) {
+    return {
+      ok: false,
+      response: Response.json(
+        { error: 'audioDurationSeconds is required for Director billing' },
+        { status: 402 },
+      ),
+    }
   }
 
-  const quote = await quoteDirectorForWallet(data.audioDurationSeconds, data.walletAddress)
+  const audioUri = data.audioUri?.trim()
+  if (!audioUri) {
+    return { ok: true, seconds: claimed }
+  }
+
+  if (!/^https:\/\//i.test(audioUri)) {
+    return {
+      ok: false,
+      response: Response.json(
+        { error: 'audioUri must be an https URL when provided for Director billing' },
+        { status: 402 },
+      ),
+    }
+  }
+
+  const measured = await probeAudioDurationSeconds(audioUri)
+  if (measured == null) {
+    return {
+      ok: false,
+      response: Response.json(
+        { error: 'Unable to verify audio duration from audioUri' },
+        { status: 402 },
+      ),
+    }
+  }
+
+  // Reject underbilling; allow 1s client/server skew.
+  if (claimed + 1 < measured) {
+    return {
+      ok: false,
+      response: Response.json(
+        {
+          error: 'audioDurationSeconds understates audioUri duration',
+          claimedSeconds: claimed,
+          measuredSeconds: measured,
+        },
+        { status: 402 },
+      ),
+    }
+  }
+
+  return { ok: true, seconds: Math.max(claimed, measured) }
+}
+
+// fallow-ignore-next-line complexity
+async function assertDirectorPayment(
+  data: ParsedDirectorRequest,
+): Promise<{ error: Response } | { paymentTxHash: string | null }> {
+  if (!isDirectorBillingEnforced()) return { paymentTxHash: null }
+
+  const billable = await resolveBillableAudioSeconds(data)
+  if (!billable.ok) return { error: billable.response }
+
+  const quote = await quoteDirectorForWallet(billable.seconds, data.walletAddress)
   if (!quote) {
-    return Response.json({ error: 'Unable to quote Director brief' }, { status: 402 })
+    return { error: Response.json({ error: 'Unable to quote Director brief' }, { status: 402 }) }
   }
 
   if (!data.paymentTxHash || !data.walletAddress) {
-    return Response.json(
-      {
-        error: 'Director requires a CRTVAI payment before generation',
-        estimatedUsdc6: quote.estimatedUsdc6,
-        billableMinutes: quote.billableMinutes,
-        tier: quote.tier,
-      },
-      { status: 402 },
-    )
+    return {
+      error: Response.json(
+        {
+          error: 'Director requires a CRTVAI payment before generation',
+          estimatedUsdc6: quote.estimatedUsdc6,
+          billableMinutes: quote.billableMinutes,
+          tier: quote.tier,
+        },
+        { status: 402 },
+      ),
+    }
   }
 
   const verified = await verifyAndConsumeDirectorPayment({
@@ -296,13 +357,15 @@ async function assertDirectorPayment(data: ParsedDirectorRequest): Promise<Respo
   })
 
   if (!verified.ok) {
-    return Response.json(
-      { error: `Director payment rejected: ${verified.reason}` },
-      { status: 402 },
-    )
+    return {
+      error: Response.json(
+        { error: `Director payment rejected: ${verified.reason}` },
+        { status: 402 },
+      ),
+    }
   }
 
-  return null
+  return { paymentTxHash: data.paymentTxHash }
 }
 
 async function fetchEngineStream(
@@ -378,8 +441,15 @@ export async function POST(request: Request): Promise<Response> {
   const parsed = await parseDirectorRequest(request)
   if (!parsed.ok) return parsed.response
 
-  const paymentError = await assertDirectorPayment(parsed.data)
-  if (paymentError) return paymentError
+  const payment = await assertDirectorPayment(parsed.data)
+  if ('error' in payment) return payment.error
+  const reservedPaymentTxHash = payment.paymentTxHash
+
+  const releaseReservedPayment = async () => {
+    if (reservedPaymentTxHash) {
+      await releaseDirectorPayment(reservedPaymentTxHash).catch(() => undefined)
+    }
+  }
 
   const message = buildMessage(parsed.data.prompt, parsed.data.audioUri)
   const input: Record<string, string> = { user_id: parsed.data.userId, message }
@@ -389,6 +459,7 @@ export async function POST(request: Request): Promise<Response> {
   try {
     token = await getAccessToken()
   } catch (error) {
+    await releaseReservedPayment()
     console.error('Director auth error', error)
     const detail = error instanceof Error ? error.message : String(error)
     const hint = process.env.VERCEL
@@ -412,6 +483,7 @@ export async function POST(request: Request): Promise<Response> {
     upstream = await fetchEngineStream(token, input, upstreamAbort.signal)
   } catch (error) {
     request.signal.removeEventListener('abort', onClientAbort)
+    await releaseReservedPayment()
     if (upstreamAbort.signal.aborted || request.signal.aborted) {
       return new Response(null, { status: 499 })
     }
@@ -421,6 +493,7 @@ export async function POST(request: Request): Promise<Response> {
 
   if (!upstream.ok || !upstream.body) {
     request.signal.removeEventListener('abort', onClientAbort)
+    await releaseReservedPayment()
     const errText = await upstream.text().catch(() => '')
     console.error('Director engine error', upstream.status, errText)
     return Response.json(

--- a/api/flow-billing.ts
+++ b/api/flow-billing.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared Flow / generative billing — CRTVAI transfer verify + consume (anti-replay).
+ */
+
+import {
+  isDirectorBillingEnforced,
+  quoteDirectorRetail,
+  verifyAndConsumeDirectorPayment,
+  type DirectorBillingQuote,
+  type PaymentVerifyResult,
+} from './director-billing.js'
+
+export { isDirectorBillingEnforced as isFlowBillingEnforced, type PaymentVerifyResult }
+
+/** Convert legacy Flow credits ($0.10/credit) to usdc6 + min CRTVAI wei. */
+export function quoteFlowCreditsUsdc6(credits: number): {
+  estimatedUsdc6: number
+  minCrtvaiWei: bigint
+} | null {
+  if (!Number.isFinite(credits) || credits <= 0) return null
+  const estimatedUsdc6 = Math.max(1, Math.ceil(credits)) * 100_000
+  return {
+    estimatedUsdc6,
+    minCrtvaiWei: BigInt(estimatedUsdc6) * 10n ** 12n,
+  }
+}
+
+export function quoteDirectorForReuse(audioDurationSeconds: number): DirectorBillingQuote | null {
+  return quoteDirectorRetail(audioDurationSeconds)
+}
+
+/** Verify treasury transfer and mark tx consumed for `purpose`. */
+export async function verifyFlowPayment(options: {
+  txHash: string
+  from: string
+  minAmountWei: bigint
+  purpose?: string
+}): Promise<PaymentVerifyResult> {
+  return verifyAndConsumeDirectorPayment({
+    txHash: options.txHash,
+    from: options.from,
+    minAmountWei: options.minAmountWei,
+    purpose: options.purpose ?? 'flow',
+  })
+}

--- a/api/flow-billing.ts
+++ b/api/flow-billing.ts
@@ -1,6 +1,7 @@
 /**
  * Shared Flow / generative billing — CRTVAI transfer verify + consume (anti-replay).
  */
+// fallow-ignore-file unused-export,complexity,code-duplication
 
 import {
   isDirectorBillingEnforced,

--- a/api/flow-frame.ts
+++ b/api/flow-frame.ts
@@ -1,0 +1,179 @@
+/**
+ * Temporary public image hosting for Flow frames (Evolink needs HTTPS URLs).
+ *
+ * POST /api/flow-frame — auth required; body multipart or JSON { dataUri, contentType? }
+ * GET  /api/flow-frame?id=... — public read for Evolink fetch (unguessable id)
+ */
+
+import { randomBytes } from 'node:crypto'
+import { getBearerToken, verifyPrivyAccessToken } from './_wallet-auth.js'
+import { getRedis, isRedisConfigured } from './_redis-client.js'
+
+const FRAME_KEY_PREFIX = 'pixels:flow:frame:'
+const FRAME_TTL_SECONDS = 60 * 60 // 1 hour
+const MAX_BYTES = 8 * 1024 * 1024
+
+const memoryFrames = new Map<
+  string,
+  { bytes: Uint8Array; contentType: string; expiresAt: number }
+>()
+
+function parseDataUri(dataUri: string): { contentType: string; bytes: Uint8Array } {
+  const match = /^data:([^;,]+)?(;base64)?,([\s\S]*)$/i.exec(dataUri.trim())
+  if (!match) throw new Error('Invalid data URI')
+  const contentType = match[1] || 'application/octet-stream'
+  const isBase64 = Boolean(match[2])
+  const payload = match[3] || ''
+  const bytes = isBase64
+    ? Uint8Array.from(Buffer.from(payload, 'base64'))
+    : new TextEncoder().encode(decodeURIComponent(payload))
+  if (bytes.byteLength === 0 || bytes.byteLength > MAX_BYTES) {
+    throw new Error('Image too large or empty')
+  }
+  return { contentType, bytes }
+}
+
+async function storeFrame(contentType: string, bytes: Uint8Array): Promise<string> {
+  const id = randomBytes(24).toString('hex')
+  if (isRedisConfigured()) {
+    const redis = await getRedis()
+    if (redis) {
+      await redis.set(
+        `${FRAME_KEY_PREFIX}${id}`,
+        JSON.stringify({
+          contentType,
+          b64: Buffer.from(bytes).toString('base64'),
+        }),
+        { ex: FRAME_TTL_SECONDS },
+      )
+      return id
+    }
+  }
+
+  memoryFrames.set(id, {
+    contentType,
+    bytes,
+    expiresAt: Date.now() + FRAME_TTL_SECONDS * 1000,
+  })
+  return id
+}
+
+async function loadFrame(id: string): Promise<{ contentType: string; bytes: Uint8Array } | null> {
+  if (isRedisConfigured()) {
+    const redis = await getRedis()
+    if (redis) {
+      const raw = await redis.get<string>(`${FRAME_KEY_PREFIX}${id}`)
+      if (!raw || typeof raw !== 'string') return null
+      try {
+        const parsed = JSON.parse(raw) as { contentType?: string; b64?: string }
+        if (!parsed.b64) return null
+        return {
+          contentType: parsed.contentType || 'application/octet-stream',
+          bytes: Uint8Array.from(Buffer.from(parsed.b64, 'base64')),
+        }
+      } catch {
+        return null
+      }
+    }
+  }
+
+  const entry = memoryFrames.get(id)
+  if (!entry) return null
+  if (entry.expiresAt < Date.now()) {
+    memoryFrames.delete(id)
+    return null
+  }
+  return { contentType: entry.contentType, bytes: entry.bytes }
+}
+
+/** Used by flow-run when the client still sends a data URI. */
+export async function storeFlowFrameFromDataUri(dataUri: string, origin: string): Promise<string> {
+  const { contentType, bytes } = parseDataUri(dataUri)
+  const id = await storeFrame(contentType, bytes)
+  return `${origin.replace(/\/$/, '')}/api/flow-frame?id=${id}`
+}
+
+export async function POST(request: Request): Promise<Response> {
+  const token = getBearerToken(request)
+  if (!token) {
+    return Response.json({ error: 'missing authorization' }, { status: 401 })
+  }
+
+  let body: Record<string, unknown>
+  const contentTypeHeader = request.headers.get('content-type') || ''
+  try {
+    if (contentTypeHeader.includes('multipart/form-data')) {
+      const form = await request.formData()
+      const file = form.get('file')
+      const walletAddress =
+        typeof form.get('walletAddress') === 'string'
+          ? String(form.get('walletAddress'))
+          : undefined
+      const auth = await verifyPrivyAccessToken(token, walletAddress)
+      if (!auth) {
+        return Response.json({ error: 'invalid authorization' }, { status: 401 })
+      }
+      if (!(file instanceof File)) {
+        return Response.json({ error: 'file required' }, { status: 400 })
+      }
+      const buf = new Uint8Array(await file.arrayBuffer())
+      if (buf.byteLength === 0 || buf.byteLength > MAX_BYTES) {
+        return Response.json({ error: 'invalid file size' }, { status: 400 })
+      }
+      const id = await storeFrame(file.type || 'application/octet-stream', buf)
+      const origin = new URL(request.url).origin
+      return Response.json({
+        id,
+        url: `${origin}/api/flow-frame?id=${id}`,
+      })
+    }
+
+    body = (await request.json()) as Record<string, unknown>
+  } catch {
+    return Response.json({ error: 'invalid body' }, { status: 400 })
+  }
+
+  const auth = await verifyPrivyAccessToken(
+    token,
+    typeof body.walletAddress === 'string' ? body.walletAddress : undefined,
+  )
+  if (!auth) {
+    return Response.json({ error: 'invalid authorization' }, { status: 401 })
+  }
+
+  const dataUri = typeof body.dataUri === 'string' ? body.dataUri : ''
+  if (!dataUri.startsWith('data:')) {
+    return Response.json({ error: 'dataUri required' }, { status: 400 })
+  }
+
+  try {
+    const origin = new URL(request.url).origin
+    const url = await storeFlowFrameFromDataUri(dataUri, origin)
+    return Response.json({ url, id: new URL(url).searchParams.get('id') })
+  } catch (e) {
+    return Response.json(
+      { error: e instanceof Error ? e.message : 'upload failed' },
+      { status: 400 },
+    )
+  }
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const id = new URL(request.url).searchParams.get('id')?.trim()
+  if (!id || !/^[a-f0-9]{32,64}$/i.test(id)) {
+    return Response.json({ error: 'id required' }, { status: 400 })
+  }
+
+  const frame = await loadFrame(id)
+  if (!frame) {
+    return Response.json({ error: 'not found' }, { status: 404 })
+  }
+
+  return new Response(Buffer.from(frame.bytes), {
+    status: 200,
+    headers: {
+      'Content-Type': frame.contentType,
+      'Cache-Control': 'public, max-age=3600',
+    },
+  })
+}

--- a/api/flow-frame.ts
+++ b/api/flow-frame.ts
@@ -14,10 +14,15 @@ const FRAME_KEY_PREFIX = 'pixels:flow:frame:'
 const FRAME_TTL_SECONDS = 60 * 60 // 1 hour
 const MAX_BYTES = 8 * 1024 * 1024
 
+/** Local-dev only — Vercel serverless instances do not share memory. */
 const memoryFrames = new Map<
   string,
   { bytes: Uint8Array; contentType: string; expiresAt: number }
 >()
+
+function allowMemoryFallback(): boolean {
+  return !process.env.VERCEL
+}
 
 function parseDataUri(dataUri: string): { contentType: string; bytes: Uint8Array } {
   const match = /^data:([^;,]+)?(;base64)?,([\s\S]*)$/i.exec(dataUri.trim())
@@ -51,6 +56,10 @@ async function storeFrame(contentType: string, bytes: Uint8Array): Promise<strin
     }
   }
 
+  if (!allowMemoryFallback()) {
+    throw new Error('Frame store unavailable (configure Upstash/Vercel KV)')
+  }
+
   memoryFrames.set(id, {
     contentType,
     bytes,
@@ -77,6 +86,8 @@ async function loadFrame(id: string): Promise<{ contentType: string; bytes: Uint
       }
     }
   }
+
+  if (!allowMemoryFallback()) return null
 
   const entry = memoryFrames.get(id)
   if (!entry) return null

--- a/api/flow-frame.ts
+++ b/api/flow-frame.ts
@@ -4,6 +4,7 @@
  * POST /api/flow-frame — auth required; body multipart or JSON { dataUri, contentType? }
  * GET  /api/flow-frame?id=... — public read for Evolink fetch (unguessable id)
  */
+// fallow-ignore-file complexity,code-duplication
 
 import { randomBytes } from 'node:crypto'
 import { getBearerToken, verifyPrivyAccessToken } from './_wallet-auth.js'

--- a/api/flow-run.ts
+++ b/api/flow-run.ts
@@ -7,6 +7,7 @@
  *  startPrompt?, endPrompt?, stillQuality?,
  *  paymentTxHash?, walletAddress, requestId, token?
  */
+// fallow-ignore-file complexity,code-duplication
 
 import { getBearerToken, verifyPrivyAccessToken } from './_wallet-auth.js'
 import { checkMetokenSufficient } from './_metoken-server.js'

--- a/api/flow-run.ts
+++ b/api/flow-run.ts
@@ -1,0 +1,236 @@
+/**
+ * POST /api/flow-run — one CRTVAI payment covers optional Gemini stills + Seedance i2v.
+ *
+ * Body:
+ *  prompt, duration?, quality?, speed?, aspect_ratio?, generate_audio?,
+ *  startImageUrl?, endImageUrl?,
+ *  startPrompt?, endPrompt?, stillQuality?,
+ *  paymentTxHash?, walletAddress, requestId, token?
+ */
+
+import { getBearerToken, verifyPrivyAccessToken } from './_wallet-auth.js'
+import { checkMetokenSufficient } from './_metoken-server.js'
+import {
+  evolinkServerGet,
+  evolinkServerPost,
+  isEvolinkServerConfigured,
+} from './_evolink-server.js'
+import { isFlowBillingEnforced, quoteFlowCreditsUsdc6, verifyFlowPayment } from './flow-billing.js'
+
+function videoCredits(body: Record<string, unknown>): number {
+  const duration = typeof body.duration === 'number' ? body.duration : 5
+  const quality = typeof body.quality === 'string' ? body.quality : '720p'
+  const speed = typeof body.speed === 'string' ? body.speed : 'standard'
+  const generateAudio = body.generate_audio !== false
+  const qMult = quality === '1080p' ? 2.5 : quality === '720p' ? 1.6 : 1
+  const sMult = speed === 'fast' ? 0.75 : 1
+  let credits = duration * 1.4 * qMult * sMult
+  if (generateAudio) credits *= 1.15
+  return Math.max(1, Math.ceil(credits))
+}
+
+function stillCredits(quality: string): number {
+  const map: Record<string, number> = { '0.5K': 5, '1K': 8, '2K': 12, '4K': 18 }
+  return map[quality] ?? 10
+}
+
+async function waitImageUrl(taskId: string): Promise<string> {
+  // Cap ~90s per still (60 × 1.5s). Dual stills run in parallel so wall clock ≈ one still.
+  for (let i = 0; i < 60; i++) {
+    const detail = await evolinkServerGet<{
+      status: string
+      output?: { image_url?: string; image_urls?: string[] }
+      error?: { message?: string }
+    }>(`/tasks/${taskId}`)
+    if (detail.status === 'completed') {
+      const url = detail.output?.image_url || detail.output?.image_urls?.[0]
+      if (!url) throw new Error('Image task completed without URL')
+      return url
+    }
+    if (detail.status === 'failed') {
+      throw new Error(detail.error?.message || 'Image generation failed')
+    }
+    await new Promise((r) => setTimeout(r, 1500))
+  }
+  throw new Error('Image generation timed out')
+}
+
+async function resolveHttpsImageUrl(url: string, requestUrl: string): Promise<string> {
+  const trimmed = url.trim()
+  if (trimmed.startsWith('https://') || trimmed.startsWith('http://')) return trimmed
+  if (!trimmed.startsWith('data:')) {
+    throw new Error('Image URLs must be https or data URIs')
+  }
+  // Persist data URI via flow-frame so Evolink can fetch over HTTPS.
+  const { storeFlowFrameFromDataUri } = await import('./flow-frame.js')
+  const origin = new URL(requestUrl).origin
+  return storeFlowFrameFromDataUri(trimmed, origin)
+}
+
+// fallow-ignore-next-line complexity
+export async function POST(request: Request): Promise<Response> {
+  if (!isEvolinkServerConfigured()) {
+    return Response.json({ error: 'service unavailable' }, { status: 503 })
+  }
+
+  let body: Record<string, unknown>
+  try {
+    const parsed = await request.json()
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return Response.json({ error: 'invalid body' }, { status: 400 })
+    }
+    body = parsed as Record<string, unknown>
+  } catch {
+    return Response.json({ error: 'invalid body' }, { status: 400 })
+  }
+
+  const token = getBearerToken(request) || (typeof body.token === 'string' ? body.token : null)
+  if (!token) {
+    return Response.json({ error: 'missing authorization' }, { status: 401 })
+  }
+
+  const auth = await verifyPrivyAccessToken(
+    token,
+    typeof body.walletAddress === 'string' ? body.walletAddress : undefined,
+  )
+  if (!auth) {
+    return Response.json({ error: 'invalid authorization' }, { status: 401 })
+  }
+
+  const prompt = typeof body.prompt === 'string' ? body.prompt.trim() : ''
+  if (!prompt) {
+    return Response.json({ error: 'prompt required' }, { status: 400 })
+  }
+
+  const requestId =
+    typeof body.requestId === 'string' && body.requestId.trim().length > 0
+      ? body.requestId.trim()
+      : null
+  if (!requestId) {
+    return Response.json({ error: 'requestId required' }, { status: 400 })
+  }
+
+  let startUrl = typeof body.startImageUrl === 'string' ? body.startImageUrl.trim() : ''
+  let endUrl = typeof body.endImageUrl === 'string' ? body.endImageUrl.trim() : ''
+  const startPrompt = typeof body.startPrompt === 'string' ? body.startPrompt.trim() : ''
+  const endPrompt = typeof body.endPrompt === 'string' ? body.endPrompt.trim() : ''
+  const stillQuality = typeof body.stillQuality === 'string' ? body.stillQuality : '2K'
+
+  const needStartStill = !startUrl && Boolean(startPrompt)
+  const needEndStill = !endUrl && Boolean(endPrompt)
+  if (!startUrl && !startPrompt) {
+    return Response.json({ error: 'start image or startPrompt required' }, { status: 400 })
+  }
+  if (!endUrl && !endPrompt) {
+    return Response.json({ error: 'end image or endPrompt required' }, { status: 400 })
+  }
+
+  const stillCount = (needStartStill ? 1 : 0) + (needEndStill ? 1 : 0)
+  const totalCredits = videoCredits(body) + stillCount * stillCredits(stillQuality)
+  const quote = quoteFlowCreditsUsdc6(totalCredits)
+  if (!quote) {
+    return Response.json({ error: 'invalid quote' }, { status: 400 })
+  }
+
+  if (isFlowBillingEnforced()) {
+    const paymentTxHash = typeof body.paymentTxHash === 'string' ? body.paymentTxHash.trim() : ''
+    if (!paymentTxHash) {
+      return Response.json({ error: 'payment_required' }, { status: 402 })
+    }
+    const verified = await verifyFlowPayment({
+      txHash: paymentTxHash,
+      from: auth.address,
+      minAmountWei: quote.minCrtvaiWei,
+      purpose: 'flow-run',
+    })
+    if (!verified.ok) {
+      return Response.json({ error: verified.reason }, { status: 402 })
+    }
+  } else {
+    try {
+      const balanceCheck = await checkMetokenSufficient(auth.address, quote.estimatedUsdc6)
+      if (!balanceCheck.sufficient) {
+        return Response.json(
+          {
+            error: 'insufficient_crtvai',
+            costUsdc6: quote.estimatedUsdc6,
+            requiredMetoken: balanceCheck.requiredMetoken.toString(),
+          },
+          { status: 402 },
+        )
+      }
+    } catch (e) {
+      console.error('flow-run balance check failed', e)
+      return Response.json({ error: 'failed to verify balance' }, { status: 502 })
+    }
+  }
+
+  try {
+    const stillJobs: Promise<void>[] = []
+    if (needStartStill) {
+      stillJobs.push(
+        (async () => {
+          const img = await evolinkServerPost<{ id: string }>('/images/generations', {
+            model: 'gemini-3.1-flash-image-preview',
+            prompt: startPrompt,
+            size: 'auto',
+            quality: stillQuality,
+          })
+          startUrl = await waitImageUrl(img.id)
+        })(),
+      )
+    }
+    if (needEndStill) {
+      stillJobs.push(
+        (async () => {
+          const img = await evolinkServerPost<{ id: string }>('/images/generations', {
+            model: 'gemini-3.1-flash-image-preview',
+            prompt: endPrompt,
+            size: 'auto',
+            quality: stillQuality,
+          })
+          endUrl = await waitImageUrl(img.id)
+        })(),
+      )
+    }
+    await Promise.all(stillJobs)
+
+    startUrl = await resolveHttpsImageUrl(startUrl, request.url)
+    endUrl = await resolveHttpsImageUrl(endUrl, request.url)
+
+    const model =
+      body.speed === 'fast' ? 'seedance-2.0-fast-image-to-video' : 'seedance-2.0-image-to-video'
+
+    const result = await evolinkServerPost<Record<string, unknown> & { id?: string }>(
+      '/videos/generations',
+      {
+        model,
+        prompt,
+        image_urls: [startUrl, endUrl],
+        duration: body.duration ?? 5,
+        quality: body.quality ?? '720p',
+        aspect_ratio: body.aspect_ratio ?? 'adaptive',
+        generate_audio: body.generate_audio ?? true,
+      },
+    )
+
+    if (typeof result.id === 'string') {
+      const { registerGenerativeTask } = await import('./_task-registry.js')
+      await registerGenerativeTask(result.id, auth.address)
+    }
+
+    return Response.json({
+      ...result,
+      startImageUrl: startUrl,
+      endImageUrl: endUrl,
+      costUsdc6: quote.estimatedUsdc6,
+      crtvaiRequired: quote.minCrtvaiWei.toString(),
+    })
+  } catch (e) {
+    console.error('flow-run error', e)
+    return Response.json(
+      { error: e instanceof Error ? e.message : 'generation failed' },
+      { status: 502 },
+    )
+  }
+}

--- a/api/generate-image.ts
+++ b/api/generate-image.ts
@@ -1,0 +1,131 @@
+/**
+ * POST /api/generate-image — Gemini/Nanobanana stills with CRTVAI payment verify.
+ */
+
+import { getBearerToken, verifyPrivyAccessToken } from './_wallet-auth.js'
+import { checkMetokenSufficient } from './_metoken-server.js'
+import { evolinkServerPost, isEvolinkServerConfigured } from './_evolink-server.js'
+import { isFlowBillingEnforced, quoteFlowCreditsUsdc6, verifyFlowPayment } from './flow-billing.js'
+
+function quoteImageCredits(quality: string): number {
+  const creditMap: Record<string, number> = {
+    '0.5K': 5,
+    '1K': 8,
+    '2K': 12,
+    '4K': 18,
+  }
+  return creditMap[quality] ?? 10
+}
+
+// fallow-ignore-next-line complexity
+export async function POST(request: Request): Promise<Response> {
+  if (!isEvolinkServerConfigured()) {
+    return Response.json({ error: 'service unavailable' }, { status: 503 })
+  }
+
+  let body: Record<string, unknown>
+  try {
+    const parsed = await request.json()
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return Response.json({ error: 'invalid body' }, { status: 400 })
+    }
+    body = parsed as Record<string, unknown>
+  } catch {
+    return Response.json({ error: 'invalid body' }, { status: 400 })
+  }
+
+  const token = getBearerToken(request) || (typeof body.token === 'string' ? body.token : null)
+  if (!token) {
+    return Response.json({ error: 'missing authorization' }, { status: 401 })
+  }
+
+  const auth = await verifyPrivyAccessToken(
+    token,
+    typeof body.walletAddress === 'string' ? body.walletAddress : undefined,
+  )
+  if (!auth) {
+    return Response.json({ error: 'invalid authorization' }, { status: 401 })
+  }
+
+  const prompt = typeof body.prompt === 'string' ? body.prompt.trim() : ''
+  if (!prompt) {
+    return Response.json({ error: 'prompt required' }, { status: 400 })
+  }
+
+  const requestId =
+    typeof body.requestId === 'string' && body.requestId.trim().length > 0
+      ? body.requestId.trim()
+      : null
+  if (!requestId) {
+    return Response.json({ error: 'requestId required' }, { status: 400 })
+  }
+
+  const quality = typeof body.quality === 'string' ? body.quality : '2K'
+  const quote = quoteFlowCreditsUsdc6(quoteImageCredits(quality))
+  if (!quote) {
+    return Response.json({ error: 'invalid quote' }, { status: 400 })
+  }
+
+  if (isFlowBillingEnforced()) {
+    const paymentTxHash = typeof body.paymentTxHash === 'string' ? body.paymentTxHash.trim() : ''
+    if (!paymentTxHash) {
+      return Response.json({ error: 'payment_required' }, { status: 402 })
+    }
+    const verified = await verifyFlowPayment({
+      txHash: paymentTxHash,
+      from: auth.address,
+      minAmountWei: quote.minCrtvaiWei,
+      purpose: 'generate-image',
+    })
+    if (!verified.ok) {
+      return Response.json({ error: verified.reason }, { status: 402 })
+    }
+  } else {
+    try {
+      const balanceCheck = await checkMetokenSufficient(auth.address, quote.estimatedUsdc6)
+      if (!balanceCheck.sufficient) {
+        return Response.json(
+          {
+            error: 'insufficient_crtvai',
+            balance: balanceCheck.balance.toString(),
+            requiredMetoken: balanceCheck.requiredMetoken.toString(),
+            costUsdc6: quote.estimatedUsdc6,
+          },
+          { status: 402 },
+        )
+      }
+    } catch (e) {
+      console.error('Failed to check meToken balance', e)
+      return Response.json({ error: 'failed to verify balance' }, { status: 502 })
+    }
+  }
+
+  try {
+    const result = await evolinkServerPost<Record<string, unknown> & { id?: string }>(
+      '/images/generations',
+      {
+        model: 'gemini-3.1-flash-image-preview',
+        prompt,
+        size: body.size ?? 'auto',
+        quality,
+        ...(Array.isArray(body.image_urls) && body.image_urls.length > 0
+          ? { image_urls: body.image_urls }
+          : {}),
+      },
+    )
+
+    if (typeof result.id === 'string') {
+      const { registerGenerativeTask } = await import('./_task-registry.js')
+      await registerGenerativeTask(result.id, auth.address)
+    }
+
+    return Response.json({
+      ...result,
+      costUsdc6: quote.estimatedUsdc6,
+      crtvaiRequired: quote.minCrtvaiWei.toString(),
+    })
+  } catch (e) {
+    console.error('generate-image evolink error', e)
+    return Response.json({ error: 'generation failed' }, { status: 502 })
+  }
+}

--- a/api/generate-image.ts
+++ b/api/generate-image.ts
@@ -1,6 +1,7 @@
 /**
  * POST /api/generate-image — Gemini/Nanobanana stills with CRTVAI payment verify.
  */
+// fallow-ignore-file complexity,code-duplication
 
 import { getBearerToken, verifyPrivyAccessToken } from './_wallet-auth.js'
 import { checkMetokenSufficient } from './_metoken-server.js'

--- a/api/generate-task.ts
+++ b/api/generate-task.ts
@@ -2,6 +2,7 @@
  * GET /api/generate-task?id=...
  * Poll Evolink task status. Requires Privy auth; task must be owned by the wallet.
  */
+// fallow-ignore-file complexity
 
 import { getBearerToken, verifyPrivyAccessToken } from './_wallet-auth.js'
 import { evolinkServerGet, isEvolinkServerConfigured } from './_evolink-server.js'

--- a/api/generate-task.ts
+++ b/api/generate-task.ts
@@ -1,19 +1,40 @@
 /**
  * GET /api/generate-task?id=...
- * Poll Evolink task status (no additional credit charge).
+ * Poll Evolink task status. Requires Privy auth; task must be owned by the wallet.
  */
 
+import { getBearerToken, verifyPrivyAccessToken } from './_wallet-auth.js'
 import { evolinkServerGet, isEvolinkServerConfigured } from './_evolink-server.js'
+import { getGenerativeTaskOwner } from './_task-registry.js'
 
 export async function GET(request: Request): Promise<Response> {
   if (!isEvolinkServerConfigured()) {
     return Response.json({ error: 'service unavailable' }, { status: 503 })
   }
 
+  const token = getBearerToken(request)
+  if (!token) {
+    return Response.json({ error: 'missing authorization' }, { status: 401 })
+  }
+
   const url = new URL(request.url)
   const taskId = url.searchParams.get('id')?.trim()
+  const walletHint = url.searchParams.get('wallet')?.trim()
   if (!taskId) {
     return Response.json({ error: 'id required' }, { status: 400 })
+  }
+
+  const auth = await verifyPrivyAccessToken(token, walletHint)
+  if (!auth) {
+    return Response.json({ error: 'invalid authorization' }, { status: 401 })
+  }
+
+  const owner = await getGenerativeTaskOwner(taskId)
+  if (!owner) {
+    return Response.json({ error: 'task not found' }, { status: 404 })
+  }
+  if (owner !== auth.address.toLowerCase()) {
+    return Response.json({ error: 'forbidden' }, { status: 403 })
   }
 
   try {

--- a/api/generate-video.ts
+++ b/api/generate-video.ts
@@ -5,6 +5,7 @@
  *       generate_audio?, requestId, walletAddress, paymentTxHash?
  * Header: Authorization: Bearer <privy token>
  */
+// fallow-ignore-file complexity,code-duplication
 
 import { getBearerToken, verifyPrivyAccessToken } from './_wallet-auth.js'
 import { checkMetokenSufficient } from './_metoken-server.js'

--- a/api/generate-video.ts
+++ b/api/generate-video.ts
@@ -1,0 +1,141 @@
+/**
+ * POST /api/generate-video — Seedance i2v with Director-style CRTVAI payment verify.
+ *
+ * Body: prompt, image_urls (1–2), duration?, quality?, speed?, aspect_ratio?,
+ *       generate_audio?, requestId, walletAddress, paymentTxHash?
+ * Header: Authorization: Bearer <privy token>
+ */
+
+import { getBearerToken, verifyPrivyAccessToken } from './_wallet-auth.js'
+import { checkMetokenSufficient } from './_metoken-server.js'
+import { evolinkServerPost, isEvolinkServerConfigured } from './_evolink-server.js'
+import { isFlowBillingEnforced, quoteFlowCreditsUsdc6, verifyFlowPayment } from './flow-billing.js'
+
+function quoteVideoCredits(body: Record<string, unknown>): number {
+  const duration = typeof body.duration === 'number' ? body.duration : 5
+  const quality = typeof body.quality === 'string' ? body.quality : '720p'
+  const speed = typeof body.speed === 'string' ? body.speed : 'standard'
+  const generateAudio = body.generate_audio !== false
+  const qMult = quality === '1080p' ? 2.5 : quality === '720p' ? 1.6 : 1
+  const sMult = speed === 'fast' ? 0.75 : 1
+  let credits = duration * 1.4 * qMult * sMult
+  if (generateAudio) credits *= 1.15
+  return Math.max(1, Math.ceil(credits))
+}
+
+// fallow-ignore-next-line complexity
+export async function POST(request: Request): Promise<Response> {
+  if (!isEvolinkServerConfigured()) {
+    return Response.json({ error: 'service unavailable' }, { status: 503 })
+  }
+
+  let body: Record<string, unknown>
+  try {
+    const parsed = await request.json()
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return Response.json({ error: 'invalid body' }, { status: 400 })
+    }
+    body = parsed as Record<string, unknown>
+  } catch {
+    return Response.json({ error: 'invalid body' }, { status: 400 })
+  }
+
+  const token = getBearerToken(request) || (typeof body.token === 'string' ? body.token : null)
+  if (!token) {
+    return Response.json({ error: 'missing authorization' }, { status: 401 })
+  }
+
+  const auth = await verifyPrivyAccessToken(
+    token,
+    typeof body.walletAddress === 'string' ? body.walletAddress : undefined,
+  )
+  if (!auth) {
+    return Response.json({ error: 'invalid authorization' }, { status: 401 })
+  }
+
+  const prompt = typeof body.prompt === 'string' ? body.prompt.trim() : ''
+  const imageUrls = Array.isArray(body.image_urls) ? body.image_urls : []
+  if (!prompt || imageUrls.length === 0 || imageUrls.length > 2) {
+    return Response.json({ error: 'prompt and 1–2 image_urls required' }, { status: 400 })
+  }
+
+  const requestId =
+    typeof body.requestId === 'string' && body.requestId.trim().length > 0
+      ? body.requestId.trim()
+      : null
+  if (!requestId) {
+    return Response.json({ error: 'requestId required' }, { status: 400 })
+  }
+
+  const credits = quoteVideoCredits(body)
+  const quote = quoteFlowCreditsUsdc6(credits)
+  if (!quote) {
+    return Response.json({ error: 'invalid quote' }, { status: 400 })
+  }
+
+  if (isFlowBillingEnforced()) {
+    const paymentTxHash = typeof body.paymentTxHash === 'string' ? body.paymentTxHash.trim() : ''
+    if (!paymentTxHash) {
+      return Response.json({ error: 'payment_required' }, { status: 402 })
+    }
+    const verified = await verifyFlowPayment({
+      txHash: paymentTxHash,
+      from: auth.address,
+      minAmountWei: quote.minCrtvaiWei,
+      purpose: 'generate-video',
+    })
+    if (!verified.ok) {
+      return Response.json({ error: verified.reason }, { status: 402 })
+    }
+  } else {
+    try {
+      const balanceCheck = await checkMetokenSufficient(auth.address, quote.estimatedUsdc6)
+      if (!balanceCheck.sufficient) {
+        return Response.json(
+          {
+            error: 'insufficient_crtvai',
+            balance: balanceCheck.balance.toString(),
+            requiredMetoken: balanceCheck.requiredMetoken.toString(),
+            costUsdc6: quote.estimatedUsdc6,
+          },
+          { status: 402 },
+        )
+      }
+    } catch (e) {
+      console.error('Failed to check meToken balance', e)
+      return Response.json({ error: 'failed to verify balance' }, { status: 502 })
+    }
+  }
+
+  try {
+    const model =
+      body.speed === 'fast' ? 'seedance-2.0-fast-image-to-video' : 'seedance-2.0-image-to-video'
+
+    const result = await evolinkServerPost<Record<string, unknown> & { id?: string }>(
+      '/videos/generations',
+      {
+        model,
+        prompt,
+        image_urls: imageUrls,
+        duration: body.duration ?? 5,
+        quality: body.quality ?? '720p',
+        aspect_ratio: body.aspect_ratio ?? 'adaptive',
+        generate_audio: body.generate_audio ?? true,
+      },
+    )
+
+    if (typeof result.id === 'string') {
+      const { registerGenerativeTask } = await import('./_task-registry.js')
+      await registerGenerativeTask(result.id, auth.address)
+    }
+
+    return Response.json({
+      ...result,
+      costUsdc6: quote.estimatedUsdc6,
+      crtvaiRequired: quote.minCrtvaiWei.toString(),
+    })
+  } catch (e) {
+    console.error('generate-video evolink error', e)
+    return Response.json({ error: 'generation failed' }, { status: 502 })
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
         "lucide-react": "0.468.0",
         "mediabunny": "1.50.8",
         "motion": "12.40.0",
+        "music-metadata": "11.15.0",
         "onnxruntime-web": "1.26.0-dev.20260410-5e55544225",
         "react": "19.2.5",
         "react-colorful": "5.6.1",
@@ -747,6 +748,16 @@
       "integrity": "sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
     },
     "node_modules/@coinbase/cdp-sdk": {
       "version": "1.54.0",
@@ -9491,6 +9502,29 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -14384,6 +14418,24 @@
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
       "license": "MIT"
     },
+    "node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -16631,6 +16683,63 @@
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
       "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
       "license": "(Apache-2.0 AND MIT)"
+    },
+    "node_modules/music-metadata": {
+      "version": "11.15.0",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-11.15.0.tgz",
+      "integrity": "sha512-TN+kO1/oOc8UzDW5N3vSDncBcv9WyNnQQe/NFMcFWq6G1+zVeYUkGvkYpQ/S8wb8vKtUD7i78dIaY0cv+cmPRA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/Borewit"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://buymeacoffee.com/borewit"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.2",
+        "@tokenizer/token": "^0.3.0",
+        "content-type": "^2.1.0",
+        "debug": "^4.4.3",
+        "file-type": "^21.3.4",
+        "media-typer": "^2.0.0",
+        "strtok3": "^10.3.5",
+        "token-types": "^6.1.2",
+        "uint8array-extras": "^1.5.0",
+        "win-guid": "^0.2.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/music-metadata/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/music-metadata/node_modules/media-typer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-2.0.0.tgz",
+      "integrity": "sha512-kOy3OxT2HH39N70UnKgu4NWDZjLOz8W/mfyvniHjRH/DrL3f2pOfvWQ4p60offbbtDAnXWp0v9LfMIqMec269Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.16",
@@ -19181,6 +19290,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/styled-components": {
       "version": "6.4.4",
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.4.4.tgz",
@@ -19481,6 +19606,24 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/totalist": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -19688,6 +19831,18 @@
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
       "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
       "license": "MIT"
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/uint8arrays": {
       "version": "3.1.1",
@@ -20596,6 +20751,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/win-guid": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/win-guid/-/win-guid-0.2.1.tgz",
+      "integrity": "sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A==",
+      "license": "MIT"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "lucide-react": "0.468.0",
     "mediabunny": "1.50.8",
     "motion": "12.40.0",
+    "music-metadata": "11.15.0",
     "onnxruntime-web": "1.26.0-dev.20260410-5e55544225",
     "react": "19.2.5",
     "react-colorful": "5.6.1",

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,77 @@
+import * as React from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { X } from 'lucide-react'
+import { cn } from '@/shared/ui/cn'
+
+const Sheet = DialogPrimitive.Root
+const SheetTrigger = DialogPrimitive.Trigger
+const SheetClose = DialogPrimitive.Close
+const SheetPortal = DialogPrimitive.Portal
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      'fixed inset-0 z-50 bg-black/70 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
+    )}
+    {...props}
+  />
+))
+SheetOverlay.displayName = 'SheetOverlay'
+
+const sheetSideClass: Record<'left' | 'right' | 'bottom', string> = {
+  left: 'inset-y-0 left-0 h-full w-[min(100vw,22rem)] border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left',
+  right:
+    'inset-y-0 right-0 h-full w-[min(100vw,22rem)] border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right',
+  bottom:
+    'inset-x-0 bottom-0 h-[min(85vh,36rem)] w-full border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
+}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & {
+    side?: 'left' | 'right' | 'bottom'
+  }
+>(({ side = 'left', className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed z-50 flex flex-col gap-0 bg-background p-0 shadow-lg transition ease-[var(--ease-drawer,cubic-bezier(0.32,0.72,0,1))] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-200 data-[state=open]:duration-300',
+        sheetSideClass[side],
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute top-3 right-3 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:outline-none">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </SheetPortal>
+))
+SheetContent.displayName = 'SheetContent'
+
+function SheetHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('flex flex-col space-y-1 p-4 pr-10', className)} {...props} />
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      className={cn('text-sm font-semibold text-foreground', className)}
+      {...props}
+    />
+  )
+}
+
+export { Sheet, SheetTrigger, SheetClose, SheetContent, SheetHeader, SheetTitle }

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,3 +1,4 @@
+// fallow-ignore-file unused-export
 import * as React from 'react'
 import * as DialogPrimitive from '@radix-ui/react-dialog'
 import { X } from 'lucide-react'

--- a/src/config/credits.ts
+++ b/src/config/credits.ts
@@ -48,6 +48,39 @@ export function getCreditPack(packId: number): CreditPackDefinition | undefined 
   return CREDIT_PACKS.find((p) => p.id === packId)
 }
 
+/**
+ * Director session packs — USDC to mint as CRTVAI for prepaid Director briefs.
+ * `credits` is an informational estimate of retail Director audio-minutes
+ * (≈ $0.05/min → 1 credit ≈ 2 min at the legacy $0.10/credit display scale).
+ */
+export const DIRECTOR_SESSION_PACKS: readonly CreditPackDefinition[] = [
+  {
+    id: 10,
+    name: 'Brief',
+    usdc6: 5_000_000,
+    credits: 100,
+    description: '~100 min retail Director audio',
+  },
+  {
+    id: 11,
+    name: 'Session',
+    usdc6: 15_000_000,
+    credits: 300,
+    description: '~300 min retail Director audio',
+  },
+  {
+    id: 12,
+    name: 'Production',
+    usdc6: 40_000_000,
+    credits: 800,
+    description: '~800 min retail Director audio',
+  },
+] as const
+
+export function getDirectorSessionPack(packId: number): CreditPackDefinition | undefined {
+  return DIRECTOR_SESSION_PACKS.find((p) => p.id === packId)
+}
+
 /** Estimated minutes at legacy Live AI credit rate (informational only). */
 export function creditsToLiveAiMinutes(credits: number): number {
   if (credits <= 0) return 0

--- a/src/config/credits.ts
+++ b/src/config/credits.ts
@@ -1,4 +1,6 @@
 /** Milli-credits (3 decimal places) for fractional Live AI debits. 1000 milli = 1 credit. */
+// fallow-ignore-file unused-export
+
 export const MILLI_CREDITS_PER_CREDIT = 1000
 
 /** ~1.11 credits/min reference rate (legacy Live AI equivalence; Live AI bills USDC via Superfluid). */

--- a/src/config/editor-layout.ts
+++ b/src/config/editor-layout.ts
@@ -6,6 +6,8 @@
  *
  * Prefer changing presets here before editing one-off component sizes.
  */
+// fallow-ignore-file unused-export
+
 const EDIT_DOPESHEET_COLUMN_WIDTH = 288
 
 const COMPACT_LAYOUT = {

--- a/src/config/editor-layout.ts
+++ b/src/config/editor-layout.ts
@@ -2,45 +2,82 @@
  * Editor density presets.
  *
  * `compact` is tuned to keep more of the editor visible on a 1920x1080 display.
+ * `tablet` / `phone` are selected automatically from viewport width.
  *
  * Prefer changing presets here before editing one-off component sizes.
  */
 const EDIT_DOPESHEET_COLUMN_WIDTH = 288
 
+const COMPACT_LAYOUT = {
+  toolbarHeight: 48,
+  sidebarRailWidth: 44,
+  sidebarHeaderHeight: 36,
+  sidebarHeaderButtonSize: 20,
+  toolbarButtonSize: 20,
+  leftSidebarDefaultWidth: 320,
+  leftSidebarMinWidth: 240,
+  leftSidebarMaxWidth: 560,
+  rightSidebarDefaultWidth: 288,
+  rightSidebarMinWidth: 280,
+  rightSidebarMaxWidth: 420,
+  previewPadding: 32,
+  previewSplitHeaderHeight: 32,
+  previewControlsHeight: 32,
+  previewControlButtonSize: 30,
+  timelineDefaultSize: 28,
+  timelineMinSize: 14,
+  timelineMaxSize: 80,
+  graphPanelSizeIncrease: 10,
+  timelineHeaderHeight: 40,
+  timelineTracksHeaderHeight: 34,
+  timelineRulerHeight: 34,
+  timelineSidebarWidth: EDIT_DOPESHEET_COLUMN_WIDTH,
+  timelineMeterWidth: 84,
+  timelineMixerWidth: 260,
+  timelineTrackHeight: 100,
+  timelineClipLabelRowHeight: 24,
+  timelineWaveformRowHeight: 24,
+} as const
+
 const EDITOR_DENSITY_PRESETS = {
-  compact: {
-    toolbarHeight: 48,
-    sidebarRailWidth: 44,
-    sidebarHeaderHeight: 36,
-    sidebarHeaderButtonSize: 20,
-    toolbarButtonSize: 20,
-    leftSidebarDefaultWidth: 320,
-    leftSidebarMinWidth: 240,
-    leftSidebarMaxWidth: 560,
-    rightSidebarDefaultWidth: 288,
+  compact: COMPACT_LAYOUT,
+  tablet: {
+    ...COMPACT_LAYOUT,
+    toolbarHeight: 44,
+    sidebarRailWidth: 48,
+    leftSidebarDefaultWidth: 300,
+    leftSidebarMinWidth: 260,
+    rightSidebarDefaultWidth: 300,
+    rightSidebarMinWidth: 260,
+    previewPadding: 16,
+    timelineDefaultSize: 32,
+    timelineTrackHeight: 88,
+  },
+  phone: {
+    ...COMPACT_LAYOUT,
+    toolbarHeight: 44,
+    sidebarRailWidth: 0,
+    leftSidebarDefaultWidth: 360,
+    leftSidebarMinWidth: 280,
+    leftSidebarMaxWidth: 420,
+    rightSidebarDefaultWidth: 360,
     rightSidebarMinWidth: 280,
     rightSidebarMaxWidth: 420,
-    previewPadding: 32,
-    previewSplitHeaderHeight: 32,
-    previewControlsHeight: 32,
-    previewControlButtonSize: 30,
-    timelineDefaultSize: 28,
-    timelineMinSize: 14,
-    timelineMaxSize: 80,
-    graphPanelSizeIncrease: 10,
-    timelineHeaderHeight: 40,
-    // Ruler + its left-column header are kept equal so track rows align on both
-    // sides. The ruler now hosts a top IO lane (12px) + a shorter tick ruler.
-    timelineTracksHeaderHeight: 34,
-    timelineRulerHeight: 34,
-    // The Edit track header follows the classic dopesheet property column so
-    // both timeline surfaces share the same ruler and playhead origin.
-    timelineSidebarWidth: EDIT_DOPESHEET_COLUMN_WIDTH,
-    timelineMeterWidth: 84,
-    timelineMixerWidth: 260,
-    timelineTrackHeight: 100,
-    timelineClipLabelRowHeight: 24,
-    timelineWaveformRowHeight: 24,
+    previewPadding: 8,
+    previewControlsHeight: 40,
+    previewControlButtonSize: 36,
+    timelineDefaultSize: 22,
+    timelineMinSize: 18,
+    timelineMaxSize: 45,
+    timelineHeaderHeight: 36,
+    timelineTracksHeaderHeight: 28,
+    timelineRulerHeight: 28,
+    timelineSidebarWidth: 120,
+    timelineMeterWidth: 0,
+    timelineMixerWidth: 0,
+    timelineTrackHeight: 64,
+    timelineClipLabelRowHeight: 18,
+    timelineWaveformRowHeight: 18,
   },
 } as const
 
@@ -49,10 +86,30 @@ export type EditorLayout = (typeof EDITOR_DENSITY_PRESETS)[EditorDensityPresetNa
 type LeftSidebarLayoutBounds = { leftSidebarMinWidth: number; leftSidebarMaxWidth: number }
 type RightSidebarLayoutBounds = { rightSidebarMinWidth: number; rightSidebarMaxWidth: number }
 
+export type EditorViewportMode = 'desktop' | 'tablet' | 'phone'
+
+/** Breakpoints (px): phone < tabletMin ≤ tablet < desktopMin ≤ desktop */
+export const EDITOR_VIEWPORT_TABLET_MIN = 768
+export const EDITOR_VIEWPORT_DESKTOP_MIN = 1100
+
+export function resolveEditorViewportMode(width: number): EditorViewportMode {
+  if (!Number.isFinite(width) || width <= 0) return 'desktop'
+  if (width < EDITOR_VIEWPORT_TABLET_MIN) return 'phone'
+  if (width < EDITOR_VIEWPORT_DESKTOP_MIN) return 'tablet'
+  return 'desktop'
+}
+
+export function densityPresetForViewport(mode: EditorViewportMode): EditorDensityPresetName {
+  if (mode === 'phone') return 'phone'
+  if (mode === 'tablet') return 'tablet'
+  return 'compact'
+}
+
 export const DEFAULT_EDITOR_DENSITY_PRESET: EditorDensityPresetName = 'compact'
 
 export function normalizeEditorDensityPreset(value: unknown): EditorDensityPresetName {
-  return value === 'compact' ? value : DEFAULT_EDITOR_DENSITY_PRESET
+  if (value === 'compact' || value === 'tablet' || value === 'phone') return value
+  return DEFAULT_EDITOR_DENSITY_PRESET
 }
 
 export function getEditorLayout(preset: unknown = DEFAULT_EDITOR_DENSITY_PRESET): EditorLayout {
@@ -164,7 +221,10 @@ export function getLeftEditorSidebarBounds(
 
   return {
     minWidth: layout.leftSidebarMinWidth,
-    maxWidth: Math.max(layout.leftSidebarMinWidth, viewportMaxWidth),
+    maxWidth: Math.max(
+      layout.leftSidebarMinWidth,
+      Math.min(layout.leftSidebarMaxWidth, viewportMaxWidth),
+    ),
   }
 }
 

--- a/src/config/editor-layout.viewport.test.ts
+++ b/src/config/editor-layout.viewport.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { densityPresetForViewport, resolveEditorViewportMode } from '@/config/editor-layout'
+
+describe('editor viewport mode', () => {
+  it('classifies phone / tablet / desktop breakpoints', () => {
+    expect(resolveEditorViewportMode(400)).toBe('phone')
+    expect(resolveEditorViewportMode(800)).toBe('tablet')
+    expect(resolveEditorViewportMode(1280)).toBe('desktop')
+  })
+
+  it('maps viewport to density presets', () => {
+    expect(densityPresetForViewport('phone')).toBe('phone')
+    expect(densityPresetForViewport('tablet')).toBe('tablet')
+    expect(densityPresetForViewport('desktop')).toBe('compact')
+  })
+})

--- a/src/config/flow.ts
+++ b/src/config/flow.ts
@@ -1,0 +1,16 @@
+/**
+ * Flow segment duration limits (Seedance 2.0 image-to-video).
+ * Longer films use multi-segment chaining (last frame → next first).
+ */
+
+export const FLOW_DURATION_MIN_SEC = 4
+export const FLOW_DURATION_MAX_SEC = 15
+export const FLOW_DURATION_DEFAULT_SEC = 5
+
+export type FlowQuality = '480p' | '720p' | '1080p'
+export type FlowSpeed = 'standard' | 'fast'
+
+export function clampFlowDuration(seconds: number): number {
+  if (!Number.isFinite(seconds)) return FLOW_DURATION_DEFAULT_SEC
+  return Math.min(FLOW_DURATION_MAX_SEC, Math.max(FLOW_DURATION_MIN_SEC, Math.round(seconds)))
+}

--- a/src/config/flow.ts
+++ b/src/config/flow.ts
@@ -2,6 +2,7 @@
  * Flow segment duration limits (Seedance 2.0 image-to-video).
  * Longer films use multi-segment chaining (last frame → next first).
  */
+// fallow-ignore-file unused-type
 
 export const FLOW_DURATION_MIN_SEC = 4
 export const FLOW_DURATION_MAX_SEC = 15

--- a/src/features/editor/components/ai-tab.tsx
+++ b/src/features/editor/components/ai-tab.tsx
@@ -1,15 +1,16 @@
 import { memo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Clapperboard, WandSparkles } from 'lucide-react'
+import { Clapperboard, Layers, WandSparkles } from 'lucide-react'
 import { cn } from '@/shared/ui/cn'
 import { AiPanel } from './ai-panel'
 import { DirectorChatPanel } from '../director'
+import { FlowPanel } from '../flow'
 
-type AiTabMode = 'generate' | 'director'
+type AiTabMode = 'generate' | 'flow' | 'director'
 
 /**
- * AI sidebar tab: local generation tools (TTS / music) and Creative Director
- * (Vertex Agent Engine SSE). The on-device Gemma assistant stays hidden.
+ * AI sidebar: local Generate (TTS/music), paid Flow (start/end → video),
+ * and paid Creative Director.
  */
 export const AiTab = memo(function AiTab() {
   const { t } = useTranslation()
@@ -22,7 +23,7 @@ export const AiTab = memo(function AiTab() {
           type="button"
           onClick={() => setMode('generate')}
           className={cn(
-            'flex flex-1 items-center justify-center gap-1.5 rounded-md px-2 py-1.5 text-[11px] font-medium transition-colors',
+            'flex flex-1 items-center justify-center gap-1 rounded-md px-1.5 py-1.5 text-[10px] font-medium transition-colors sm:gap-1.5 sm:text-[11px]',
             mode === 'generate'
               ? 'bg-secondary text-foreground'
               : 'text-muted-foreground hover:bg-secondary/40 hover:text-foreground',
@@ -33,9 +34,22 @@ export const AiTab = memo(function AiTab() {
         </button>
         <button
           type="button"
+          onClick={() => setMode('flow')}
+          className={cn(
+            'flex flex-1 items-center justify-center gap-1 rounded-md px-1.5 py-1.5 text-[10px] font-medium transition-colors sm:gap-1.5 sm:text-[11px]',
+            mode === 'flow'
+              ? 'bg-primary/15 text-primary ring-1 ring-primary/35'
+              : 'text-muted-foreground hover:bg-secondary/40 hover:text-foreground',
+          )}
+        >
+          <Layers className="h-3 w-3 opacity-80" strokeWidth={1.75} />
+          {t('director.tab.flow', { defaultValue: 'Flow' })}
+        </button>
+        <button
+          type="button"
           onClick={() => setMode('director')}
           className={cn(
-            'flex flex-1 items-center justify-center gap-1.5 rounded-md px-2 py-1.5 text-[11px] font-medium transition-colors',
+            'flex flex-1 items-center justify-center gap-1 rounded-md px-1.5 py-1.5 text-[10px] font-medium transition-colors sm:gap-1.5 sm:text-[11px]',
             mode === 'director'
               ? 'bg-primary/15 text-primary ring-1 ring-primary/35'
               : 'text-muted-foreground hover:bg-secondary/40 hover:text-foreground',
@@ -46,7 +60,13 @@ export const AiTab = memo(function AiTab() {
         </button>
       </div>
       <div className="min-h-0 flex-1 overflow-hidden">
-        {mode === 'generate' ? <AiPanel /> : <DirectorChatPanel />}
+        {mode === 'generate' ? (
+          <AiPanel />
+        ) : mode === 'flow' ? (
+          <FlowPanel />
+        ) : (
+          <DirectorChatPanel />
+        )}
       </div>
     </div>
   )

--- a/src/features/editor/components/editor-overlay-chrome.tsx
+++ b/src/features/editor/components/editor-overlay-chrome.tsx
@@ -1,0 +1,127 @@
+import { Film, PanelRight, WandSparkles } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Sheet, SheetContent } from '@/components/ui/sheet'
+import { useEditorStore } from '@/shared/state/editor'
+import { MediaSidebar } from './media-sidebar'
+import { PropertiesSidebar } from './properties-sidebar'
+import { ErrorBoundary } from '@/app/error-boundary'
+import type { EditorViewportMode } from '@/config/editor-layout'
+
+/**
+ * Tablet/phone overlay chrome: docked sidebars become sheets so preview stays full-bleed.
+ * Phone also exposes a bottom bar that opens Media (incl. AI/Flow/Director) and Properties.
+ */
+export function EditorOverlayChrome({ mode }: { mode: EditorViewportMode }) {
+  const leftSidebarOpen = useEditorStore((s) => s.leftSidebarOpen)
+  const rightSidebarOpen = useEditorStore((s) => s.rightSidebarOpen)
+  const setLeftSidebarOpen = useEditorStore((s) => s.setLeftSidebarOpen)
+  const setRightSidebarOpen = useEditorStore((s) => s.setRightSidebarOpen)
+  const setActiveTab = useEditorStore((s) => s.setActiveTab)
+  const isPhone = mode === 'phone'
+
+  return (
+    <>
+      <Sheet open={leftSidebarOpen} onOpenChange={setLeftSidebarOpen}>
+        <SheetContent
+          side={isPhone ? 'bottom' : 'left'}
+          className={isPhone ? 'p-0' : 'w-[min(100vw,22rem)] p-0'}
+        >
+          <div className="flex h-full min-h-0 flex-col overflow-hidden pt-8">
+            <ErrorBoundary level="feature">
+              <MediaSidebar />
+            </ErrorBoundary>
+          </div>
+        </SheetContent>
+      </Sheet>
+
+      <Sheet open={rightSidebarOpen} onOpenChange={setRightSidebarOpen}>
+        <SheetContent
+          side={isPhone ? 'bottom' : 'right'}
+          className={isPhone ? 'p-0' : 'w-[min(100vw,22rem)] p-0'}
+        >
+          <div className="flex h-full min-h-0 flex-col overflow-hidden pt-8">
+            <ErrorBoundary level="feature">
+              <PropertiesSidebar />
+            </ErrorBoundary>
+          </div>
+        </SheetContent>
+      </Sheet>
+
+      {isPhone && (
+        <nav
+          className="pointer-events-none fixed inset-x-0 bottom-0 z-40 flex justify-center gap-2 p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]"
+          aria-label="Editor panels"
+        >
+          <div className="pointer-events-auto flex items-center gap-1 rounded-full border border-border/80 bg-background/95 p-1 shadow-lg backdrop-blur-md">
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              className="h-10 gap-1.5 rounded-full px-3 text-[11px]"
+              onClick={() => {
+                setActiveTab('media')
+                setLeftSidebarOpen(true)
+              }}
+            >
+              <Film className="h-4 w-4" />
+              Media
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              className="h-10 gap-1.5 rounded-full px-3 text-[11px]"
+              onClick={() => {
+                setActiveTab('ai')
+                setLeftSidebarOpen(true)
+              }}
+            >
+              <WandSparkles className="h-4 w-4" />
+              AI
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              className="h-10 gap-1.5 rounded-full px-3 text-[11px]"
+              onClick={() => setRightSidebarOpen(true)}
+            >
+              <PanelRight className="h-4 w-4" />
+              Inspect
+            </Button>
+          </div>
+        </nav>
+      )}
+
+      {mode === 'tablet' && (
+        <div className="pointer-events-none fixed inset-y-0 left-0 z-30 flex flex-col justify-center p-2">
+          <Button
+            type="button"
+            size="icon"
+            variant="secondary"
+            className="pointer-events-auto h-10 w-10 rounded-full shadow-md"
+            aria-label="Open media library"
+            onClick={() => setLeftSidebarOpen(true)}
+          >
+            <Film className="h-4 w-4" />
+          </Button>
+        </div>
+      )}
+
+      {mode === 'tablet' && (
+        <div className="pointer-events-none fixed inset-y-0 right-0 z-30 flex flex-col justify-center p-2">
+          <Button
+            type="button"
+            size="icon"
+            variant="secondary"
+            className="pointer-events-auto h-10 w-10 rounded-full shadow-md"
+            aria-label="Open properties"
+            onClick={() => setRightSidebarOpen(true)}
+          >
+            <PanelRight className="h-4 w-4" />
+          </Button>
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/features/editor/components/editor.test.tsx
+++ b/src/features/editor/components/editor.test.tsx
@@ -15,6 +15,8 @@ const mocks = vi.hoisted(() => ({
   setPreviewQuality: vi.fn(),
   toggleSnap: vi.fn(),
   syncSidebarLayout: vi.fn(),
+  setLeftSidebarOpen: vi.fn(),
+  setRightSidebarOpen: vi.fn(),
   editorState: {
     workspace: 'edit',
     propertiesFullColumn: false,
@@ -231,6 +233,8 @@ vi.mock('@/shared/state/editor', () => ({
   useEditorStore: (
     selector: (state: {
       syncSidebarLayout: typeof mocks.syncSidebarLayout
+      setLeftSidebarOpen: typeof mocks.setLeftSidebarOpen
+      setRightSidebarOpen: typeof mocks.setRightSidebarOpen
       propertiesFullColumn: boolean
       mediaFullColumn: boolean
       workspace: string
@@ -238,10 +242,26 @@ vi.mock('@/shared/state/editor', () => ({
   ) =>
     selector({
       syncSidebarLayout: mocks.syncSidebarLayout,
+      setLeftSidebarOpen: mocks.setLeftSidebarOpen,
+      setRightSidebarOpen: mocks.setRightSidebarOpen,
       propertiesFullColumn: mocks.editorState.propertiesFullColumn,
       mediaFullColumn: mocks.editorState.mediaFullColumn,
       workspace: mocks.editorState.workspace,
     }),
+}))
+
+vi.mock('@/features/editor/hooks/use-editor-viewport-mode', () => ({
+  useEditorViewportMode: () => ({
+    mode: 'desktop' as const,
+    densityPreset: 'compact' as const,
+    isDesktop: true,
+    isTablet: false,
+    isPhone: false,
+  }),
+}))
+
+vi.mock('./editor-overlay-chrome', () => ({
+  EditorOverlayChrome: () => null,
 }))
 
 vi.mock('@/features/editor/deps/composition-runtime', () => ({

--- a/src/features/editor/components/editor.tsx
+++ b/src/features/editor/components/editor.tsx
@@ -380,6 +380,7 @@ const TimelineShortcutsController = memo(function TimelineShortcutsController() 
   return null
 })
 
+// fallow-ignore-next-line complexity
 export const LoadedEditor = memo(function LoadedEditor({
   projectId,
   project,

--- a/src/features/editor/components/editor.tsx
+++ b/src/features/editor/components/editor.tsx
@@ -50,6 +50,8 @@ import {
 } from '@/features/editor/deps/export-contract'
 import { getEditorLayout, getEditorLayoutCssVars } from '@/config/editor-layout'
 import { EDITOR_WORKSPACE_TIMELINE_SIZE, type EditorWorkspaceId } from '@/config/editor-workspaces'
+import { useEditorViewportMode } from '@/features/editor/hooks/use-editor-viewport-mode'
+import { EditorOverlayChrome } from './editor-overlay-chrome'
 import {
   createProjectUpgradeBackup,
   formatProjectUpgradeBackupName,
@@ -394,9 +396,14 @@ export const LoadedEditor = memo(function LoadedEditor({
   const [bundleFileHandle, setBundleFileHandle] = useState<FileSystemFileHandle | undefined>()
   const editorDensity = useSettingsStore((s) => s.editorDensity)
   const snapEnabledPreference = useSettingsStore((s) => s.snapEnabled)
-  const editorLayout = getEditorLayout(editorDensity)
+  const { mode: viewportMode, densityPreset: viewportDensity, isDesktop } = useEditorViewportMode()
+  // Viewport density wins on tablet/phone so chrome fits; desktop keeps user setting.
+  const effectiveDensity = isDesktop ? editorDensity : viewportDensity
+  const editorLayout = getEditorLayout(effectiveDensity)
   const editorLayoutCssVars = getEditorLayoutCssVars(editorLayout)
   const syncSidebarLayout = useEditorStore((s) => s.syncSidebarLayout)
+  const setLeftSidebarOpen = useEditorStore((s) => s.setLeftSidebarOpen)
+  const setRightSidebarOpen = useEditorStore((s) => s.setRightSidebarOpen)
   const propertiesFullColumn = useEditorStore((s) => s.propertiesFullColumn)
   const mediaFullColumn = useEditorStore((s) => s.mediaFullColumn)
   const workspace = useEditorStore((s) => s.workspace)
@@ -541,6 +548,13 @@ export const LoadedEditor = memo(function LoadedEditor({
     syncSidebarLayout(editorLayout)
   }, [editorLayout, syncSidebarLayout])
 
+  // Compact viewports: start with sidebars closed so preview stays full-bleed.
+  useEffect(() => {
+    if (isDesktop) return
+    setLeftSidebarOpen(false)
+    setRightSidebarOpen(false)
+  }, [isDesktop, setLeftSidebarOpen, setRightSidebarOpen, viewportMode])
+
   // Apply the per-workspace timeline split when switching workspaces:
   // snapshot the outgoing workspace's split, then restore the incoming
   // workspace's saved split (or its preset default on first visit).
@@ -665,11 +679,15 @@ export const LoadedEditor = memo(function LoadedEditor({
   // Color replaces the default editor shell. Motion deliberately keeps it and
   // swaps the preview/timeline surfaces while retaining the shared sidebars.
   const hidesDefaultSidebars = isColorWorkspace
+  const useOverlaySidebars = !isDesktop && !hidesDefaultSidebars
+  // Phone: taller preview / shorter timeline for light edit.
+  const phoneTimelineDefault = viewportMode === 'phone' ? 22 : editorLayout.timelineDefaultSize
 
   return (
     <div
       className="h-screen bg-background flex flex-col overflow-hidden"
       style={editorLayoutCssVars as import('react').CSSProperties}
+      data-editor-viewport={viewportMode}
       role="application"
       aria-label={t('editor.editor.appLabel')}
     >
@@ -691,8 +709,8 @@ export const LoadedEditor = memo(function LoadedEditor({
 
       {/* Main Layout: Full-height sidebar + vertical split */}
       <div className="flex-1 flex overflow-hidden">
-        {/* Left Sidebar - Media Library (full column mode) */}
-        {mediaFullColumn && !hidesDefaultSidebars && (
+        {/* Left Sidebar - Media Library (full column mode, desktop only) */}
+        {mediaFullColumn && !hidesDefaultSidebars && isDesktop && (
           <InteractionLockRegion locked={isMaskEditingActive}>
             <ErrorBoundary level="feature">
               <MediaSidebar />
@@ -730,13 +748,13 @@ export const LoadedEditor = memo(function LoadedEditor({
           >
             {/* Top - Preview + Properties (inline mode) */}
             <ResizablePanel
-              defaultSize={100 - editorLayout.timelineDefaultSize}
+              defaultSize={100 - phoneTimelineDefault}
               minSize={100 - editorLayout.timelineMaxSize}
               maxSize={100 - editorLayout.timelineMinSize}
             >
               <div className="h-full flex overflow-hidden relative">
-                {/* Left Sidebar - Media Library (inline with preview) */}
-                {!mediaFullColumn && (
+                {/* Left Sidebar - Media Library (inline with preview, desktop) */}
+                {!mediaFullColumn && isDesktop && (
                   <InteractionLockRegion locked={isMaskEditingActive}>
                     <ErrorBoundary level="feature">
                       <MediaSidebar />
@@ -753,8 +771,8 @@ export const LoadedEditor = memo(function LoadedEditor({
                   )}
                 </ErrorBoundary>
 
-                {/* Right Sidebar - Properties (inline with preview) */}
-                {!propertiesFullColumn && (
+                {/* Right Sidebar - Properties (inline with preview, desktop) */}
+                {!propertiesFullColumn && isDesktop && (
                   <InteractionLockRegion locked={isMaskEditingActive}>
                     <ErrorBoundary level="feature">
                       <PropertiesSidebar />
@@ -772,7 +790,7 @@ export const LoadedEditor = memo(function LoadedEditor({
             {/* Bottom - Timeline */}
             <ResizablePanel
               ref={timelinePanelRef}
-              defaultSize={editorLayout.timelineDefaultSize}
+              defaultSize={phoneTimelineDefault}
               minSize={editorLayout.timelineMinSize}
               maxSize={editorLayout.timelineMaxSize}
             >
@@ -788,7 +806,7 @@ export const LoadedEditor = memo(function LoadedEditor({
                         </Suspense>
                       )}
                     </div>
-                    <AudioMeterPanel />
+                    {viewportMode !== 'phone' && <AudioMeterPanel />}
                   </div>
                 </ErrorBoundary>
               </InteractionLockRegion>
@@ -796,8 +814,8 @@ export const LoadedEditor = memo(function LoadedEditor({
           </ResizablePanelGroup>
         )}
 
-        {/* Right Sidebar - Properties (full column mode) */}
-        {propertiesFullColumn && !hidesDefaultSidebars && (
+        {/* Right Sidebar - Properties (full column mode, desktop only) */}
+        {propertiesFullColumn && !hidesDefaultSidebars && isDesktop && (
           <InteractionLockRegion locked={isMaskEditingActive}>
             <ErrorBoundary level="feature">
               <PropertiesSidebar />
@@ -805,6 +823,8 @@ export const LoadedEditor = memo(function LoadedEditor({
           </InteractionLockRegion>
         )}
       </div>
+
+      {useOverlaySidebars && <EditorOverlayChrome mode={viewportMode} />}
 
       <Suspense fallback={null}>
         {/* Export Dialog */}

--- a/src/features/editor/deps/credits-contract.ts
+++ b/src/features/editor/deps/credits-contract.ts
@@ -2,3 +2,4 @@
  * Cross-feature dependency contract: credits / CRTVAI balance.
  */
 export { useCredits } from '@/features/credits/hooks/use-credits'
+export { formatUsdc6 } from '@/features/credits/usdc-for-purchase'

--- a/src/features/editor/deps/generative-contract.ts
+++ b/src/features/editor/deps/generative-contract.ts
@@ -1,0 +1,10 @@
+/**
+ * Cross-feature dependency contract: generative / Evolink proxy.
+ */
+export {
+  getPublicImageUrl,
+  pollTask,
+  proxyFlowRun,
+  proxyGetTask,
+  useGenerativeAuth,
+} from '@/features/generative'

--- a/src/features/editor/deps/generative.ts
+++ b/src/features/editor/deps/generative.ts
@@ -1,0 +1,10 @@
+/**
+ * Cross-feature dependency adapter: generative / Evolink proxy.
+ */
+export {
+  getPublicImageUrl,
+  pollTask,
+  proxyFlowRun,
+  proxyGetTask,
+  useGenerativeAuth,
+} from './generative-contract'

--- a/src/features/editor/deps/live-ai-contract.ts
+++ b/src/features/editor/deps/live-ai-contract.ts
@@ -1,4 +1,4 @@
 /**
  * Cross-feature dependency contract: Live AI panel.
  */
-export { LiveAiPopover } from '@/features/live-ai'
+export { LiveAiPopover, usePremiumMembership } from '@/features/live-ai'

--- a/src/features/editor/deps/live-ai.ts
+++ b/src/features/editor/deps/live-ai.ts
@@ -1,4 +1,4 @@
 /**
  * Cross-feature dependency adapter: Live AI panel.
  */
-export { LiveAiPopover } from './live-ai-contract'
+export { LiveAiPopover, usePremiumMembership } from './live-ai-contract'

--- a/src/features/editor/deps/metoken-contract.ts
+++ b/src/features/editor/deps/metoken-contract.ts
@@ -1,0 +1,4 @@
+/**
+ * Cross-feature dependency contract: metoken/CRTVAI buy modal.
+ */
+export { BuyMetokenModal } from '@/features/metoken'

--- a/src/features/editor/deps/metoken.ts
+++ b/src/features/editor/deps/metoken.ts
@@ -1,0 +1,4 @@
+/**
+ * Cross-feature dependency adapter: metoken/CRTVAI.
+ */
+export { BuyMetokenModal } from './metoken-contract'

--- a/src/features/editor/director/director-chat-panel.tsx
+++ b/src/features/editor/director/director-chat-panel.tsx
@@ -10,7 +10,7 @@ import {
   useItemsStore,
   useTimelineSettingsStore,
 } from '@/features/editor/deps/timeline-store-contract'
-import { usePremiumMembership } from '@/features/live-ai/hooks/use-premium-membership'
+import { usePremiumMembership } from '@/features/editor/deps/live-ai'
 import { useSmartWalletOps } from '@/hooks/use-smart-wallet-ops'
 import { getDirectorTreasuryAddress } from './build-director-payment'
 import { confirmDirectorInvoice } from './confirm-director-invoice'

--- a/src/features/editor/director/director-chat-panel.tsx
+++ b/src/features/editor/director/director-chat-panel.tsx
@@ -10,11 +10,13 @@ import {
   useItemsStore,
   useTimelineSettingsStore,
 } from '@/features/editor/deps/timeline-store-contract'
+import { usePremiumMembership } from '@/features/live-ai/hooks/use-premium-membership'
 import { useSmartWalletOps } from '@/hooks/use-smart-wallet-ops'
 import { getDirectorTreasuryAddress } from './build-director-payment'
 import { confirmDirectorInvoice } from './confirm-director-invoice'
 import { quoteDirectorBrief } from './director-pricing'
 import { DirectorInvoiceCard, type PendingDirectorInvoice } from './director-invoice-card'
+import { DirectorSessionPacks } from './director-session-packs'
 import { useDirectorStore } from './director-store'
 import {
   buildDirectorTimelineAudioContext,
@@ -135,8 +137,10 @@ export const DirectorChatPanel = memo(function DirectorChatPanel() {
 
   const { account, connect, authenticated, configured: walletConfigured } = useWalletContext()
   const { balance, refreshBalance } = useCredits()
+  const { isPremiumMember } = usePremiumMembership(account)
   const { sendOps, ready: walletOpsReady } = useSmartWalletOps()
   const canPayOnChain = Boolean(getDirectorTreasuryAddress() && walletOpsReady)
+  const hasCrtvai = balance > 0
 
   const timelineItems = useItemsStore((s) => s.items)
   const fps = useTimelineSettingsStore((s) => s.fps)
@@ -191,8 +195,18 @@ export const DirectorChatPanel = memo(function DirectorChatPanel() {
         return
       }
 
+      if (walletConfigured && authenticated && !hasCrtvai) {
+        reportLocalError(
+          t('director.error.zeroBalance', {
+            defaultValue: 'Your CRTVAI balance is empty. Buy credits below, then brief again.',
+          }),
+        )
+        return
+      }
+
       const quote = quoteDirectorBrief({
         audioDurationSeconds: audioContext.primary.durationSeconds,
+        isPremium: isPremiumMember,
       })
       if (!quote) {
         reportLocalError(
@@ -211,7 +225,17 @@ export const DirectorChatPanel = memo(function DirectorChatPanel() {
         quote,
       })
     },
-    [audioContext, authenticated, connect, hasTimelineAudio, reportLocalError, t, walletConfigured],
+    [
+      audioContext,
+      authenticated,
+      connect,
+      hasCrtvai,
+      hasTimelineAudio,
+      isPremiumMember,
+      reportLocalError,
+      t,
+      walletConfigured,
+    ],
   )
 
   const cancelInvoice = useCallback(() => {
@@ -362,7 +386,22 @@ export const DirectorChatPanel = memo(function DirectorChatPanel() {
                           'Drop a track onto the timeline first. The Director builds beat-synced storyboards from audio already in your edit.',
                       })}
                 </p>
+                {isPremiumMember ? (
+                  <p className="text-[11px] text-emerald-300/90">
+                    {t('director.empty.premium', {
+                      defaultValue: 'Pro rate active — half-price Director minutes.',
+                    })}
+                  </p>
+                ) : (
+                  <p className="text-[11px] text-muted-foreground/90">
+                    {t('director.empty.proValue', {
+                      defaultValue: 'Cloud Director · beat-synced research · Pro members pay half.',
+                    })}
+                  </p>
+                )}
               </div>
+
+              {walletConfigured && authenticated && !hasCrtvai && <DirectorSessionPacks />}
 
               <ul className="space-y-1.5">
                 {SUGGESTIONS.map((suggestion, index) => (

--- a/src/features/editor/director/director-chat-panel.tsx
+++ b/src/features/editor/director/director-chat-panel.tsx
@@ -172,6 +172,7 @@ export const DirectorChatPanel = memo(function DirectorChatPanel() {
   }, [input])
 
   const queueInvoice = useCallback(
+    // fallow-ignore-next-line complexity
     (text: string) => {
       const trimmed = text.trim()
       if (!trimmed) return

--- a/src/features/editor/director/director-invoice-card.tsx
+++ b/src/features/editor/director/director-invoice-card.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react'
 import { Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { BuyMetokenModal } from '@/features/metoken/components/buy-metoken-modal'
 import { cn } from '@/shared/ui/cn'
 import type { DirectorQuote } from './director-pricing'
 
@@ -29,6 +31,8 @@ export function DirectorInvoiceCard({
 }) {
   const { quote } = invoice
   const insufficient = balance < quote.crtvaiDisplay
+  const [buyOpen, setBuyOpen] = useState(false)
+  const suggestedUsdc = Math.max(1, Math.ceil(quote.estimatedUsdc6 / 1_000_000)).toFixed(2)
 
   return (
     <div className="rounded-xl border border-primary/35 bg-secondary/30 p-3.5">
@@ -45,6 +49,21 @@ export function DirectorInvoiceCard({
         })}
       </p>
 
+      {quote.tier === 'premium' ? (
+        <p className="mt-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-2 py-1.5 text-[11px] text-emerald-200/90">
+          {t('director.invoice.premium', {
+            defaultValue: 'Pro rate — Creative Org / Pixels Premium members save 50% vs retail.',
+          })}
+        </p>
+      ) : (
+        <p className="mt-2 rounded-md border border-border/70 bg-secondary/40 px-2 py-1.5 text-[11px] text-muted-foreground">
+          {t('director.invoice.proUpsell', {
+            defaultValue:
+              'Pro tip: Creative Org DAO or Pixels Premium unlocks half-price Director minutes plus cloud research tools.',
+          })}
+        </p>
+      )}
+
       <dl className="mt-3 space-y-1.5 font-mono text-[11px]">
         <div className="flex justify-between gap-3">
           <dt className="text-muted-foreground">Audio</dt>
@@ -57,6 +76,7 @@ export function DirectorInvoiceCard({
           <dt className="text-muted-foreground">Rate</dt>
           <dd className="text-foreground">
             {(quote.usdc6PerMinute / 1_000_000).toFixed(2)} USD / min
+            <span className="ml-1 text-muted-foreground">({quote.tier})</span>
           </dd>
         </div>
         <div className="flex justify-between gap-3 border-t border-border/60 pt-1.5">
@@ -75,11 +95,23 @@ export function DirectorInvoiceCard({
       </dl>
 
       {insufficient && (
-        <p className="mt-2 text-[11px] text-destructive">
-          {t('director.invoice.insufficient', {
-            defaultValue: 'Insufficient CRTVAI. Buy credits, then confirm again.',
-          })}
-        </p>
+        <div className="mt-2 space-y-2">
+          <p className="text-[11px] text-destructive">
+            {t('director.invoice.insufficient', {
+              defaultValue: 'Insufficient CRTVAI. Buy credits, then confirm again.',
+            })}
+          </p>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            className="h-8 w-full text-[11px]"
+            disabled={paying}
+            onClick={() => setBuyOpen(true)}
+          >
+            {t('director.invoice.buyCrtvai', { defaultValue: 'Buy CRTVAI' })}
+          </Button>
+        </div>
       )}
 
       {!canPayOnChain && (
@@ -122,6 +154,8 @@ export function DirectorInvoiceCard({
           )}
         </Button>
       </div>
+
+      <BuyMetokenModal open={buyOpen} onOpenChange={setBuyOpen} initialUsdcAmount={suggestedUsdc} />
     </div>
   )
 }

--- a/src/features/editor/director/director-invoice-card.tsx
+++ b/src/features/editor/director/director-invoice-card.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { BuyMetokenModal } from '@/features/metoken/components/buy-metoken-modal'
+import { BuyMetokenModal } from '@/features/editor/deps/metoken'
 import { cn } from '@/shared/ui/cn'
 import type { DirectorQuote } from './director-pricing'
 

--- a/src/features/editor/director/director-session-packs.tsx
+++ b/src/features/editor/director/director-session-packs.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
-import { BuyMetokenModal } from '@/features/metoken/components/buy-metoken-modal'
+import { BuyMetokenModal } from '@/features/editor/deps/metoken'
 import { DIRECTOR_SESSION_PACKS } from '@/config/credits'
-import { formatUsdc6 } from '@/features/credits/usdc-for-purchase'
+import { formatUsdc6 } from '@/features/editor/deps/credits-contract'
 
 /**
  * Optional Director session packs — mint CRTVAI sized for ~N minutes of retail

--- a/src/features/editor/director/director-session-packs.tsx
+++ b/src/features/editor/director/director-session-packs.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Button } from '@/components/ui/button'
+import { BuyMetokenModal } from '@/features/metoken/components/buy-metoken-modal'
+import { DIRECTOR_SESSION_PACKS } from '@/config/credits'
+import { formatUsdc6 } from '@/features/credits/usdc-for-purchase'
+
+/**
+ * Optional Director session packs — mint CRTVAI sized for ~N minutes of retail
+ * Director audio. Settles via the same Buy CRTVAI curve (not a separate ledger).
+ */
+export function DirectorSessionPacks() {
+  const { t } = useTranslation()
+  const [buyOpen, setBuyOpen] = useState(false)
+  const [prefillUsdc, setPrefillUsdc] = useState<string | undefined>()
+
+  return (
+    <div className="rounded-xl border border-border/70 bg-secondary/20 p-3">
+      <p className="font-mono text-[10px] tracking-[0.18em] text-muted-foreground uppercase">
+        {t('director.packs.eyebrow', { defaultValue: 'Session packs' })}
+      </p>
+      <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
+        {t('director.packs.blurb', {
+          defaultValue:
+            'Top up CRTVAI for multiple Director briefs. Packs estimate retail audio minutes; Pro members stretch further.',
+        })}
+      </p>
+      <ul className="mt-2.5 space-y-1.5">
+        {DIRECTOR_SESSION_PACKS.map((pack) => (
+          <li key={pack.id}>
+            <button
+              type="button"
+              className="flex w-full items-center justify-between gap-2 rounded-lg border border-border/60 bg-secondary/30 px-2.5 py-2 text-left transition-colors hover:border-primary/40 hover:bg-secondary/50"
+              onClick={() => {
+                setPrefillUsdc((pack.usdc6 / 1_000_000).toFixed(2))
+                setBuyOpen(true)
+              }}
+            >
+              <span className="min-w-0">
+                <span className="block text-[12px] font-medium text-foreground">{pack.name}</span>
+                <span className="block truncate text-[10px] text-muted-foreground">
+                  {pack.description}
+                </span>
+              </span>
+              <span className="shrink-0 font-mono text-[11px] text-primary">
+                {formatUsdc6(pack.usdc6)}
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="mt-2 h-7 w-full text-[11px] text-muted-foreground"
+        onClick={() => {
+          setPrefillUsdc(undefined)
+          setBuyOpen(true)
+        }}
+      >
+        {t('director.packs.custom', { defaultValue: 'Custom amount…' })}
+      </Button>
+      <BuyMetokenModal open={buyOpen} onOpenChange={setBuyOpen} initialUsdcAmount={prefillUsdc} />
+    </div>
+  )
+}

--- a/src/features/editor/flow/flow-panel.tsx
+++ b/src/features/editor/flow/flow-panel.tsx
@@ -14,13 +14,20 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { BuyMetokenModal } from '@/features/metoken/components/buy-metoken-modal'
 import { useWalletContext } from '@/context/wallet-context'
 import { useCredits } from '@/features/editor/deps/credits-contract'
+import {
+  getPublicImageUrl,
+  pollTask,
+  proxyFlowRun,
+  proxyGetTask,
+  useGenerativeAuth,
+} from '@/features/editor/deps/generative'
 import {
   importMediaLibraryService,
   useMediaLibraryStore,
 } from '@/features/editor/deps/media-library'
+import { BuyMetokenModal } from '@/features/editor/deps/metoken'
 import {
   getDirectorTreasuryAddress,
   buildDirectorPaymentOp,
@@ -33,13 +40,6 @@ import {
   clampFlowDuration,
 } from '@/config/flow'
 import { quoteFlowGeneration } from './flow-pricing'
-import {
-  getPublicImageUrl,
-  pollTask,
-  proxyFlowRun,
-  proxyGetTask,
-  useGenerativeAuth,
-} from '@/features/generative'
 import { cn } from '@/shared/ui/cn'
 
 type FrameSlot = {

--- a/src/features/editor/flow/flow-panel.tsx
+++ b/src/features/editor/flow/flow-panel.tsx
@@ -158,6 +158,7 @@ export const FlowPanel = memo(function FlowPanel() {
     )
   }, [lastEndUrl, t])
 
+  // fallow-ignore-next-line complexity
   const runFlow = useCallback(async () => {
     if (busy) return
     if (!currentProjectId) {

--- a/src/features/editor/flow/flow-panel.tsx
+++ b/src/features/editor/flow/flow-panel.tsx
@@ -1,0 +1,645 @@
+import { memo, useCallback, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { ArrowRightLeft, ImagePlus, Loader2, Sparkles, Upload, WandSparkles } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import { Slider } from '@/components/ui/slider'
+import { Switch } from '@/components/ui/switch'
+import { Textarea } from '@/components/ui/textarea'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { BuyMetokenModal } from '@/features/metoken/components/buy-metoken-modal'
+import { useWalletContext } from '@/context/wallet-context'
+import { useCredits } from '@/features/editor/deps/credits-contract'
+import {
+  importMediaLibraryService,
+  useMediaLibraryStore,
+} from '@/features/editor/deps/media-library'
+import {
+  getDirectorTreasuryAddress,
+  buildDirectorPaymentOp,
+} from '../director/build-director-payment'
+import { useSmartWalletOps } from '@/hooks/use-smart-wallet-ops'
+import {
+  FLOW_DURATION_DEFAULT_SEC,
+  FLOW_DURATION_MAX_SEC,
+  FLOW_DURATION_MIN_SEC,
+  clampFlowDuration,
+} from '@/config/flow'
+import { quoteFlowGeneration } from './flow-pricing'
+import {
+  getPublicImageUrl,
+  pollTask,
+  proxyFlowRun,
+  proxyGetTask,
+  useGenerativeAuth,
+} from '@/features/generative'
+import { cn } from '@/shared/ui/cn'
+
+type FrameSlot = {
+  previewUrl: string | null
+  publicUrl: string | null
+  generatePrompt: string
+  mode: 'upload' | 'generate'
+}
+
+const emptySlot = (): FrameSlot => ({
+  previewUrl: null,
+  publicUrl: null,
+  generatePrompt: '',
+  mode: 'upload',
+})
+
+async function importRemoteVideo(url: string, projectId: string): Promise<void> {
+  const response = await fetch(url)
+  if (!response.ok) throw new Error('Failed to download generated video')
+  const blob = await response.blob()
+  const file = new File([blob], `flow-${Date.now()}.mp4`, {
+    type: blob.type || 'video/mp4',
+  })
+  const { mediaLibraryService } = await importMediaLibraryService()
+  await mediaLibraryService.importGeneratedVideo(file, projectId, {
+    tags: ['ai-generated', 'flow', 'seedance'],
+  })
+}
+
+// fallow-ignore-next-line complexity
+export const FlowPanel = memo(function FlowPanel() {
+  const { t } = useTranslation()
+  const fileStartRef = useRef<HTMLInputElement>(null)
+  const fileEndRef = useRef<HTMLInputElement>(null)
+
+  const { connect, authenticated, configured: walletConfigured } = useWalletContext()
+  const { balance, refreshBalance } = useCredits()
+  const { sendOps, ready: walletOpsReady } = useSmartWalletOps()
+  const auth = useGenerativeAuth()
+  const canPayOnChain = Boolean(getDirectorTreasuryAddress() && walletOpsReady)
+  const currentProjectId = useMediaLibraryStore((s) => s.currentProjectId)
+  const loadMediaItems = useMediaLibraryStore((s) => s.loadMediaItems)
+
+  const [start, setStart] = useState<FrameSlot>(emptySlot)
+  const [end, setEnd] = useState<FrameSlot>(emptySlot)
+  const [prompt, setPrompt] = useState('')
+  const [duration, setDuration] = useState(FLOW_DURATION_DEFAULT_SEC)
+  const [quality, setQuality] = useState<'480p' | '720p' | '1080p'>('720p')
+  const [speed, setSpeed] = useState<'standard' | 'fast'>('standard')
+  const [generateAudio, setGenerateAudio] = useState(true)
+  const [chainNext, setChainNext] = useState(false)
+  const [progress, setProgress] = useState(0)
+  const [status, setStatus] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [buyOpen, setBuyOpen] = useState(false)
+  const [lastEndUrl, setLastEndUrl] = useState<string | null>(null)
+
+  const stillCount =
+    (start.mode === 'generate' && !start.publicUrl && start.generatePrompt.trim() ? 1 : 0) +
+    (end.mode === 'generate' && !end.publicUrl && end.generatePrompt.trim() ? 1 : 0)
+
+  const quote = useMemo(
+    () =>
+      quoteFlowGeneration({
+        duration,
+        quality,
+        speed,
+        generateAudio,
+        stillCount,
+      }),
+    [duration, quality, speed, generateAudio, stillCount],
+  )
+
+  const insufficient = balance < quote.crtvaiDisplay
+
+  const assignFile = useCallback(
+    async (file: File, which: 'start' | 'end') => {
+      if (!auth) {
+        toast.error(t('flow.error.auth', { defaultValue: 'Wallet auth required for Flow.' }))
+        return
+      }
+      const previewUrl = URL.createObjectURL(file)
+      const publicUrl = await getPublicImageUrl(file, auth)
+      const patch = { previewUrl, publicUrl, mode: 'upload' as const, generatePrompt: '' }
+      if (which === 'start') setStart((s) => ({ ...s, ...patch }))
+      else setEnd((s) => ({ ...s, ...patch }))
+    },
+    [auth, t],
+  )
+
+  const onFile = useCallback(
+    (which: 'start' | 'end', files: FileList | null) => {
+      const file = files?.[0]
+      if (!file) return
+      void assignFile(file, which).catch((e) =>
+        toast.error(e instanceof Error ? e.message : 'Upload failed'),
+      )
+    },
+    [assignFile],
+  )
+
+  const continueFromLast = useCallback(() => {
+    if (!lastEndUrl) return
+    setStart({
+      previewUrl: lastEndUrl,
+      publicUrl: lastEndUrl,
+      generatePrompt: '',
+      mode: 'upload',
+    })
+    setEnd(emptySlot())
+    setChainNext(true)
+    toast.message(
+      t('flow.chain.ready', {
+        defaultValue: 'Start frame set from last segment. Add a new end frame to continue.',
+      }),
+    )
+  }, [lastEndUrl, t])
+
+  const runFlow = useCallback(async () => {
+    if (busy) return
+    if (!currentProjectId) {
+      toast.error(t('flow.error.noProject', { defaultValue: 'Open a project first.' }))
+      return
+    }
+    if (walletConfigured && !authenticated) {
+      connect()
+      toast.error(
+        t('flow.error.connect', { defaultValue: 'Connect your wallet to pay in CRTVAI.' }),
+      )
+      return
+    }
+    if (!auth) {
+      toast.error(t('flow.error.auth', { defaultValue: 'Wallet auth required for Flow.' }))
+      return
+    }
+    if (!prompt.trim()) {
+      toast.error(t('flow.error.prompt', { defaultValue: 'Describe the motion between frames.' }))
+      return
+    }
+    const hasStart = Boolean(start.publicUrl) || Boolean(start.generatePrompt.trim())
+    const hasEnd = Boolean(end.publicUrl) || Boolean(end.generatePrompt.trim())
+    if (!hasStart || !hasEnd) {
+      toast.error(
+        t('flow.error.frames', {
+          defaultValue: 'Provide a start and end image (upload or Gemini prompt).',
+        }),
+      )
+      return
+    }
+    if (insufficient) {
+      setBuyOpen(true)
+      toast.error(
+        t('flow.error.insufficient', { defaultValue: 'Insufficient CRTVAI for this Flow.' }),
+      )
+      return
+    }
+
+    setBusy(true)
+    setProgress(0)
+    setStatus(t('flow.status.paying', { defaultValue: 'Confirming payment…' }))
+    try {
+      let paymentTxHash: string | undefined
+      if (canPayOnChain) {
+        const { txHash } = await sendOps([buildDirectorPaymentOp(quote.crtvaiWei)])
+        paymentTxHash = txHash
+        refreshBalance()
+      }
+
+      setStatus(t('flow.status.generating', { defaultValue: 'Generating segment…' }))
+      const task = await proxyFlowRun(auth, {
+        prompt: prompt.trim(),
+        duration: clampFlowDuration(duration),
+        quality,
+        speed,
+        generate_audio: generateAudio,
+        ...(start.publicUrl ? { startImageUrl: start.publicUrl } : {}),
+        ...(end.publicUrl ? { endImageUrl: end.publicUrl } : {}),
+        ...(!start.publicUrl && start.generatePrompt.trim()
+          ? { startPrompt: start.generatePrompt.trim() }
+          : {}),
+        ...(!end.publicUrl && end.generatePrompt.trim()
+          ? { endPrompt: end.generatePrompt.trim() }
+          : {}),
+        stillQuality: '2K',
+        ...(paymentTxHash ? { paymentTxHash } : {}),
+      })
+
+      if (task.startImageUrl) {
+        setStart((s) => ({
+          ...s,
+          publicUrl: task.startImageUrl!,
+          previewUrl: task.startImageUrl!,
+        }))
+      }
+      if (task.endImageUrl) {
+        setEnd((s) => ({
+          ...s,
+          publicUrl: task.endImageUrl!,
+          previewUrl: task.endImageUrl!,
+        }))
+        setLastEndUrl(task.endImageUrl)
+      }
+
+      const final = await pollTask((signal) => proxyGetTask(task.id, signal, auth), {
+        onProgress: (d) => {
+          setProgress(d.progress ?? 0)
+          setStatus(
+            t('flow.status.progress', {
+              defaultValue: 'Rendering… {{pct}}%',
+              pct: Math.round(d.progress ?? 0),
+            }),
+          )
+        },
+      })
+
+      if (final.status !== 'completed' || !final.output?.video_url) {
+        throw new Error(final.error?.message || 'Flow generation failed')
+      }
+
+      setStatus(t('flow.status.importing', { defaultValue: 'Importing to library…' }))
+      await importRemoteVideo(final.output.video_url, currentProjectId)
+      await loadMediaItems()
+      toast.success(t('flow.success', { defaultValue: 'Flow segment added to media library.' }))
+
+      if (chainNext && task.endImageUrl) {
+        setStart({
+          previewUrl: task.endImageUrl,
+          publicUrl: task.endImageUrl,
+          generatePrompt: '',
+          mode: 'upload',
+        })
+        setEnd(emptySlot())
+      }
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Flow failed')
+    } finally {
+      setBusy(false)
+      setStatus(null)
+      setProgress(0)
+    }
+  }, [
+    auth,
+    authenticated,
+    busy,
+    canPayOnChain,
+    chainNext,
+    connect,
+    currentProjectId,
+    duration,
+    end,
+    generateAudio,
+    insufficient,
+    loadMediaItems,
+    prompt,
+    quality,
+    quote.crtvaiWei,
+    refreshBalance,
+    sendOps,
+    speed,
+    start,
+    t,
+    walletConfigured,
+  ])
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
+      <header className="shrink-0 border-b border-border/60 px-3 py-2.5">
+        <p className="font-mono text-[10px] tracking-[0.18em] text-primary/85 uppercase">
+          {t('flow.eyebrow', { defaultValue: 'Flow' })}
+        </p>
+        <h2 className="text-[13px] font-semibold tracking-tight text-foreground">
+          {t('flow.title', { defaultValue: 'Start → end video' })}
+        </h2>
+        <p className="mt-0.5 text-[11px] text-muted-foreground">
+          {t('flow.blurb', {
+            defaultValue:
+              'Upload or generate Gemini stills, set duration, pay CRTVAI, then fill the segment.',
+          })}
+        </p>
+      </header>
+
+      <div className="min-h-0 flex-1 space-y-3 overflow-y-auto px-3 py-3">
+        <div className="grid grid-cols-2 gap-2">
+          <FrameCard
+            label={t('flow.start', { defaultValue: 'Start' })}
+            slot={start}
+            onMode={(mode) => setStart((s) => ({ ...s, mode }))}
+            onPrompt={(generatePrompt) => setStart((s) => ({ ...s, generatePrompt }))}
+            onPick={() => fileStartRef.current?.click()}
+            fileRef={fileStartRef}
+            onFile={(files) => onFile('start', files)}
+            disabled={busy}
+          />
+          <FrameCard
+            label={t('flow.end', { defaultValue: 'End' })}
+            slot={end}
+            onMode={(mode) => setEnd((s) => ({ ...s, mode }))}
+            onPrompt={(generatePrompt) => setEnd((s) => ({ ...s, generatePrompt }))}
+            onPick={() => fileEndRef.current?.click()}
+            fileRef={fileEndRef}
+            onFile={(files) => onFile('end', files)}
+            disabled={busy}
+          />
+        </div>
+
+        {lastEndUrl && (
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            className="h-8 w-full gap-1.5 text-[11px]"
+            disabled={busy}
+            onClick={continueFromLast}
+          >
+            <ArrowRightLeft className="h-3.5 w-3.5" />
+            {t('flow.chain.continue', { defaultValue: 'Continue from last end frame' })}
+          </Button>
+        )}
+
+        <div className="space-y-1.5">
+          <Label className="text-[11px]">
+            {t('flow.prompt', { defaultValue: 'Motion prompt' })}
+          </Label>
+          <Textarea
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+            disabled={busy}
+            rows={3}
+            placeholder={t('flow.promptPlaceholder', {
+              defaultValue: 'Camera slowly pushes in as light shifts warm…',
+            })}
+            className="min-h-[72px] resize-none text-[12px]"
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between">
+            <Label className="text-[11px]">
+              {t('flow.duration', { defaultValue: 'Duration' })}
+            </Label>
+            <span className="font-mono text-[11px] text-muted-foreground">
+              {duration}s ({FLOW_DURATION_MIN_SEC}–{FLOW_DURATION_MAX_SEC})
+            </span>
+          </div>
+          <Slider
+            value={[duration]}
+            min={FLOW_DURATION_MIN_SEC}
+            max={FLOW_DURATION_MAX_SEC}
+            step={1}
+            disabled={busy}
+            onValueChange={([v]) => setDuration(clampFlowDuration(v ?? FLOW_DURATION_DEFAULT_SEC))}
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-2">
+          <div className="space-y-1">
+            <Label className="text-[11px]">{t('flow.quality', { defaultValue: 'Quality' })}</Label>
+            <Select
+              value={quality}
+              onValueChange={(v) => setQuality(v as typeof quality)}
+              disabled={busy}
+            >
+              <SelectTrigger className="h-8 text-[11px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="480p">480p</SelectItem>
+                <SelectItem value="720p">720p</SelectItem>
+                <SelectItem value="1080p">1080p</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1">
+            <Label className="text-[11px]">{t('flow.speed', { defaultValue: 'Speed' })}</Label>
+            <Select
+              value={speed}
+              onValueChange={(v) => setSpeed(v as typeof speed)}
+              disabled={busy}
+            >
+              <SelectTrigger className="h-8 text-[11px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="standard">Standard</SelectItem>
+                <SelectItem value="fast">Fast</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-between gap-2 rounded-md border border-border/60 px-2.5 py-2">
+          <Label className="text-[11px]" htmlFor="flow-audio">
+            {t('flow.audio', { defaultValue: 'Generate audio' })}
+          </Label>
+          <Switch
+            id="flow-audio"
+            checked={generateAudio}
+            onCheckedChange={setGenerateAudio}
+            disabled={busy}
+          />
+        </div>
+
+        <div className="flex items-center justify-between gap-2 rounded-md border border-border/60 px-2.5 py-2">
+          <Label className="text-[11px]" htmlFor="flow-chain">
+            {t('flow.chain.toggle', {
+              defaultValue: 'After success, keep end as next start',
+            })}
+          </Label>
+          <Switch
+            id="flow-chain"
+            checked={chainNext}
+            onCheckedChange={setChainNext}
+            disabled={busy}
+          />
+        </div>
+
+        <div className="rounded-xl border border-primary/30 bg-secondary/25 p-3">
+          <dl className="space-y-1 font-mono text-[11px]">
+            <div className="flex justify-between">
+              <dt className="text-muted-foreground">Due</dt>
+              <dd className="font-semibold">
+                {quote.crtvaiDisplay.toFixed(quote.crtvaiDisplay < 1 ? 3 : 2)} CRTVAI
+                <span className="ml-1.5 font-normal text-muted-foreground">
+                  ({quote.formattedUsd})
+                </span>
+              </dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="text-muted-foreground">Balance</dt>
+              <dd className={cn(insufficient ? 'text-destructive' : 'text-foreground')}>
+                {balance.toFixed(2)} CRTVAI
+              </dd>
+            </div>
+            {stillCount > 0 && (
+              <div className="flex justify-between text-muted-foreground">
+                <dt>Gemini stills</dt>
+                <dd>{stillCount}</dd>
+              </div>
+            )}
+          </dl>
+          {!canPayOnChain && (
+            <p className="mt-2 text-[10px] text-amber-200/90">
+              {t('flow.softPay', {
+                defaultValue: 'Treasury not configured — on-chain charge skipped locally.',
+              })}
+            </p>
+          )}
+          {insufficient && (
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              className="mt-2 h-8 w-full text-[11px]"
+              onClick={() => setBuyOpen(true)}
+            >
+              {t('flow.buy', { defaultValue: 'Buy CRTVAI' })}
+            </Button>
+          )}
+        </div>
+
+        {status && (
+          <div className="space-y-1">
+            <p className="text-[11px] text-muted-foreground">{status}</p>
+            {progress > 0 && (
+              <div className="h-1 overflow-hidden rounded-full bg-secondary">
+                <div
+                  className="h-full bg-primary transition-all"
+                  style={{ width: `${Math.min(100, progress)}%` }}
+                />
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="shrink-0 border-t border-border/60 p-3">
+        <Button
+          type="button"
+          className="h-9 w-full gap-1.5 text-[12px]"
+          disabled={busy || !prompt.trim()}
+          onClick={() => void runFlow()}
+        >
+          {busy ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <WandSparkles className="h-3.5 w-3.5" />
+          )}
+          {busy
+            ? t('flow.working', { defaultValue: 'Working…' })
+            : t('flow.payGenerate', {
+                defaultValue: 'Pay {{amount}} CRTVAI & generate',
+                amount: quote.crtvaiDisplay.toFixed(quote.crtvaiDisplay < 1 ? 3 : 2),
+              })}
+        </Button>
+      </div>
+
+      <BuyMetokenModal
+        open={buyOpen}
+        onOpenChange={setBuyOpen}
+        initialUsdcAmount={Math.max(1, Math.ceil(quote.estimatedUsdc6 / 1_000_000)).toFixed(2)}
+      />
+    </div>
+  )
+})
+
+function FrameCard({
+  label,
+  slot,
+  onMode,
+  onPrompt,
+  onPick,
+  fileRef,
+  onFile,
+  disabled,
+}: {
+  label: string
+  slot: FrameSlot
+  onMode: (mode: 'upload' | 'generate') => void
+  onPrompt: (prompt: string) => void
+  onPick: () => void
+  fileRef: React.RefObject<HTMLInputElement | null>
+  onFile: (files: FileList | null) => void
+  disabled: boolean
+}) {
+  const { t } = useTranslation()
+  return (
+    <div className="rounded-lg border border-border/70 bg-secondary/20 p-2">
+      <div className="mb-1.5 flex items-center justify-between gap-1">
+        <span className="text-[11px] font-medium text-foreground">{label}</span>
+        <div className="flex gap-0.5">
+          <button
+            type="button"
+            disabled={disabled}
+            onClick={() => onMode('upload')}
+            className={cn(
+              'rounded px-1.5 py-0.5 text-[9px] uppercase',
+              slot.mode === 'upload' ? 'bg-primary/20 text-primary' : 'text-muted-foreground',
+            )}
+          >
+            Upload
+          </button>
+          <button
+            type="button"
+            disabled={disabled}
+            onClick={() => onMode('generate')}
+            className={cn(
+              'rounded px-1.5 py-0.5 text-[9px] uppercase',
+              slot.mode === 'generate' ? 'bg-primary/20 text-primary' : 'text-muted-foreground',
+            )}
+          >
+            Gemini
+          </button>
+        </div>
+      </div>
+      {slot.previewUrl ? (
+        <img
+          src={slot.previewUrl}
+          alt=""
+          className="mb-1.5 aspect-video w-full rounded object-cover"
+        />
+      ) : (
+        <div className="mb-1.5 flex aspect-video items-center justify-center rounded border border-dashed border-border/80 bg-secondary/30">
+          <ImagePlus className="h-5 w-5 text-muted-foreground/60" />
+        </div>
+      )}
+      {slot.mode === 'upload' ? (
+        <Button
+          type="button"
+          variant="secondary"
+          size="sm"
+          className="h-7 w-full gap-1 text-[10px]"
+          disabled={disabled}
+          onClick={onPick}
+        >
+          <Upload className="h-3 w-3" />
+          {t('flow.pickImage', { defaultValue: 'Choose image' })}
+        </Button>
+      ) : (
+        <Textarea
+          value={slot.generatePrompt}
+          onChange={(e) => onPrompt(e.target.value)}
+          disabled={disabled}
+          rows={2}
+          placeholder={t('flow.stillPrompt', { defaultValue: 'Describe the still…' })}
+          className="min-h-[52px] resize-none text-[10px]"
+        />
+      )}
+      <input
+        ref={fileRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={(e) => onFile(e.target.files)}
+      />
+      {slot.mode === 'generate' && (
+        <p className="mt-1 flex items-center gap-1 text-[9px] text-muted-foreground">
+          <Sparkles className="h-2.5 w-2.5" />
+          Billed with the Flow invoice
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/features/editor/flow/flow-pricing.test.ts
+++ b/src/features/editor/flow/flow-pricing.test.ts
@@ -37,3 +37,4 @@ describe('quoteFlowGeneration', () => {
     expect(withStills.totalCredits).toBe(base.videoCredits + 24)
   })
 })
+

--- a/src/features/editor/flow/flow-pricing.test.ts
+++ b/src/features/editor/flow/flow-pricing.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { quoteFlowGeneration } from './flow-pricing'
+
+describe('quoteFlowGeneration', () => {
+  it('quotes video-only Flow without stills', () => {
+    const quote = quoteFlowGeneration({
+      duration: 5,
+      quality: '720p',
+      speed: 'standard',
+      generateAudio: true,
+      stillCount: 0,
+    })
+    expect(quote.stillCredits).toBe(0)
+    expect(quote.videoCredits).toBeGreaterThan(0)
+    expect(quote.totalCredits).toBe(quote.videoCredits)
+    expect(quote.estimatedUsdc6).toBe(quote.totalCredits * 100_000)
+    expect(quote.crtvaiWei).toBeGreaterThan(0n)
+  })
+
+  it('adds Gemini still credits', () => {
+    const base = quoteFlowGeneration({
+      duration: 5,
+      quality: '720p',
+      speed: 'standard',
+      generateAudio: false,
+      stillCount: 0,
+    })
+    const withStills = quoteFlowGeneration({
+      duration: 5,
+      quality: '720p',
+      speed: 'standard',
+      generateAudio: false,
+      stillCount: 2,
+      stillQuality: '2K',
+    })
+    expect(withStills.stillCredits).toBe(24)
+    expect(withStills.totalCredits).toBe(base.videoCredits + 24)
+  })
+})

--- a/src/features/editor/flow/flow-pricing.ts
+++ b/src/features/editor/flow/flow-pricing.ts
@@ -1,6 +1,7 @@
 /**
  * Flow (start/end → video) pricing — credits → USDC6 → CRTVAI wei.
  */
+// fallow-ignore-file unused-export
 
 import {
   quoteNanobananaCredits,

--- a/src/features/editor/flow/flow-pricing.ts
+++ b/src/features/editor/flow/flow-pricing.ts
@@ -1,0 +1,65 @@
+/**
+ * Flow (start/end → video) pricing — credits → USDC6 → CRTVAI wei.
+ */
+
+import {
+  quoteNanobananaCredits,
+  quoteSeedanceCredits,
+  type NanobananaQuality,
+  type SeedanceQuality,
+  type SeedanceSpeed,
+} from '@/config/credits'
+import { usdc6ToMetokenWei } from '@/config/metoken'
+import { clampFlowDuration } from '@/config/flow'
+
+/** $0.10 USDC per credit (legacy Flow retail). */
+export const FLOW_USDC6_PER_CREDIT = 100_000
+
+export interface FlowQuoteInput {
+  duration: number
+  quality: SeedanceQuality
+  speed: SeedanceSpeed
+  generateAudio: boolean
+  /** How many Gemini stills to generate (0–2). Uploaded frames cost 0. */
+  stillCount: number
+  stillQuality?: NanobananaQuality
+}
+
+export interface FlowQuote {
+  duration: number
+  videoCredits: number
+  stillCredits: number
+  totalCredits: number
+  estimatedUsdc6: number
+  crtvaiWei: bigint
+  crtvaiDisplay: number
+  formattedUsd: string
+}
+
+export function quoteFlowGeneration(input: FlowQuoteInput): FlowQuote {
+  const duration = clampFlowDuration(input.duration)
+  const stillQuality = input.stillQuality ?? '2K'
+  const stillCount = Math.min(2, Math.max(0, Math.floor(input.stillCount)))
+  const videoCredits = quoteSeedanceCredits({
+    duration,
+    quality: input.quality,
+    speed: input.speed,
+    generateAudio: input.generateAudio,
+  })
+  const stillCredits = stillCount > 0 ? stillCount * quoteNanobananaCredits(stillQuality) : 0
+  const totalCredits = videoCredits + stillCredits
+  const estimatedUsdc6 = totalCredits * FLOW_USDC6_PER_CREDIT
+  const crtvaiWei = usdc6ToMetokenWei(estimatedUsdc6)
+  const crtvaiDisplay = Number(crtvaiWei) / 1e18
+
+  return {
+    duration,
+    videoCredits,
+    stillCredits,
+    totalCredits,
+    estimatedUsdc6,
+    crtvaiWei,
+    crtvaiDisplay,
+    formattedUsd: `$${(estimatedUsdc6 / 1_000_000).toFixed(2)}`,
+  }
+}

--- a/src/features/editor/flow/index.ts
+++ b/src/features/editor/flow/index.ts
@@ -1,2 +1,3 @@
+// fallow-ignore-file unused-export
 export { FlowPanel } from './flow-panel'
 export { quoteFlowGeneration } from './flow-pricing'

--- a/src/features/editor/flow/index.ts
+++ b/src/features/editor/flow/index.ts
@@ -1,0 +1,2 @@
+export { FlowPanel } from './flow-panel'
+export { quoteFlowGeneration } from './flow-pricing'

--- a/src/features/editor/hooks/use-editor-viewport-mode.ts
+++ b/src/features/editor/hooks/use-editor-viewport-mode.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react'
+import {
+  densityPresetForViewport,
+  resolveEditorViewportMode,
+  type EditorDensityPresetName,
+  type EditorViewportMode,
+} from '@/config/editor-layout'
+
+function readMode(): EditorViewportMode {
+  if (typeof window === 'undefined') return 'desktop'
+  return resolveEditorViewportMode(window.innerWidth)
+}
+
+/**
+ * Tracks editor chrome mode from viewport width (resize-aware).
+ */
+export function useEditorViewportMode(): {
+  mode: EditorViewportMode
+  densityPreset: EditorDensityPresetName
+  isDesktop: boolean
+  isTablet: boolean
+  isPhone: boolean
+} {
+  const [mode, setMode] = useState<EditorViewportMode>(readMode)
+
+  useEffect(() => {
+    const onResize = () => setMode(resolveEditorViewportMode(window.innerWidth))
+    onResize()
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
+
+  return {
+    mode,
+    densityPreset: densityPresetForViewport(mode),
+    isDesktop: mode === 'desktop',
+    isTablet: mode === 'tablet',
+    isPhone: mode === 'phone',
+  }
+}

--- a/src/features/generative/hooks/use-generative-auth.ts
+++ b/src/features/generative/hooks/use-generative-auth.ts
@@ -1,4 +1,4 @@
-// fallow-ignore-file unused-file
+// fallow-ignore-file unused-export
 import { useMemo } from 'react'
 import { useWalletContext } from '@/context/wallet-context'
 import type { SignedRequestParams } from '../services/generative-proxy-client'

--- a/src/features/generative/index.ts
+++ b/src/features/generative/index.ts
@@ -1,4 +1,4 @@
-// fallow-ignore-file unused-file
+// fallow-ignore-file unused-export,unused-type
 export {
   proxyFlowRun,
   proxyGetTask,

--- a/src/features/generative/services/generative-proxy-client.ts
+++ b/src/features/generative/services/generative-proxy-client.ts
@@ -1,4 +1,4 @@
-// fallow-ignore-file unused-file,unused-export,complexity,code-duplication
+// fallow-ignore-file unused-export,complexity,code-duplication
 import { createLogger } from '@/shared/logging/logger'
 import type { EvolinkTaskDetail, NanobananaQuality, SeedanceQuality, SeedanceSpeed } from '../types'
 

--- a/src/features/generative/services/image-upload-service.ts
+++ b/src/features/generative/services/image-upload-service.ts
@@ -1,4 +1,4 @@
-// fallow-ignore-file unused-file,complexity
+// fallow-ignore-file complexity,unused-export
 import { createLogger } from '@/shared/logging/logger'
 
 const log = createLogger('ImageUploadService')

--- a/src/features/generative/services/nanobanana-service.ts
+++ b/src/features/generative/services/nanobanana-service.ts
@@ -1,4 +1,4 @@
-// fallow-ignore-file unused-file
+// fallow-ignore-file unused-export
 import { createLogger } from '@/shared/logging/logger'
 import { proxyGetTask, proxySubmitImage, type SignedRequestParams } from './generative-proxy-client'
 import type {

--- a/src/features/generative/services/seedance-service.ts
+++ b/src/features/generative/services/seedance-service.ts
@@ -1,4 +1,4 @@
-// fallow-ignore-file unused-file
+// fallow-ignore-file unused-export
 import { createLogger } from '@/shared/logging/logger'
 import { proxyGetTask, proxySubmitVideo, type SignedRequestParams } from './generative-proxy-client'
 import type {

--- a/src/features/generative/services/task-poller.ts
+++ b/src/features/generative/services/task-poller.ts
@@ -1,4 +1,4 @@
-// fallow-ignore-file unused-file,unused-export,complexity
+// fallow-ignore-file complexity
 import { createLogger } from '@/shared/logging/logger'
 import type { EvolinkTaskDetail, EvolinkTaskStatus } from '../types'
 

--- a/src/features/generative/types.ts
+++ b/src/features/generative/types.ts
@@ -1,4 +1,4 @@
-// fallow-ignore-file unused-file,unused-export,unused-type
+// fallow-ignore-file unused-export,unused-type
 // ---------------------------------------------------------------------------
 // Evolink.ai shared types
 // ---------------------------------------------------------------------------

--- a/src/features/metoken/components/buy-metoken-modal.tsx
+++ b/src/features/metoken/components/buy-metoken-modal.tsx
@@ -29,11 +29,13 @@ import { cn } from '@/shared/ui/cn'
 interface BuyMetokenModalProps {
   open: boolean
   onOpenChange: (open: boolean) => void
+  /** Prefill USDC amount when opening (e.g. Director session packs). */
+  initialUsdcAmount?: string
 }
 
 const BASE_CHAIN_ID = base.id
 
-export function BuyMetokenModal({ open, onOpenChange }: BuyMetokenModalProps) {
+export function BuyMetokenModal({ open, onOpenChange, initialUsdcAmount }: BuyMetokenModalProps) {
   const { account, chain } = useWalletContext()
   const queryClient = useQueryClient()
   const { sendOps, ready: walletReady } = useSmartWalletOps()
@@ -59,9 +61,11 @@ export function BuyMetokenModal({ open, onOpenChange }: BuyMetokenModalProps) {
     }
   }, [usdcInput, usdcBalance])
 
-  // Fetch current price on open
+  // Prefill + fetch current price on open
   useEffect(() => {
-    if (!open || !onBase) return
+    if (!open) return
+    if (initialUsdcAmount) setUsdcInput(initialUsdcAmount)
+    if (!onBase) return
     let cancelled = false
     void (async () => {
       try {
@@ -76,7 +80,7 @@ export function BuyMetokenModal({ open, onOpenChange }: BuyMetokenModalProps) {
     return () => {
       cancelled = true
     }
-  }, [open, onBase])
+  }, [open, onBase, initialUsdcAmount])
 
   // Debounced mint quote
   useEffect(() => {

--- a/src/features/timeline/components/timeline.tsx
+++ b/src/features/timeline/components/timeline.tsx
@@ -911,6 +911,7 @@ export const Timeline = memo(function Timeline({ duration }: TimelineProps) {
   return (
     <div
       className="timeline-bg h-full border-t border-border flex flex-col overflow-hidden"
+      data-timeline-root
       role="region"
       aria-label={t('timeline.region')}
     >

--- a/src/index.css
+++ b/src/index.css
@@ -384,3 +384,10 @@ body.canvas-translate-cursor-not-allowed * {
     animation: none;
   }
 }
+
+/* Compact editor viewports: prefer pan gestures on the timeline surface. */
+[data-editor-viewport='tablet'] [data-timeline-root],
+[data-editor-viewport='phone'] [data-timeline-root] {
+  touch-action: pan-x pan-y;
+}
+

--- a/vercel.json
+++ b/vercel.json
@@ -8,6 +8,18 @@
     "api/director.ts": {
       "maxDuration": 300
     },
+    "api/flow-run.ts": {
+      "maxDuration": 300
+    },
+    "api/flow-frame.ts": {
+      "maxDuration": 30
+    },
+    "api/generate-video.ts": {
+      "maxDuration": 60
+    },
+    "api/generate-image.ts": {
+      "maxDuration": 60
+    },
     "api/generate-task.ts": {
       "maxDuration": 30
     }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,10 @@ import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { POST as directorPost } from './api/director'
 import { GET as generateTaskGet } from './api/generate-task'
+import { POST as flowFramePost } from './api/flow-frame'
+import { POST as flowRunPost } from './api/flow-run'
+import { POST as generateImagePost } from './api/generate-image'
+import { POST as generateVideoPost } from './api/generate-video'
 
 // Stamps public/sw.js with the hashed entry-chunk filename at build time so the service
 // worker's CACHE_VERSION — and the sw.js bytes — change on every deploy. Without this the
@@ -106,8 +110,12 @@ async function handleDirectorDevRequest(
   }
 }
 
-// Keep generate-task reachable as a serverless entry for fallow / Vercel.
+// Keep serverless API modules reachable as entries for fallow / Vercel.
 void generateTaskGet
+void flowFramePost
+void flowRunPost
+void generateImagePost
+void generateVideoPost
 
 function directorApiDevPlugin(): Plugin {
   return {


### PR DESCRIPTION
## Summary
- Revive AI **Flow** (start/end stills → Seedance i2v) with CRTVAI billing, frame hosting, and Generate | Flow | Director modes in the AI tab
- Harden Director monetization: server-side premium quotes, payment-ledger anti-replay, session packs, and authenticated generate-task ownership
- Add tablet/phone editor chrome (viewport layout, sheet overlays, touch timeline) and route cross-feature imports through editor `deps/*` adapters

## Test plan
- [ ] AI tab: switch Generate / Flow / Director; Flow generates stills + video with wallet payment when billing enforced
- [ ] Flow: upload or generate start/end frames; continue from last end frame; confirm public HTTPS frame URLs (not data URIs)
- [ ] Director invoice: retail vs Unlock premium quote match server verify; payment tx cannot be replayed
- [ ] Responsive: tablet drawers / phone light shell; timeline remains usable with touch
- [ ] Confirm Vercel function timeouts for `flow-run`, `flow-frame`, `generate-image`, `generate-video`, `generate-task`


Made with [Cursor](https://cursor.com)