### PR TITLE
feat(credits): fixed-price CRTVAI credit packs via CreditPackSettlement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,6 @@ Browser-based multi-track video editor. React 19 + TypeScript + Vite.
 
 ## Git
 
-- `main` — production, `staging` — pre-release integration, `develop` — active development
-- Commit work straight to `develop` — do **not** cut feature branches
-- PR target: `staging` (`develop` PRs into `staging`; `staging` is promoted to `main`). Do **not** open PRs against `main` directly
+- `prod` — production (this is `origin/HEAD`), `staging` — pre-release integration
+- Cut a feature branch off `staging` and open the PR against `staging`; `staging` is promoted to `prod`. Do **not** open PRs against `prod` directly
 - Conventional commits — `type(scope): description` (e.g. `fix(timeline):`, `feat(export):`)

--- a/src/components/wallet-connect-button.tsx
+++ b/src/components/wallet-connect-button.tsx
@@ -20,7 +20,7 @@ import { SWITCHABLE_CHAINS } from '@/config/chains'
 import { useUsdcBalance } from '@/hooks/use-usdc-balance'
 import { useCrtvaiBalance } from '@/hooks/use-crtvai-balance'
 import { BuyUsdcOnrampModal } from '@/features/onramp'
-import { BuyMetokenModal } from '@/features/metoken'
+import { BuyCreditsModal } from '@/features/credits'
 import { cn } from '@/shared/ui/cn'
 
 function truncateAddress(address: string): string {
@@ -58,7 +58,7 @@ export function WalletConnectButton({
     address as `0x${string}` | undefined,
   )
   const [copied, setCopied] = useState(false)
-  const [buyMetokenOpen, setBuyMetokenOpen] = useState(false)
+  const [buyCreditsOpen, setBuyCreditsOpen] = useState(false)
   const [buyOnrampOpen, setBuyOnrampOpen] = useState(false)
 
   const handleCopyAddress = useCallback(() => {
@@ -142,7 +142,7 @@ export function WalletConnectButton({
           </DropdownMenuItem>
 
           <DropdownMenuItem
-            onClick={() => setBuyMetokenOpen(true)}
+            onClick={() => setBuyCreditsOpen(true)}
             className="flex cursor-pointer items-center gap-2"
             aria-label="Buy CRTVAI"
           >
@@ -178,7 +178,7 @@ export function WalletConnectButton({
         </DropdownMenuContent>
       </DropdownMenu>
 
-      <BuyMetokenModal open={buyMetokenOpen} onOpenChange={setBuyMetokenOpen} />
+      <BuyCreditsModal open={buyCreditsOpen} onOpenChange={setBuyCreditsOpen} />
       <BuyUsdcOnrampModal open={buyOnrampOpen} onOpenChange={setBuyOnrampOpen} />
     </>
   )

--- a/src/config/credit-pack-settlement.ts
+++ b/src/config/credit-pack-settlement.ts
@@ -1,0 +1,68 @@
+import { parseAbi } from 'viem'
+
+/**
+ * CreditPackSettlement — the fixed-price credit-pack contract on Base.
+ *
+ * Single-tx curve-aware buy + burn + credit mint. The user pays a FIXED USDC
+ * price (no curve slippage at checkout); the treasury absorbs the curve risk
+ * and the 20% refundRatio burn donation.
+ *
+ * `settlePack(buyer, packId, maxSlippageBps)` is `nonpayable` — it pulls USDC
+ * from the buyer via `safeTransferFrom`, so the buyer must approve USDC to the
+ * settlement contract first. `maxSlippageBps` is a fixed internal default
+ * (50 bps), NOT user-facing.
+ */
+
+/** Deployed CreditPackSettlement contract on Base. */
+export const CREDIT_PACK_SETTLEMENT_ADDRESS = '0x03e8a588CD5873796b5C5EF6A96e7EE7704d1FF9' as const
+
+/** Fixed internal slippage guard (bps). Invisible to the user by design. */
+export const CREDIT_PACK_MAX_SLIPPAGE_BPS = 50n
+
+export const CREDIT_PACK_SETTLEMENT_ABI = parseAbi([
+  'function settlePack(address buyer, uint256 packId, uint256 maxSlippageBps) returns (uint256 meTokensBurned)',
+  'function packPrice(uint256 packId) view returns (uint256 fiatAmount)',
+  'function packCredits(uint256 packId) view returns (uint256 credits)',
+  'function setPack(uint256 packId, uint256 fiatAmount, uint256 credits)',
+  'function sweep(address recipient)',
+  'function owner() view returns (address)',
+  'event PackSettled(address indexed buyer, uint256 packId, uint256 fiatAmount, uint256 assetDeposited, uint256 meTokensMinted, uint256 meTokensBurned, uint256 assetRefunded, uint256 creditsMinted)',
+])
+
+export interface CreditPackDefinition {
+  /** On-chain packId (must match the `setPack` registration). */
+  id: number
+  name: string
+  /** USDC amount with 6 decimals (e.g. 20_000_000 = $20). */
+  usdc6: number
+  credits: number
+  description: string
+}
+
+/**
+ * The three retail packs. IDs 0/1/2 must match the `setPack` calldata @boo
+ * registers on-chain. $0.10/credit: $20→200, $50→500, $100→1000.
+ */
+export const SETTLEMENT_CREDIT_PACKS: readonly CreditPackDefinition[] = [
+  {
+    id: 0,
+    name: 'Starter',
+    usdc6: 20_000_000,
+    credits: 200,
+    description: '200 credits',
+  },
+  {
+    id: 1,
+    name: 'Pro',
+    usdc6: 50_000_000,
+    credits: 500,
+    description: '500 credits',
+  },
+  {
+    id: 2,
+    name: 'Studio',
+    usdc6: 100_000_000,
+    credits: 1000,
+    description: '1000 credits',
+  },
+] as const

--- a/src/config/metoken.ts
+++ b/src/config/metoken.ts
@@ -6,18 +6,29 @@ import { ALCHEMY_API_KEY } from '@/config/alchemy'
 /**
  * CRTVAI MeToken — Creative TV's AI payment token.
  *
- * Diamond ERC-2535 contract on Base, backed by USDC via Bancor Zero formula.
- * Users mint CRTVAI by sending USDC to the meToken contract; the bonding curve
- * determines how many meTokens they receive. They can sell (burn) meTokens
- * back into USDC at the current curve price.
+ * Two distinct contracts are involved:
+ *  - The **meToken** (`0xecb6…4846`) is a plain ERC-20 (MeToken.sol). Its
+ *    `mint`/`burn` are `onlyDiamond`-gated, so users NEVER call them directly.
+ *    Users only read `balanceOf` / `transfer` / `approve` on it.
+ *  - The **Diamond** (`0xba55…3f5`) is the ERC-2535 proxy. Minting/burning go
+ *    through its `FoundryFacet`:
+ *      mint(address meToken, uint256 assetsDeposited, address recipient)
+ *      burn(address meToken, uint256 meTokensBurned, address recipient)
+ *    The FoundryFacet pulls the connector asset (USDC) from the caller via the
+ *    hub vault's `handleDeposit` → `safeTransferFrom`, so the caller must
+ *    approve USDC to the **vault**, not the Diamond and not the meToken.
  *
- * Diamond address: 0xecb695544a3d2a64d579b3828f3f60f6932f4846
- * Hub ID: 2 (USDC-backed, curve params fixed: baseY=224, reserveWeight=32)
- * Underlying asset: USDC on Base (0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913)
+ * Hub 2 (USDC-backed): baseY=224, reserveWeight=32, refundRatio=80%.
  */
 
-/** CRTVAI meToken diamond address on Base. */
-export const CRTVAI_DIAMOND_ADDRESS = '0xecb695544a3d2a64d579b3828f3f60f6932f4846' as const
+/** CRTVAI meToken (ERC-20) address on Base. */
+export const CRTVAI_METOKEN_ADDRESS = '0xecb695544a3d2a64d579b3828f3f60f6932f4846' as const
+
+/** meTokens Diamond (ERC-2535 proxy) address on Base. */
+export const CRTVAI_DIAMOND_ADDRESS = '0xba5502db2aC2cBff189965e991C07109B14eB3f5' as const
+
+/** Hub-2 vault — the USDC approval target for minting. */
+export const CRTVAI_HUB_2_VAULT_ADDRESS = '0xd4b3f4d2c44Feba751F30e19D7e1047A29eE085d' as const
 
 /** MeToken hub ID for CRTVAI (USDC-backed hub on Base). */
 export const CRTVAI_HUB_ID = 2
@@ -90,9 +101,9 @@ export function hourlyUsdcFromInterval(intervalCostUsdc6: number): number {
   return (intervalCostUsdc6 * 12) / 1_000_000
 }
 
-// ── MeToken Diamond ABI (ERC-2535 facets) ──────────────────────────
+// ── ABIs ────────────────────────────────────────────────────────────
 
-/** ERC-20 facet — standard token interface for balanceOf, transfer, etc. */
+/** ERC-20 facet — standard token interface on the meToken (balanceOf, transfer, etc.). */
 export const METOKEN_ERC20_ABI = parseAbi([
   'function balanceOf(address account) view returns (uint256)',
   'function transfer(address to, uint256 amount) returns (bool)',
@@ -104,16 +115,16 @@ export const METOKEN_ERC20_ABI = parseAbi([
   'function decimals() view returns (uint8)',
 ])
 
-/** MeToken facet — mint, sell, and curve pricing. */
+/**
+ * FoundryFacet — the mint/burn entry point on the Diamond.
+ * `mint`/`burn` take the meToken address and pull the connector asset through
+ * the hub vault (approve USDC to the vault first).
+ */
 export const METOKEN_DIAMOND_ABI = parseAbi([
-  'function balanceOf(address account) view returns (uint256)',
-  'function mint(uint256 amount) external',
-  'function sell(uint256 amount) external',
-  'function getCurrentPrice() view returns (uint256)',
-  'function getMintPrice(uint256 amount) view returns (uint256)',
-  'function getSellPrice(uint256 amount) view returns (uint256)',
-  'function getHubId() view returns (uint256)',
-  'function activeCollateralOnly() view returns (bool)',
+  'function mint(address meToken, uint256 assetsDeposited, address recipient) returns (uint256 meTokensMinted)',
+  'function burn(address meToken, uint256 meTokensBurned, address recipient) returns (uint256 assetsReturned)',
+  'function calculateMeTokensMinted(address meToken, uint256 assetsDeposited) view returns (uint256 meTokensMinted)',
+  'function calculateAssetsReturned(address meToken, uint256 meTokensBurned, address sender) view returns (uint256 assetsReturned)',
 ])
 
 /** CFAv1Forwarder — same address on all Superfluid networks. */
@@ -130,43 +141,49 @@ export const SUPER_TOKEN_ABI = parseAbi([
 export async function readCrtvaiBalance(address: `0x${string}`): Promise<bigint> {
   const client = getBasePublicClient()
   return client.readContract({
-    address: CRTVAI_DIAMOND_ADDRESS,
-    abi: METOKEN_DIAMOND_ABI,
+    address: CRTVAI_METOKEN_ADDRESS,
+    abi: METOKEN_ERC20_ABI,
     functionName: 'balanceOf',
     args: [address],
   })
 }
 
-/** Read current meToken mint price (USDC per meToken, in raw units). */
-export async function readCrtvaiCurrentPrice(): Promise<bigint> {
-  const client = getBasePublicClient()
-  return client.readContract({
-    address: CRTVAI_DIAMOND_ADDRESS,
-    abi: METOKEN_DIAMOND_ABI,
-    functionName: 'getCurrentPrice',
-  })
-}
-
-/** Read estimated meToken output for a given USDC input amount. */
+/** Read estimated meToken output for a given USDC input amount (FoundryFacet quote). */
 export async function readCrtvaiMintQuote(usdcAmount: bigint): Promise<bigint> {
   const client = getBasePublicClient()
   return client.readContract({
     address: CRTVAI_DIAMOND_ADDRESS,
     abi: METOKEN_DIAMOND_ABI,
-    functionName: 'getMintPrice',
-    args: [usdcAmount],
+    functionName: 'calculateMeTokensMinted',
+    args: [CRTVAI_METOKEN_ADDRESS, usdcAmount],
   })
 }
 
-/** Read estimated USDC return for selling a given meToken amount. */
-export async function readCrtvaiSellQuote(metokenAmount: bigint): Promise<bigint> {
+/** Read estimated USDC return for selling a given meToken amount (FoundryFacet quote). */
+export async function readCrtvaiSellQuote(
+  metokenAmount: bigint,
+  sender: `0x${string}`,
+): Promise<bigint> {
   const client = getBasePublicClient()
   return client.readContract({
     address: CRTVAI_DIAMOND_ADDRESS,
     abi: METOKEN_DIAMOND_ABI,
-    functionName: 'getSellPrice',
-    args: [metokenAmount],
+    functionName: 'calculateAssetsReturned',
+    args: [CRTVAI_METOKEN_ADDRESS, metokenAmount, sender],
   })
+}
+
+/**
+ * Implied current price in USDC6 per whole CRTVAI, derived from a 1-USDC mint
+ * quote. There is no `getCurrentPrice` view on the FoundryFacet; this is the
+ * equivalent derived from `calculateMeTokensMinted`.
+ */
+export async function readCrtvaiCurrentPrice(): Promise<bigint> {
+  const ONE_USDC = 1_000_000n
+  const minted = await readCrtvaiMintQuote(ONE_USDC)
+  if (minted === 0n) return 0n
+  // price (USDC6 per whole token) = 1e6 * 1e18 / meTokensMinted
+  return (ONE_USDC * 10n ** 18n) / minted
 }
 
 export function requireAlchemyKey(): string {

--- a/src/features/credits/api/settle-pack.ts
+++ b/src/features/credits/api/settle-pack.ts
@@ -1,0 +1,52 @@
+import { encodeFunctionData, erc20Abi } from 'viem'
+import {
+  CREDIT_PACK_SETTLEMENT_ADDRESS,
+  CREDIT_PACK_SETTLEMENT_ABI,
+  CREDIT_PACK_MAX_SLIPPAGE_BPS,
+} from '@/config/credit-pack-settlement'
+import { USDC_BASE_ADDRESS } from '@/config/metoken'
+import type { SmartWalletOp } from '@/hooks/use-smart-wallet-ops'
+
+/**
+ * Builds the batched UserOperations for settling a fixed-price credit pack.
+ *
+ * Flow (mirrors the settlement contract):
+ *  1. Approve USDC to the settlement contract (it pulls USDC via safeTransferFrom).
+ *  2. Call `settlePack(buyer, packId, maxSlippageBps)` — atomic buy + burn + credit mint.
+ *
+ * `maxSlippageBps` is a fixed internal default (50 bps), never user-facing.
+ */
+
+export interface SettlePackOpsResult {
+  ops: SmartWalletOp[]
+}
+
+/**
+ * @param packId On-chain pack id (must be registered via `setPack`).
+ * @param usdc6 Pack price in USDC6 (must match the on-chain `packPrice`).
+ * @param buyer Buyer's smart-wallet address (also the credit recipient).
+ */
+export function buildSettlePackOps(
+  packId: number,
+  usdc6: bigint,
+  buyer: `0x${string}`,
+): SettlePackOpsResult {
+  const approveData = encodeFunctionData({
+    abi: erc20Abi,
+    functionName: 'approve',
+    args: [CREDIT_PACK_SETTLEMENT_ADDRESS, usdc6],
+  })
+
+  const settleData = encodeFunctionData({
+    abi: CREDIT_PACK_SETTLEMENT_ABI,
+    functionName: 'settlePack',
+    args: [buyer, BigInt(packId), CREDIT_PACK_MAX_SLIPPAGE_BPS],
+  })
+
+  return {
+    ops: [
+      { target: USDC_BASE_ADDRESS, data: approveData, value: 0n },
+      { target: CREDIT_PACK_SETTLEMENT_ADDRESS, data: settleData, value: 0n },
+    ],
+  }
+}

--- a/src/features/credits/components/buy-credits-modal.tsx
+++ b/src/features/credits/components/buy-credits-modal.tsx
@@ -1,4 +1,11 @@
-import { BuyMetokenModal } from '../deps/metoken'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { CreditPackCheckout } from './credit-pack-checkout'
 
 interface BuyCreditsModalProps {
   open: boolean
@@ -6,15 +13,26 @@ interface BuyCreditsModalProps {
 }
 
 /**
- * Backward-compatible credits buy modal.
+ * Credits buy modal — fixed-price credit packs.
  *
  * The legacy server-side credits system has been deprecated in favor of CRTVAI
- * meToken. Buying "credits" now opens the CRTVAI mint flow.
+ * meToken. Buying "credits" now settles a fixed-price pack via the
+ * CreditPackSettlement contract (atomic buy + burn + credit mint).
  */
 export function BuyCreditsModal({ open, onOpenChange }: BuyCreditsModalProps) {
-  return <BuyMetokenModal open={open} onOpenChange={onOpenChange} />
-}
-
-export function CreditBalanceBadge() {
-  return null
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Buy credits</DialogTitle>
+          <DialogDescription>
+            Fixed-price credit packs. Pay in USDC — no curve slippage at checkout.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="pt-2">
+          <CreditPackCheckout />
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
 }

--- a/src/features/credits/components/credit-pack-checkout.tsx
+++ b/src/features/credits/components/credit-pack-checkout.tsx
@@ -1,0 +1,129 @@
+import { useCallback, useMemo, useState } from 'react'
+import { Coins, Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { useQueryClient } from '@tanstack/react-query'
+import { Button } from '@/components/ui/button'
+import { useWalletContext } from '@/context/wallet-context'
+import { useSmartWalletOps } from '@/hooks/use-smart-wallet-ops'
+import { useUsdcBalance } from '@/hooks/use-usdc-balance'
+import { SETTLEMENT_CREDIT_PACKS, type CreditPackDefinition } from '@/config/credit-pack-settlement'
+import { buildSettlePackOps } from '@/features/credits/api/settle-pack'
+import { base } from 'viem/chains'
+import { cn } from '@/shared/ui/cn'
+
+/**
+ * Fixed-price credit-pack checkout.
+ *
+ * Each pack is a fixed USDC price → credits (no curve slippage at checkout).
+ * Slippage is a fixed internal treasury parameter and is intentionally NOT
+ * shown. On success the user's CRTVAI balance is refreshed.
+ */
+
+const BASE_CHAIN_ID = base.id
+
+export function CreditPackCheckout() {
+  const { account, chain } = useWalletContext()
+  const queryClient = useQueryClient()
+  const { sendOps, ready: walletReady } = useSmartWalletOps()
+  const { balance: usdcBalance } = useUsdcBalance(chain, account)
+
+  const [settlingId, setSettlingId] = useState<number | null>(null)
+
+  const onBase = chain?.id === BASE_CHAIN_ID
+
+  const handleBuy = useCallback(
+    async (pack: CreditPackDefinition) => {
+      if (!account || !onBase) return
+      setSettlingId(pack.id)
+      try {
+        const usdc6 = BigInt(pack.usdc6)
+        const { ops } = buildSettlePackOps(pack.id, usdc6, account)
+        await sendOps(ops)
+        toast.success(`Purchased ${pack.credits} credits`)
+        void queryClient.invalidateQueries({ queryKey: ['usdc-balance', chain?.id, account] })
+        void queryClient.invalidateQueries({ queryKey: ['crtvai-balance', account] })
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e)
+        toast.error(`Purchase failed: ${msg}`)
+      } finally {
+        setSettlingId(null)
+      }
+    },
+    [account, onBase, chain?.id, sendOps, queryClient],
+  )
+
+  return (
+    <div className="grid gap-3 sm:grid-cols-3">
+      {SETTLEMENT_CREDIT_PACKS.map((pack) => (
+        <PackCard
+          key={pack.id}
+          pack={pack}
+          onBase={onBase}
+          walletReady={walletReady}
+          usdcBalance={usdcBalance}
+          settling={settlingId === pack.id}
+          onBuy={() => handleBuy(pack)}
+        />
+      ))}
+    </div>
+  )
+}
+
+function PackCard({
+  pack,
+  onBase,
+  walletReady,
+  usdcBalance,
+  settling,
+  onBuy,
+}: {
+  pack: CreditPackDefinition
+  onBase: boolean
+  walletReady: boolean
+  usdcBalance: string | null
+  settling: boolean
+  onBuy: () => void
+}) {
+  const priceUsd = (pack.usdc6 / 1_000_000).toFixed(0)
+
+  const insufficient = useMemo(() => {
+    if (usdcBalance === null) return false
+    return Number(usdcBalance) < pack.usdc6 / 1_000_000
+  }, [usdcBalance, pack.usdc6])
+
+  const disabled = !onBase || !walletReady || settling || insufficient
+
+  return (
+    <div className="flex flex-col rounded-xl border border-border/70 bg-secondary/20 p-4">
+      <div className="flex items-center gap-2">
+        <Coins className="h-4 w-4 text-muted-foreground" aria-hidden />
+        <span className="text-sm font-medium">{pack.name}</span>
+      </div>
+      <div className="mt-3 flex items-baseline gap-1">
+        <span className="text-2xl font-semibold">${priceUsd}</span>
+        <span className="text-xs text-muted-foreground">USDC</span>
+      </div>
+      <p className="mt-1 text-xs text-muted-foreground">{pack.description}</p>
+
+      {!onBase && <p className="mt-2 text-[11px] text-amber-500">Switch to Base to buy.</p>}
+      {insufficient && (
+        <p className="mt-2 text-[11px] text-destructive">Insufficient USDC balance.</p>
+      )}
+
+      <Button
+        onClick={onBuy}
+        disabled={disabled}
+        className={cn('mt-3 w-full', settling && 'opacity-80')}
+      >
+        {settling ? (
+          <>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            Purchasing…
+          </>
+        ) : (
+          `Buy ${pack.credits} credits`
+        )}
+      </Button>
+    </div>
+  )
+}

--- a/src/features/credits/index.ts
+++ b/src/features/credits/index.ts
@@ -1,5 +1,2 @@
-export { BuyCreditsModal, CreditBalanceBadge } from './components/buy-credits-modal'
-export { InsufficientCreditsPaywall } from './components/insufficient-credits-paywall'
-export { RedeemPromoModal } from './components/redeem-promo-modal'
-export { useCredits } from './hooks/use-credits'
+export { BuyCreditsModal } from './components/buy-credits-modal'
 export * from './usdc-for-purchase'

--- a/src/features/editor/director/build-director-payment.ts
+++ b/src/features/editor/director/build-director-payment.ts
@@ -4,7 +4,7 @@
 
 import { encodeFunctionData, type Address, type Hex } from 'viem'
 import {
-  CRTVAI_DIAMOND_ADDRESS,
+  CRTVAI_METOKEN_ADDRESS,
   METOKEN_ERC20_ABI,
   getSuperfluidReceiverAddress,
 } from '@/config/metoken'
@@ -30,7 +30,7 @@ export function buildDirectorPaymentOp(amountWei: bigint): SmartWalletOp {
   }) as Hex
 
   return {
-    target: CRTVAI_DIAMOND_ADDRESS,
+    target: CRTVAI_METOKEN_ADDRESS,
     data,
     value: 0n,
   }

--- a/src/features/metoken/api/buy-metoken.ts
+++ b/src/features/metoken/api/buy-metoken.ts
@@ -1,12 +1,19 @@
 import { encodeFunctionData, erc20Abi } from 'viem'
-import { CRTVAI_DIAMOND_ADDRESS, METOKEN_DIAMOND_ABI, USDC_BASE_ADDRESS } from '@/config/metoken'
+import {
+  CRTVAI_METOKEN_ADDRESS,
+  CRTVAI_DIAMOND_ADDRESS,
+  CRTVAI_HUB_2_VAULT_ADDRESS,
+  METOKEN_DIAMOND_ABI,
+  USDC_BASE_ADDRESS,
+} from '@/config/metoken'
 
 /**
  * Builds the UserOperation calldata for buying (minting) CRTVAI meTokens.
  *
- * meToken mint flow:
- *  1. Approve USDC to the meToken diamond (it pulls USDC on mint)
- *  2. Call mint(amount) on the diamond — Bancor Zero formula computes output
+ * meToken mint flow (FoundryFacet on the Diamond):
+ *  1. Approve USDC to the hub-2 VAULT (the FoundryFacet pulls USDC from the
+ *     caller via `vault.handleDeposit` → `safeTransferFrom`).
+ *  2. Call `mint(meToken, assetsDeposited, recipient)` on the Diamond.
  *
  * The smart wallet batched call executes both ops atomically.
  */
@@ -25,18 +32,22 @@ export interface BuyMetokenOpsResult {
 /**
  * Build the batched user ops for minting CRTVAI with USDC.
  * @param usdcAmount Amount of USDC (raw, 6 decimals) to spend on minting.
+ * @param recipient Address to receive the minted CRTVAI (defaults to the buyer).
  */
-export function buildBuyMetokenOps(usdcAmount: bigint): BuyMetokenOpsResult {
+export function buildBuyMetokenOps(
+  usdcAmount: bigint,
+  recipient: `0x${string}`,
+): BuyMetokenOpsResult {
   const approveData = encodeFunctionData({
     abi: erc20Abi,
     functionName: 'approve',
-    args: [CRTVAI_DIAMOND_ADDRESS, usdcAmount],
+    args: [CRTVAI_HUB_2_VAULT_ADDRESS, usdcAmount],
   })
 
   const mintData = encodeFunctionData({
     abi: METOKEN_DIAMOND_ABI,
     functionName: 'mint',
-    args: [usdcAmount],
+    args: [CRTVAI_METOKEN_ADDRESS, usdcAmount, recipient],
   })
 
   return {
@@ -50,12 +61,13 @@ export function buildBuyMetokenOps(usdcAmount: bigint): BuyMetokenOpsResult {
 /**
  * Build the UserOperation calldata for selling (burning) CRTVAI back to USDC.
  * @param metokenAmount Amount of CRTVAI (raw, 18 decimals) to sell.
+ * @param recipient Address to receive the returned USDC (defaults to the seller).
  */
-export function buildSellMetokenOp(metokenAmount: bigint): SmartWalletOp {
+export function buildSellMetokenOp(metokenAmount: bigint, recipient: `0x${string}`): SmartWalletOp {
   const sellData = encodeFunctionData({
     abi: METOKEN_DIAMOND_ABI,
-    functionName: 'sell',
-    args: [metokenAmount],
+    functionName: 'burn',
+    args: [CRTVAI_METOKEN_ADDRESS, metokenAmount, recipient],
   })
 
   return {

--- a/src/features/metoken/components/buy-metoken-modal.tsx
+++ b/src/features/metoken/components/buy-metoken-modal.tsx
@@ -135,7 +135,7 @@ export function BuyMetokenModal({ open, onOpenChange, initialUsdcAmount }: BuyMe
     }
     setMinting(true)
     try {
-      const { ops } = buildBuyMetokenOps(usdcRaw)
+      const { ops } = buildBuyMetokenOps(usdcRaw, account)
       await sendOps(ops)
       toast.success(`Minted CRTVAI with ${usdcInput} USDC`)
       setUsdcInput('')


### PR DESCRIPTION
## Summary

Ports the fixed-price credit-pack checkout into edit-pixels and fixes the broken CRTVAI mint flow.

## Changes

- **Fix broken mint flow** — `config/metoken.ts` now correctly splits the meToken (ERC-20, `0xecb6…4846`) from the Diamond (proxy, `0xba55…3f5`), and `buy-metoken.ts` approves USDC to the hub-2 vault (`0xd4b3…085d`) then calls `FoundryFacet.mint(address,uint256,address)` on the Diamond. The old `mint(uint256)`/`getCurrentPrice()` ABI didn't exist and reverted.
- **Add CreditPackSettlement surface** — `config/credit-pack-settlement.ts` (contract `0x03e8a5…d1FF9`, ABI, fixed 50-bps slippage) + `api/settle-pack.ts` (approve USDC to settlement contract, then `settlePack(buyer, packId, 50bps)`).
- **Add pack checkout** — `credit-pack-checkout.tsx` renders $20/200, $50/500, $100/1000 packs (no curve read, no slippage field).
- **Wire entry point** — wallet 'Buy CRTVAI' now opens the pack checkout.
- **Fix Director payment** — `transfer` targets the meToken (ERC-20), not the Diamond.

## Verification

- All three packs confirmed on-chain (`packPrice`/`packCredits` non-zero on `0x03e8a5…d1FF9`).
- `tsc --noEmit` clean (only pre-existing `compositing-timeline.tsx` error).
- Fallow changed-health gate passes (0 introduced dead code).