### PR TITLE
fix(headless): align MCP client with lifecycle HTTP contract

### DIFF
--- a/headless/lib/contract.mjs
+++ b/headless/lib/contract.mjs
@@ -550,6 +550,14 @@ export const mediaProbeRequestSchema = z
     path: ['expectedRevision'],
   })
 
+export const mediaImportRequestSchema = z
+  .object({
+    file: z.string().min(1),
+    id: z.string().optional(),
+    project: z.string().optional(),
+  })
+  .strict()
+
 const RENDER_OPTIONS = {
   codecs: ['h264', 'h265', 'vp9', 'vp8', 'av1'],
   containers: ['mp4', 'webm', 'mov', 'mkv', 'mp3', 'wav', 'm4a'],
@@ -675,6 +683,7 @@ export function capabilities() {
       projectUpdate: z.toJSONSchema(projectUpdateRequestSchema, { target: 'draft-7' }),
       lifecycleEdit: z.toJSONSchema(lifecycleEditRequestSchema, { target: 'draft-7' }),
       mediaProbe: z.toJSONSchema(mediaProbeRequestSchema, { target: 'draft-7' }),
+      mediaImport: z.toJSONSchema(mediaImportRequestSchema, { target: 'draft-7' }),
     },
     lifecycle: {
       routes: [
@@ -687,10 +696,11 @@ export function capabilities() {
         'POST /v1/projects/:id/edit',
         'GET /v1/media',
         'GET /v1/media/:id',
+        'POST /v1/media/import',
         'POST /v1/media/:id/probe',
         'POST /v1/render',
       ],
-      httpMediaUpload: false,
+      httpMediaUpload: true,
       deleteProject: false,
       writerMode: 'exclusive',
       limits: {

--- a/headless/lib/mcp-server-core.mjs
+++ b/headless/lib/mcp-server-core.mjs
@@ -7,6 +7,7 @@ import {
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js'
 import { spawn } from 'node:child_process'
+import crypto from 'node:crypto'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -212,10 +213,14 @@ function httpErrorFrom(data, status) {
   return { code: 'HTTP_ERROR', message: `HTTP ${status}` }
 }
 
-async function pixelsFetch(serviceUrl, method, route, body) {
+function idempotencyHeaders() {
+  return { 'Idempotency-Key': `mcp-${crypto.randomUUID()}` }
+}
+
+async function pixelsFetch(serviceUrl, method, route, body, extraHeaders = {}) {
   const init = {
     method,
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...extraHeaders },
   }
   if (body) init.body = JSON.stringify(body)
   const response = await fetch(`${serviceUrl}${route}`, init)
@@ -245,20 +250,24 @@ async function toolCreateProject(serviceUrl, args) {
     name: args.name,
     ...pickDefined(args, ['description', 'width', 'height', 'fps', 'backgroundColor']),
   }
-  return textResult(await pixelsFetch(serviceUrl, 'POST', '/v1/projects', body))
+  return textResult(
+    await pixelsFetch(serviceUrl, 'POST', '/v1/projects', body, idempotencyHeaders()),
+  )
 }
 
 async function toolUpdateProject(serviceUrl, args) {
-  const body = pickDefined(args, [
+  const updates = pickDefined(args, [
     'name',
     'description',
     'width',
     'height',
     'fps',
     'backgroundColor',
-    'expectedRevision',
-    'force',
   ])
+  const body = {
+    updates,
+    ...pickDefined(args, ['expectedRevision', 'force']),
+  }
   return textResult(
     await pixelsFetch(
       serviceUrl,
@@ -275,12 +284,14 @@ async function toolEditProject(serviceUrl, args) {
     persist: Boolean(args.persist),
     ...pickDefined(args, ['expectedRevision', 'force']),
   }
+  const extraHeaders = args.persist ? idempotencyHeaders() : {}
   return textResult(
     await pixelsFetch(
       serviceUrl,
       'POST',
       `/v1/projects/${encodeURIComponent(args.projectId)}/edit`,
       body,
+      extraHeaders,
     ),
   )
 }
@@ -322,14 +333,62 @@ function buildRenderBody(args) {
   }
 }
 
+const RENDER_MIME_EXT = {
+  'video/mp4': 'mp4',
+  'video/webm': 'webm',
+  'video/quicktime': 'mov',
+  'video/x-matroska': 'mkv',
+  'audio/mpeg': 'mp3',
+  'audio/wav': 'wav',
+  'audio/x-wav': 'wav',
+  'audio/mp4': 'm4a',
+}
+
+function parseWarningsHeader(header) {
+  if (!header) return undefined
+  try {
+    return JSON.parse(header)
+  } catch {
+    return undefined
+  }
+}
+
+function extensionFromDisposition(contentDisposition) {
+  const match = /filename="([^"]+)"/.exec(contentDisposition)
+  return match ? path.extname(match[1]).slice(1) : ''
+}
+
+function extensionFromMime(contentType) {
+  const mime = contentType.split(';')[0].trim().toLowerCase()
+  return RENDER_MIME_EXT[mime] ?? ''
+}
+
 async function downloadRenderBinary(serviceUrl, body) {
   const response = await fetch(`${serviceUrl}/v1/render`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   })
-  if (!response.ok) throw new Error(`Render download failed: HTTP ${response.status}`)
-  return Buffer.from(await response.arrayBuffer())
+  if (!response.ok) {
+    const data = parseBodyText(await response.text())
+    const error = httpErrorFrom(data, response.status)
+    throw new Error(`Render failed: ${error.code} — ${error.message}`)
+  }
+  return {
+    buffer: Buffer.from(await response.arrayBuffer()),
+    contentType: response.headers.get('content-type') ?? '',
+    contentDisposition: response.headers.get('content-disposition') ?? '',
+    warnings: parseWarningsHeader(response.headers.get('x-pixels-warnings')),
+  }
+}
+
+function renderExtension({ container, contentType, contentDisposition }) {
+  return (
+    container ||
+    extensionFromDisposition(contentDisposition) ||
+    extensionFromMime(contentType) ||
+    'mp4'
+  )
 }
 
 function defaultRenderOutPath() {
@@ -338,33 +397,26 @@ function defaultRenderOutPath() {
   return path.join(outDir, `render-${process.pid}-${Date.now()}.out`)
 }
 
-function assertRenderOk(data) {
-  if (data && data.ok) return
-  throw new Error(`Render failed: ${JSON.stringify(data)}`)
-}
-
-function renderContainer(data) {
-  const settings = data.effectiveSettings
-  if (settings && settings.container) return settings.container
-  return 'mp4'
-}
-
 async function toolRenderProject(serviceUrl, args) {
   let outPath = args.outputPath
   if (!outPath) outPath = defaultRenderOutPath()
   const body = buildRenderBody(args)
-  const data = await pixelsFetch(serviceUrl, 'POST', '/v1/render', body)
-  assertRenderOk(data)
-  const buffer = await downloadRenderBinary(serviceUrl, body)
-  const finalPath = `${outPath}.${renderContainer(data)}`
+  const { buffer, contentType, contentDisposition, warnings } = await downloadRenderBinary(
+    serviceUrl,
+    body,
+  )
+  const ext = renderExtension({
+    container: args.container,
+    contentType,
+    contentDisposition,
+  })
+  const finalPath = `${outPath}.${ext}`
   fs.writeFileSync(finalPath, buffer)
   return textResult({
     ok: true,
     outputPath: finalPath,
     fileSize: buffer.length,
-    durationSeconds: data.durationSeconds,
-    effectiveSettings: data.effectiveSettings,
-    warnings: data.warnings,
+    ...(warnings ? { warnings } : {}),
   })
 }
 

--- a/headless/lifecycle-contract.test.mjs
+++ b/headless/lifecycle-contract.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict'
 import {
   capabilities,
   lifecycleEditRequestSchema,
+  mediaImportRequestSchema,
   mediaProbeRequestSchema,
   projectCreateRequestSchema,
   projectSaveRequestSchema,
@@ -40,6 +41,8 @@ test('lifecycle project requests are strict and revision guarded', () => {
   assert.equal(projectSaveRequestSchema.safeParse({ project: {} }).success, false)
   assert.equal(mediaProbeRequestSchema.safeParse({ persist: true }).success, false)
   assert.equal(mediaProbeRequestSchema.safeParse({ persist: true, force: true }).success, true)
+  assert.equal(mediaImportRequestSchema.safeParse({ file: '/tmp/tone.wav' }).success, true)
+  assert.equal(mediaImportRequestSchema.safeParse({ file: '/tmp/tone.wav', surprise: true }).success, false)
 })
 
 test('lifecycle edits require unique caller ids and accept id references', () => {
@@ -83,8 +86,9 @@ test('lifecycle edits require unique caller ids and accept id references', () =>
 
 test('capabilities publish lifecycle constraints', () => {
   const result = capabilities()
-  assert.equal(result.lifecycle.httpMediaUpload, false)
+  assert.equal(result.lifecycle.httpMediaUpload, true)
   assert.equal(result.lifecycle.deleteProject, false)
   assert.equal(result.lifecycle.writerMode, 'exclusive')
   assert.ok(result.lifecycle.routes.includes('POST /v1/projects/:id/edit'))
+  assert.ok(result.lifecycle.routes.includes('POST /v1/media/import'))
 })

--- a/headless/lifecycle-e2e.mjs
+++ b/headless/lifecycle-e2e.mjs
@@ -105,6 +105,16 @@ try {
   const edited = (await jsonRequest('/v1/projects/demo/edit', editOptions)).body
   assert.equal(edited.persisted, true)
   assert.equal(edited.project.timeline.items[0].from, 6)
+  const source = path.join(workspace, 'tone.wav')
+  generateToneWav(source)
+  const importedHttp = (
+    await jsonRequest('/v1/media/import', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ file: source, id: 'tone_1', project: 'demo' }),
+    })
+  ).body
+  assert.equal(importedHttp.metadata.mimeType, 'audio/wav')
 } finally {
   const exited = new Promise((resolve) => service.once('exit', () => resolve(true)))
   service.kill('SIGTERM')
@@ -122,26 +132,12 @@ try {
   const source = path.join(workspace, 'tone.wav')
   const output = path.join(workspace, 'rendered.wav')
   const ops = path.join(workspace, 'add-tone.json')
-  generateToneWav(source)
   fs.writeFileSync(
     ops,
     JSON.stringify([
       { callerId: 'tone', op: 'addClip', mediaId: 'tone_1', from: 0, durationInFrames: 15 },
     ]),
   )
-  const imported = runAgent([
-    'media',
-    'import',
-    '--workspace',
-    workspace,
-    '--file',
-    source,
-    '--id',
-    'tone_1',
-    '--project',
-    'demo',
-  ])
-  assert.equal(imported.media.metadata.mimeType, 'audio/wav')
   const current = runAgent(['project', 'get', '--workspace', workspace, '--id', 'demo'])
   const edited = runAgent([
     'project',

--- a/headless/serve.mjs
+++ b/headless/serve.mjs
@@ -65,6 +65,7 @@ import {
   frameRequestSchema,
   layoutRequestSchema,
   lifecycleEditRequestSchema,
+  mediaImportRequestSchema,
   mediaProbeRequestSchema,
   projectCreateRequestSchema,
   projectSaveRequestSchema,
@@ -82,6 +83,9 @@ import {
   listMediaResources,
   listProjectResources,
   saveProjectResource,
+  stageLocalMedia,
+  commitStagedMedia,
+  rollbackStagedMedia,
   updateMediaMetadata,
 } from './lib/lifecycle-store.mjs'
 import { withIdempotency } from './lib/idempotency.mjs'
@@ -441,6 +445,31 @@ async function main() {
     sendJson(res, result.status, result.response)
   }
 
+  const handleV1MediaImport = async (req, res) => {
+    const body = validate(mediaImportRequestSchema, await readJsonBody(req))
+    let staged
+    try {
+      staged = await stageLocalMedia(workspace, body.file, body.id)
+      const probe = await queue.enqueue(
+        () =>
+          session.page.evaluate((payload) => window.pixels.probeMedia(payload), {
+            url: mediaUrlOf(staged.id),
+            fileName: path.basename(staged.target),
+            mimeType: staged.mimeType,
+          }),
+        { timeoutMs: editTimeoutMs, kind: 'media-probe' },
+      )
+      const media = await commitStagedMedia(staged, probe, {
+        workspace,
+        projectId: body.project,
+      })
+      sendJson(res, 201, resourceEnvelope(media))
+    } catch (error) {
+      if (staged) await rollbackStagedMedia(staged)
+      throw error
+    }
+  }
+
   const handleV1MediaProbe = async (req, res, id) => {
     const body = validate(
       mediaProbeRequestSchema,
@@ -627,7 +656,9 @@ async function main() {
                                 apiVersion: HEADLESS_API_VERSION,
                                 media: await listMediaResources(workspace),
                               })
-                          : mediaProbeMatch && req.method === 'POST'
+                          : route === 'POST /v1/media/import'
+                            ? () => handleV1MediaImport(req, res)
+                            : mediaProbeMatch && req.method === 'POST'
                             ? () =>
                                 handleV1MediaProbe(
                                   req,


### PR DESCRIPTION
## Summary
- Send `Idempotency-Key` on MCP project create and persist-edit calls so lifecycle writes are accepted by the server.
- Fix render export to download binary once instead of parsing the attachment as JSON (and rendering twice).
- Add `POST /v1/media/import` on the headless server and wire MCP import to the implemented route.
- Wrap project update payloads under `updates` to match `projectUpdateRequestSchema`.

## Test plan
- [x] `node --test headless/lifecycle-contract.test.mjs headless/contract.test.mjs headless/serve.test.mjs`
- [ ] `node headless/lifecycle-e2e.mjs` (Chrome/GPU)
- [ ] Manual MCP smoke: create project, persist edit, update project, import media, render project


Made with [Cursor](https://cursor.com)