### PR TITLE
fix(onramp): accept COINBASE_CDP_API_KEY_NAME fallback for API key id

### DIFF
--- a/api/onramp-url.ts
+++ b/api/onramp-url.ts
@@ -72,7 +72,9 @@ function normalizeAmount(value: string | null | undefined): string | null {
 }
 
 export async function GET(request: Request): Promise<Response> {
-  const apiKeyId = process.env.COINBASE_CDP_API_KEY_ID
+  // Accept either env var name: the CDP SDK itself falls back from
+  // CDP_API_KEY_ID to CDP_API_KEY_NAME, and Vercel has the _NAME variant set.
+  const apiKeyId = process.env.COINBASE_CDP_API_KEY_ID ?? process.env.COINBASE_CDP_API_KEY_NAME
   const apiKeySecret = process.env.COINBASE_CDP_API_KEY_SECRET
 
   if (!apiKeyId || !apiKeySecret) {


### PR DESCRIPTION
## Summary

The "Buy USDC" modal in edit-pixels returned `Onramp not configured: missing CDP API credentials` (503) because `api/onramp-url.ts` read only `COINBASE_CDP_API_KEY_ID`, while Vercel has `COINBASE_CDP_API_KEY_NAME` + `COINBASE_CDP_API_KEY_SECRET` set.

## Fix

One line: accept either env var name:

```ts
const apiKeyId = process.env.COINBASE_CDP_API_KEY_ID ?? process.env.COINBASE_CDP_API_KEY_NAME
```

This matches the CDP SDK's own resolution order (`_esm/client/cdp.js` reads `apiKeyId ?? CDP_API_KEY_ID ?? CDP_API_KEY_NAME`), so it's consistent with upstream behavior. No Vercel env rename needed.

## Verification

- Verified via `vercel env ls` that `COINBASE_CDP_API_KEY_NAME` + `COINBASE_CDP_API_KEY_SECRET` are set on Preview + Production.
- Verified the SDK fallback in the installed `@coinbase/cdp-sdk` source.
- `tsc` clean on the touched file.

Companion fix for crtv3 (different surface: `app/api/coinbase/onramp/order/route.ts`) is on `feat/campaign-page-predict`.