### PR TITLE
refactor(quality): clear fallow introduced findings and enforce the ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,13 +82,15 @@ jobs:
 
       # Quality ratchet: fails only on dead code / complexity / duplication
       # INTRODUCED by the PR (gate new-only), never on inherited issues.
-      # Advisory for now (continue-on-error) — drop that line to enforce once
-      # the current develop-vs-main delta is cleaned up.
+      # Enforcing as of the upstream-sync-2026-08 cleanup (#65): the integration
+      # delta is cleared and the local pre-push gate runs the same audit, so a
+      # red ratchet here now means the PR itself introduced findings.
+      # Version pinned to match scripts/check-fallow-changed-health.mjs so local
+      # and CI verdicts cannot drift apart across rule releases.
       - name: Fallow quality ratchet
         if: github.event_name == 'pull_request'
-        continue-on-error: true
         run: |
-          npm install -g fallow
+          npm install -g fallow@2.89.0
           fallow audit --base "origin/${{ github.base_ref }}" --gate new-only --ci
 
   # Repeatedly re-runs the preview-sync suite from cold to surface ordering /

--- a/src/headless/main.ts
+++ b/src/headless/main.ts
@@ -84,6 +84,28 @@ const log = createLogger('Headless')
 const HEADLESS_FONT_WEIGHTS = [400, 500, 600, 700, 800]
 
 /**
+ * Probe every family×weight pair, collecting the combinations that never
+ * became applied before the deadline (as `family:weight` strings).
+ */
+async function collectUnresolvedFontFaces(
+  measure: (font: string) => number,
+  families: Iterable<string>,
+  weights: readonly number[],
+  deadline: number,
+): Promise<string[]> {
+  const unresolved: string[] = []
+  for (const family of families) {
+    const bare = family.replace(/^["']|["']$/g, '')
+    for (const weight of weights) {
+      if (!(await waitForFaceApplied(measure, bare, weight, deadline))) {
+        unresolved.push(`${bare}:${weight}`)
+      }
+    }
+  }
+  return unresolved
+}
+
+/**
  * Block until the requested families are actually being APPLIED by the canvas
  * text renderer, not merely until their FontFace promises settled.
  *
@@ -109,12 +131,11 @@ async function awaitFontsApplied(
   weights: readonly number[],
   timeoutMs = 8000,
 ): Promise<string[]> {
-  const unresolved: string[] = []
-  if (families.length === 0 || typeof document === 'undefined') return unresolved
+  if (families.length === 0 || typeof document === 'undefined') return []
 
   const canvas = document.createElement('canvas')
   const ctx = canvas.getContext('2d')
-  if (!ctx) return unresolved
+  if (!ctx) return []
 
   const deadline = Date.now() + timeoutMs
   const measure = (font: string): number => {
@@ -122,23 +143,35 @@ async function awaitFontsApplied(
     return ctx.measureText(PROBE).width
   }
 
-  for (const family of new Set(families)) {
-    const bare = family.replace(/^["']|["']$/g, '')
-    for (const weight of weights) {
-      if (!(await waitForFaceApplied(measure, bare, weight, deadline))) {
-        unresolved.push(`${bare}:${weight}`)
-      }
-    }
-  }
+  const unresolvedCombinations = await collectUnresolvedFontFaces(
+    measure,
+    new Set(families),
+    weights,
+    deadline,
+  )
   // Let the compositor settle one frame before the first rasterisation.
   await new Promise((resolve) => requestAnimationFrame(() => resolve(undefined)))
-  return unresolved
+  return unresolvedCombinations
 }
 
 // Glyph-rich probe: Latin + Cyrillic + digits, so a family that only ships a
 // partial subset cannot pass on a handful of shared glyphs.
 const PROBE = 'HAMBURGEFONTSIVЖЯЦЩ0123456789'
 const GENERICS = ['monospace', 'serif'] as const
+
+/**
+ * One measure→wait cycle for a single family+weight. Returns true when the
+ * face has held its applied streak, false when the deadline passed first.
+ */
+async function awaitFaceStability(isApplied: () => boolean, deadline: number): Promise<boolean> {
+  const STABLE_PASSES = 2
+  let streak = 0
+  while (streak < STABLE_PASSES && Date.now() < deadline) {
+    streak = isApplied() ? streak + 1 : 0
+    await new Promise((resolve) => setTimeout(resolve, 60))
+  }
+  return streak >= STABLE_PASSES
+}
 
 /**
  * True once ONE family+weight measurably differs from the generics it is
@@ -155,7 +188,6 @@ async function waitForFaceApplied(
   weight: number,
   deadline: number,
 ): Promise<boolean> {
-  const STABLE_PASSES = 2
   // A family still falling back measures identically to the generic it is stacked
   // on. Differing from BOTH generics means the face is really in use.
   const isApplied = (): boolean =>
@@ -165,14 +197,7 @@ async function waitForFaceApplied(
         measure(`${weight} 100px ${generic}`),
     )
 
-  let streak = 0
-  while (streak < STABLE_PASSES) {
-    streak = isApplied() ? streak + 1 : 0
-    if (streak >= STABLE_PASSES) return true
-    if (Date.now() >= deadline) return false
-    await new Promise((resolve) => setTimeout(resolve, 60))
-  }
-  return true
+  return awaitFaceStability(isApplied, deadline)
 }
 
 /**
@@ -475,18 +500,25 @@ function detectWebGpuOnce(): Promise<boolean> {
   return webGpuAvailable
 }
 
+/**
+ * Can this browser hand us a working GPU device? Adapter presence alone is not
+ * proof — device acquisition is what fails on headless/software stacks.
+ */
+async function acquireWebGpuDevice(): Promise<boolean> {
+  const adapter = await navigator.gpu?.requestAdapter()
+  if (!adapter) return false
+  // An adapter is not enough: device acquisition is what actually fails on
+  // headless/software stacks, and reporting "GPU available" on the strength of
+  // an adapter alone would suppress warnings for presets that then fall back.
+  const device = await adapter.requestDevice()
+  if (!device) return false
+  device.destroy()
+  return true
+}
+
 async function detectWebGpu(): Promise<boolean> {
   try {
-    if (!('gpu' in navigator) || !navigator.gpu) return false
-    const adapter = await navigator.gpu.requestAdapter()
-    if (!adapter) return false
-    // An adapter is not enough: device acquisition is what actually fails on
-    // headless/software stacks, and reporting "GPU available" on the strength of
-    // an adapter alone would suppress warnings for presets that then fall back.
-    const device = await adapter.requestDevice()
-    if (!device) return false
-    device.destroy()
-    return true
+    return await acquireWebGpuDevice()
   } catch {
     return false
   }

--- a/src/shared/marquee/use-marquee-selection.ts
+++ b/src/shared/marquee/use-marquee-selection.ts
@@ -362,16 +362,8 @@ export function useMarqueeSelection({
     }
   }, [commitSelectionOnMouseUp, containerRef, scheduleLiveCommit])
 
-  // Handle mouse down - start marquee
-  // Using useEffectEvent so changes to enabled, appendMode don't re-register listeners
-  const cancelGesture = useEffectEvent(() => {
-    if (!isDraggingRef.current) return
-
-    const wasActualDrag = hasMovedRef.current
-    const selectionToRestore = hasLiveCommittedRef.current
-      ? gestureStartSelectionIdsRef.current
-      : null
-
+  // Cancel any scheduled live-commit work belonging to the active gesture.
+  const cancelGestureTimers = () => {
     if (rafIdRef.current !== null) {
       cancelAnimationFrame(rafIdRef.current)
       rafIdRef.current = null
@@ -380,7 +372,10 @@ export function useMarqueeSelection({
       clearTimeout(liveCommitTimeoutRef.current)
       liveCommitTimeoutRef.current = null
     }
+  }
 
+  // Clear every per-gesture ref so a cancelled gesture cannot leak into the next.
+  const resetGestureState = () => {
     isDraggingRef.current = false
     hasMovedRef.current = false
     marqueeRef.current = { startX: 0, startY: 0, currentX: 0, currentY: 0 }
@@ -389,7 +384,11 @@ export function useMarqueeSelection({
     lastLiveCommitTimeRef.current = 0
     gestureStartSelectionIdsRef.current = null
     hasLiveCommittedRef.current = false
+  }
 
+  // Notify subscribers that the gesture ended by cancellation. Selection is
+  // restored to its gesture-start state when a live commit already fired.
+  const notifyGestureCancelled = (wasActualDrag: boolean, selectionToRestore: string[] | null) => {
     setIsActive(false)
     publishSnapshot(INACTIVE_SNAPSHOT)
 
@@ -400,6 +399,21 @@ export function useMarqueeSelection({
       onSelectionChangeRef.current?.(selectionToRestore)
     }
     onGestureCancel?.(wasActualDrag)
+  }
+
+  // Handle mouse down - start marquee
+  // Using useEffectEvent so changes to enabled, appendMode don't re-register listeners
+  const cancelGesture = useEffectEvent(() => {
+    if (!isDraggingRef.current) return
+
+    const wasActualDrag = hasMovedRef.current
+    const selectionToRestore = hasLiveCommittedRef.current
+      ? gestureStartSelectionIdsRef.current
+      : null
+
+    cancelGestureTimers()
+    resetGestureState()
+    notifyGestureCancelled(wasActualDrag, selectionToRestore)
   })
 
   const onMouseDown = useEffectEvent((e: MouseEvent) => {

--- a/src/shared/typography/text-block-layout.ts
+++ b/src/shared/typography/text-block-layout.ts
@@ -222,6 +222,10 @@ function buildLineRuns(
  * font/size/letter-spacing — mixed fonts/sizes on one line are out of scope
  * (such spans render in the base font).
  */
+// fallow-ignore-next-line complexity
+// Kept whole on purpose: the wrap-loop's leading-space condition must stay
+// visually paired with pushLine's consumption rule (see the isContinuation
+// comment inside) — splitting them across functions invites drift.
 function layoutInlineSpanLines(
   spans: ReturnType<typeof resolveSpanStyles>,
   lineHeightFactor: number,


### PR DESCRIPTION
## Summary

Tier 1 (and final step) of #65: clears the fallow quality debt from the upstream-sync-2026-08 integration and flips the CI ratchet from advisory to **enforcing**.

### Plan change — no ignore list needed

The issue's original plan called for ~16 scoped `health.ignore` entries. That turned out to be unnecessary: once #64 landed, the upstream engine code became part of the audit **base**, so its findings count as *inherited* and the `new-only` gate ignores them. Current attribution on this branch: `dead_code_introduced=0, complexity_introduced=0, duplication_introduced=0`.

### Proper fixes (no suppressions except one, justified)

- **`src/shared/marquee/use-marquee-selection.ts`** — `cancelGesture` (cyc 10) split into `cancelGestureTimers`, `resetGestureState`, and `notifyGestureCancelled`
- **`src/headless/main.ts`** — three extractions, all ≤ cyc 4: `awaitFaceStability` (from `waitForFaceApplied`), `collectUnresolvedFontFaces` (from `awaitFontsApplied`), `acquireWebGpuDevice` (from `detectWebGpu`)
- **`src/shared/typography/text-block-layout.ts`** — `layoutInlineSpanLines` (cyc 9) kept whole with an inline `fallow-ignore-next-line complexity` + justification: its wrap-loop's leading-space condition must stay visually paired with `pushLine`'s consumption rule; splitting invites drift

### CI: ratchet now enforcing

- Removed `continue-on-error: true` from the `Fallow quality ratchet` step — the condition the config comment anticipated ("drop that line once the develop-vs-main delta is cleaned up") now holds
- Pinned `fallow@2.89.0` in CI to match `scripts/check-fallow-changed-health.mjs`, so local and CI verdicts cannot drift across rule releases (this mismatch caused the local-vs-CI divergence observed during #64)

## Test plan

- [x] `fallow audit --base origin/staging` → **verdict: pass**, 0 introduced (dead-code / complexity / duplication)
- [x] 4,783/4,783 unit tests pass
- [x] 44/44 headless node tests pass
- [x] Production build succeeds
- [x] Local pre-push quality gate passed without bypass

Closes #65