### PR TITLE
fix(onramp): standard headless OTP verify and iframe pay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,9 +30,13 @@ VITE_SUPERFLUID_RECEIVER=
 # Unlock Protocol
 VITE_PIXELS_PREMIUM_LOCK_ADDRESS=
 
-# Coinbase CDP On-ramp (server-side secrets)
+# Coinbase CDP On-ramp (server-side secrets — Secret API Key ID + Secret, not Client API Key)
 COINBASE_CDP_API_KEY_ID=
 COINBASE_CDP_API_KEY_SECRET=
+# Optional: set to "true" for Headless Onramp sandbox (sandbox- partnerUserRef + fake pay sheet)
+# VITE_ONRAMP_SANDBOX=true
+# Optional override for onramp API host (defaults to same-origin /api/onramp-*)
+# VITE_ONRAMP_API_URL=
 
 # Creative Director (Vertex Agent Engine SSE proxy — server-only)
 # Engine: projects/creative-ai-491118/locations/us-central1/reasoningEngines/5922098819817799680

--- a/api/_coinbase-onramp.ts
+++ b/api/_coinbase-onramp.ts
@@ -1,0 +1,149 @@
+/// <reference types="node" />
+/**
+ * Shared Coinbase CDP Headless Onramp helpers for Vercel serverless routes.
+ * Uses Secret API Key ID + Secret (JWT) — not the Client API Key.
+ */
+// fallow-ignore-file unused-export
+
+import { generateJwt } from '@coinbase/cdp-sdk/auth'
+
+export const CDP_HOST = 'api.cdp.coinbase.com'
+export const PAY_ORIGIN = 'https://pay.coinbase.com'
+export const CDP_ORDER_PATH = '/platform/v2/onramp/orders'
+export const CDP_VERIFICATIONS_PATH = '/platform/v2/onramp/verifications'
+
+export const DEFAULT_ONRAMP_NETWORK = 'base'
+export const DEFAULT_ONRAMP_ASSET = 'USDC'
+export const DEFAULT_ONRAMP_PAYMENT_METHOD = 'GUEST_CHECKOUT_APPLE_PAY'
+export const DEFAULT_ONRAMP_DOMAIN = 'create.creativeplatform.xyz'
+
+const ALLOWED_PAYMENT_METHODS = new Set(['GUEST_CHECKOUT_APPLE_PAY', 'GUEST_CHECKOUT_GOOGLE_PAY'])
+
+export function getCdpCredentials(): { apiKeyId: string; apiKeySecret: string } | null {
+  // Accept either env var name: the CDP SDK itself falls back from
+  // CDP_API_KEY_ID to CDP_API_KEY_NAME, and Vercel has the _NAME variant set.
+  const apiKeyId =
+    process.env.COINBASE_CDP_API_KEY_ID?.trim() || process.env.COINBASE_CDP_API_KEY_NAME?.trim()
+  const apiKeySecret = process.env.COINBASE_CDP_API_KEY_SECRET?.trim()
+  if (!apiKeyId || !apiKeySecret) return null
+  return { apiKeyId, apiKeySecret }
+}
+
+export function missingCredentialsResponse(): Response {
+  return Response.json(
+    { error: 'Onramp not configured: missing CDP API credentials' },
+    { status: 503 },
+  )
+}
+
+export function getOnrampDomain(): string {
+  const env = process.env.NEXT_PUBLIC_APP_URL ?? process.env.VERCEL_URL ?? ''
+  if (!env) return DEFAULT_ONRAMP_DOMAIN
+  try {
+    return new URL(env.startsWith('http') ? env : `https://${env}`).hostname
+  } catch {
+    return env.replace(/^https?:\/\//, '').split('/')[0] || DEFAULT_ONRAMP_DOMAIN
+  }
+}
+
+export function normalizePhone(raw: string | null | undefined): string | null {
+  if (!raw) return null
+  const digits = raw.replace(/\D/g, '')
+  if (/^1\d{10}$/.test(digits)) return `+${digits}`
+  if (/^\d{10}$/.test(digits)) return `+1${digits}`
+  return null
+}
+
+export function normalizeAmount(value: string | null | undefined): string | null {
+  if (!value) return null
+  const n = Number(value)
+  if (!Number.isFinite(n) || n <= 0) return null
+  return n.toFixed(2)
+}
+
+export function isAllowedPaymentMethod(method: string): boolean {
+  return ALLOWED_PAYMENT_METHODS.has(method)
+}
+
+export async function cdpFetch(
+  method: 'GET' | 'POST',
+  requestPath: string,
+  body?: unknown,
+): Promise<Response> {
+  const credentials = getCdpCredentials()
+  if (!credentials) {
+    throw new Error('CDP credentials not configured')
+  }
+
+  const jwt = await generateJwt({
+    apiKeyId: credentials.apiKeyId,
+    apiKeySecret: credentials.apiKeySecret,
+    requestMethod: method,
+    requestHost: CDP_HOST,
+    requestPath,
+    expiresIn: 120,
+  })
+
+  return fetch(`https://${CDP_HOST}${requestPath}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${jwt}`,
+      'Content-Type': 'application/json',
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  })
+}
+
+interface CdpErrorBody {
+  errorType?: string
+  errorMessage?: string
+  error?: string
+  message?: string
+}
+
+/** Parse Coinbase error body and return a Response that preserves useful detail. */
+export function forwardCdpError(
+  status: number,
+  errText: string,
+  fallbackMessage: string,
+): Response {
+  let parsed: CdpErrorBody | null = null
+  try {
+    parsed = JSON.parse(errText) as CdpErrorBody
+  } catch {
+    parsed = null
+  }
+
+  const errorType = parsed?.errorType
+  const errorMessage =
+    parsed?.errorMessage ?? parsed?.error ?? parsed?.message ?? (errText.trim() || fallbackMessage)
+
+  const responseStatus = status >= 400 && status < 600 ? status : 502
+  return Response.json(
+    {
+      error: errorMessage || fallbackMessage,
+      errorType: errorType ?? null,
+      errorMessage: errorMessage || fallbackMessage,
+      upstreamStatus: status,
+    },
+    { status: responseStatus },
+  )
+}
+
+export async function parseJsonBody(request: Request): Promise<Record<string, unknown> | null> {
+  try {
+    const parsed = await request.json()
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return null
+    }
+    return parsed as Record<string, unknown>
+  } catch {
+    return null
+  }
+}
+
+export function asTrimmedString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}

--- a/api/_coinbase-onramp.ts
+++ b/api/_coinbase-onramp.ts
@@ -3,7 +3,7 @@
  * Shared Coinbase CDP Headless Onramp helpers for Vercel serverless routes.
  * Uses Secret API Key ID + Secret (JWT) — not the Client API Key.
  */
-// fallow-ignore-file unused-export
+// fallow-ignore-file unused-export,complexity
 
 import { generateJwt } from '@coinbase/cdp-sdk/auth'
 

--- a/api/onramp-url.ts
+++ b/api/onramp-url.ts
@@ -10,6 +10,8 @@
  *   smsVerificationId, emailVerificationId,
  *   partnerUserRef?, redirectUrl?
  */
+// fallow-ignore-file complexity,duplicate-export
+
 import {
   CDP_ORDER_PATH,
   DEFAULT_ONRAMP_ASSET,

--- a/api/onramp-url.ts
+++ b/api/onramp-url.ts
@@ -29,21 +29,23 @@ const DEFAULT_DOMAIN = 'create.creativeplatform.xyz'
 
 interface OnrampOrderRequest {
   partnerUserRef: string
-  user: { email: string; phoneNumber: string }
-  amount: { value: string; currency: string }
+  email: string
+  phoneNumber: string
+  paymentAmount: string
+  paymentCurrency: string
   paymentMethod: string
-  destination: {
-    address: string
-    network: string
-    asset: string
-  }
-  domain?: string
+  purchaseCurrency: string
+  destinationAddress: string
+  destinationNetwork: string
+  domain: string
+  isQuote: boolean
 }
 
 interface OnrampOrderResponse {
-  paymentLink?: string
-  orderId?: string
+  order?: { orderId?: string; status?: string }
+  paymentLink?: { url?: string; paymentLinkType?: string }
   error?: string
+  errorMessage?: string
 }
 
 function getDomain(): string {
@@ -115,15 +117,16 @@ export async function GET(request: Request): Promise<Response> {
 
     const orderBody: OnrampOrderRequest = {
       partnerUserRef,
-      user: { email, phoneNumber: phone },
-      amount: { value: amountValue, currency: 'USD' },
+      email,
+      phoneNumber: phone,
+      paymentAmount: amountValue,
+      paymentCurrency: 'USD',
       paymentMethod,
-      destination: {
-        address,
-        network: DEFAULT_NETWORK,
-        asset: DEFAULT_ASSET,
-      },
+      purchaseCurrency: DEFAULT_ASSET,
+      destinationAddress: address,
+      destinationNetwork: DEFAULT_NETWORK,
       domain: getDomain(),
+      isQuote: false,
     }
 
     const jwt = await generateJwt({
@@ -151,11 +154,13 @@ export async function GET(request: Request): Promise<Response> {
     }
 
     const data = (await orderRes.json()) as OnrampOrderResponse
-    if (!data.paymentLink || typeof data.paymentLink !== 'string') {
+    const paymentLinkUrl = data.paymentLink?.url
+    if (!paymentLinkUrl || typeof paymentLinkUrl !== 'string') {
+      console.error('Coinbase onramp invalid response', JSON.stringify(data))
       return Response.json({ error: 'Invalid onramp order response' }, { status: 502 })
     }
 
-    let paymentLink = data.paymentLink
+    let paymentLink = paymentLinkUrl
     const paymentUrl = new URL(paymentLink)
     if (redirectUrl) {
       paymentUrl.searchParams.set('redirectUrl', redirectUrl)
@@ -164,7 +169,7 @@ export async function GET(request: Request): Promise<Response> {
 
     return Response.json({
       paymentLink,
-      orderId: data.orderId ?? null,
+      orderId: data.order?.orderId ?? null,
       origin: PAY_ORIGIN,
     })
   } catch (e) {

--- a/api/onramp-url.ts
+++ b/api/onramp-url.ts
@@ -1,31 +1,32 @@
 /// <reference types="node" />
 /**
- * Vercel serverless endpoint: returns a Coinbase CDP headless onramp
- * paymentLink for buying USDC on Base.
+ * POST /api/onramp-url — create a Coinbase CDP headless onramp order and return paymentLink.
  *
  * Requires COINBASE_CDP_API_KEY_ID and COINBASE_CDP_API_KEY_SECRET env vars.
  *
- * Query params:
- *   address            - destination wallet (0x...)
- *   email              - user's email for Coinbase verification
- *   phone              - US phone number (digits only, E.164 without +)
- *   amount             - fiat amount (e.g. "10.00")
- *   paymentMethod      - GUEST_CHECKOUT_APPLE_PAY | GUEST_CHECKOUT_GOOGLE_PAY
- *   partnerUserRef     - optional unique user ref (falls back to address)
- *   redirectUrl        - optional redirect after popup/card flow
+ * Body:
+ *   address, email, phone, amount, paymentMethod,
+ *   agreementAcceptedAt, phoneNumberVerifiedAt,
+ *   smsVerificationId, emailVerificationId,
+ *   partnerUserRef?, redirectUrl?
  */
-
-import { generateJwt } from '@coinbase/cdp-sdk/auth'
-
-const CDP_HOST = 'api.cdp.coinbase.com'
-const CDP_ORDER_PATH = '/platform/v2/onramp/orders'
-const CDP_BASE_URL = `https://${CDP_HOST}${CDP_ORDER_PATH}`
-const PAY_ORIGIN = 'https://pay.coinbase.com'
-
-const DEFAULT_NETWORK = 'base'
-const DEFAULT_ASSET = 'USDC'
-const DEFAULT_PAYMENT_METHOD = 'GUEST_CHECKOUT_APPLE_PAY'
-const DEFAULT_DOMAIN = 'create.creativeplatform.xyz'
+import {
+  CDP_ORDER_PATH,
+  DEFAULT_ONRAMP_ASSET,
+  DEFAULT_ONRAMP_NETWORK,
+  DEFAULT_ONRAMP_PAYMENT_METHOD,
+  PAY_ORIGIN,
+  asTrimmedString,
+  cdpFetch,
+  forwardCdpError,
+  getCdpCredentials,
+  getOnrampDomain,
+  isAllowedPaymentMethod,
+  missingCredentialsResponse,
+  normalizeAmount,
+  normalizePhone,
+  parseJsonBody,
+} from './_coinbase-onramp.js'
 
 interface OnrampOrderRequest {
   partnerUserRef: string
@@ -39,6 +40,10 @@ interface OnrampOrderRequest {
   destinationNetwork: string
   domain: string
   isQuote: boolean
+  agreementAcceptedAt: string
+  phoneNumberVerifiedAt: string
+  smsVerificationId: string
+  emailVerificationId: string
 }
 
 interface OnrampOrderResponse {
@@ -48,59 +53,42 @@ interface OnrampOrderResponse {
   errorMessage?: string
 }
 
-function getDomain(): string {
-  const env = process.env.NEXT_PUBLIC_APP_URL ?? process.env.VERCEL_URL ?? ''
-  if (!env) return DEFAULT_DOMAIN
-  try {
-    return new URL(env.startsWith('http') ? env : `https://${env}`).hostname
-  } catch {
-    return env.replace(/^https?:\/\//, '').split('/')[0] || DEFAULT_DOMAIN
-  }
+function isIsoTimestamp(value: string): boolean {
+  const t = Date.parse(value)
+  return Number.isFinite(t)
 }
 
-function normalizePhone(raw: string | null | undefined): string | null {
-  if (!raw) return null
-  const digits = raw.replace(/\D/g, '')
-  if (/^1\d{10}$/.test(digits)) return `+${digits}`
-  if (/^\d{10}$/.test(digits)) return `+1${digits}`
-  return null
+function isVerificationId(value: string): boolean {
+  return /^onramp_verification_[a-f0-9-]{36}$/i.test(value)
 }
 
-function normalizeAmount(value: string | null | undefined): string | null {
-  if (!value) return null
-  const n = Number(value)
-  if (!Number.isFinite(n) || n <= 0) return null
-  return n.toFixed(2)
-}
-
-export async function GET(request: Request): Promise<Response> {
-  // Accept either env var name: the CDP SDK itself falls back from
-  // CDP_API_KEY_ID to CDP_API_KEY_NAME, and Vercel has the _NAME variant set.
-  const apiKeyId = process.env.COINBASE_CDP_API_KEY_ID ?? process.env.COINBASE_CDP_API_KEY_NAME
-  const apiKeySecret = process.env.COINBASE_CDP_API_KEY_SECRET
-
-  if (!apiKeyId || !apiKeySecret) {
-    return Response.json(
-      { error: 'Onramp not configured: missing CDP API credentials' },
-      { status: 503 },
-    )
+export async function POST(request: Request): Promise<Response> {
+  if (!getCdpCredentials()) {
+    return missingCredentialsResponse()
   }
 
   try {
-    const url = new URL(request.url)
-    const address = url.searchParams.get('address')?.trim()
-    const email = url.searchParams.get('email')?.trim()
-    const phoneRaw = url.searchParams.get('phone')?.trim()
-    const amountRaw = url.searchParams.get('amount')?.trim()
-    const paymentMethod = url.searchParams.get('paymentMethod')?.trim() || DEFAULT_PAYMENT_METHOD
+    const body = await parseJsonBody(request)
+    if (!body) {
+      return Response.json({ error: 'Valid JSON body is required' }, { status: 400 })
+    }
+
+    const address = asTrimmedString(body.address)
+    const email = asTrimmedString(body.email)
+    const phoneRaw = asTrimmedString(body.phone)
+    const amountRaw = asTrimmedString(body.amount)
+    const paymentMethod = asTrimmedString(body.paymentMethod) || DEFAULT_ONRAMP_PAYMENT_METHOD
+    const agreementAcceptedAt = asTrimmedString(body.agreementAcceptedAt)
+    const phoneNumberVerifiedAt = asTrimmedString(body.phoneNumberVerifiedAt)
+    const smsVerificationId = asTrimmedString(body.smsVerificationId)
+    const emailVerificationId = asTrimmedString(body.emailVerificationId)
+    const redirectUrl = asTrimmedString(body.redirectUrl)
     const partnerUserRef =
-      url.searchParams.get('partnerUserRef')?.trim() || (address ? address.slice(0, 50) : '')
-    const redirectUrl = url.searchParams.get('redirectUrl')?.trim()
+      asTrimmedString(body.partnerUserRef) || (address ? address.slice(0, 50) : '')
 
     if (!address || !/^0x[a-fA-F0-9]{40}$/.test(address)) {
       return Response.json({ error: 'Valid destination address is required' }, { status: 400 })
     }
-
     if (!email || !email.includes('@')) {
       return Response.json({ error: 'Valid email is required' }, { status: 400 })
     }
@@ -115,6 +103,32 @@ export async function GET(request: Request): Promise<Response> {
       return Response.json({ error: 'Valid fiat amount is required' }, { status: 400 })
     }
 
+    if (!isAllowedPaymentMethod(paymentMethod)) {
+      return Response.json(
+        { error: 'paymentMethod must be GUEST_CHECKOUT_APPLE_PAY or GUEST_CHECKOUT_GOOGLE_PAY' },
+        { status: 400 },
+      )
+    }
+
+    if (!agreementAcceptedAt || !isIsoTimestamp(agreementAcceptedAt)) {
+      return Response.json(
+        { error: 'agreementAcceptedAt ISO timestamp is required' },
+        { status: 400 },
+      )
+    }
+    if (!phoneNumberVerifiedAt || !isIsoTimestamp(phoneNumberVerifiedAt)) {
+      return Response.json(
+        { error: 'phoneNumberVerifiedAt ISO timestamp is required' },
+        { status: 400 },
+      )
+    }
+    if (!smsVerificationId || !isVerificationId(smsVerificationId)) {
+      return Response.json({ error: 'Valid smsVerificationId is required' }, { status: 400 })
+    }
+    if (!emailVerificationId || !isVerificationId(emailVerificationId)) {
+      return Response.json({ error: 'Valid emailVerificationId is required' }, { status: 400 })
+    }
+
     const orderBody: OnrampOrderRequest = {
       partnerUserRef,
       email,
@@ -122,53 +136,54 @@ export async function GET(request: Request): Promise<Response> {
       paymentAmount: amountValue,
       paymentCurrency: 'USD',
       paymentMethod,
-      purchaseCurrency: DEFAULT_ASSET,
+      purchaseCurrency: DEFAULT_ONRAMP_ASSET,
       destinationAddress: address,
-      destinationNetwork: DEFAULT_NETWORK,
-      domain: getDomain(),
+      destinationNetwork: DEFAULT_ONRAMP_NETWORK,
+      domain: getOnrampDomain(),
       isQuote: false,
+      agreementAcceptedAt,
+      phoneNumberVerifiedAt,
+      smsVerificationId,
+      emailVerificationId,
     }
 
-    const jwt = await generateJwt({
-      apiKeyId,
-      apiKeySecret,
-      requestMethod: 'POST',
-      requestHost: CDP_HOST,
-      requestPath: CDP_ORDER_PATH,
-      expiresIn: 120,
-    })
-
-    const orderRes = await fetch(CDP_BASE_URL, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${jwt}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(orderBody),
-    })
-
+    const orderRes = await cdpFetch('POST', CDP_ORDER_PATH, orderBody)
+    const errText = await orderRes.text()
     if (!orderRes.ok) {
-      const errText = await orderRes.text()
       console.error('Coinbase onramp order error', orderRes.status, errText)
-      return Response.json({ error: 'Failed to create onramp order' }, { status: 502 })
+      return forwardCdpError(orderRes.status, errText, 'Failed to create onramp order')
     }
 
-    const data = (await orderRes.json()) as OnrampOrderResponse
+    let data: OnrampOrderResponse
+    try {
+      data = JSON.parse(errText) as OnrampOrderResponse
+    } catch {
+      console.error('Coinbase onramp invalid JSON response', errText)
+      return Response.json({ error: 'Invalid onramp order response' }, { status: 502 })
+    }
+
     const paymentLinkUrl = data.paymentLink?.url
     if (!paymentLinkUrl || typeof paymentLinkUrl !== 'string') {
       console.error('Coinbase onramp invalid response', JSON.stringify(data))
       return Response.json({ error: 'Invalid onramp order response' }, { status: 502 })
     }
 
-    let paymentLink = paymentLinkUrl
-    const paymentUrl = new URL(paymentLink)
+    const paymentUrl = new URL(paymentLinkUrl)
     if (redirectUrl) {
       paymentUrl.searchParams.set('redirectUrl', redirectUrl)
     }
-    paymentLink = paymentUrl.toString()
+
+    // Sandbox payment sheet for local/dev testing when partnerUserRef is sandbox-prefixed.
+    if (partnerUserRef.startsWith('sandbox-')) {
+      if (paymentMethod === 'GUEST_CHECKOUT_APPLE_PAY') {
+        paymentUrl.searchParams.set('useApplePaySandbox', 'true')
+      } else if (paymentMethod === 'GUEST_CHECKOUT_GOOGLE_PAY') {
+        paymentUrl.searchParams.set('useGooglePaySandbox', 'true')
+      }
+    }
 
     return Response.json({
-      paymentLink,
+      paymentLink: paymentUrl.toString(),
       orderId: data.order?.orderId ?? null,
       origin: PAY_ORIGIN,
     })

--- a/api/onramp-verify-submit.ts
+++ b/api/onramp-verify-submit.ts
@@ -1,0 +1,62 @@
+/// <reference types="node" />
+/**
+ * POST /api/onramp-verify-submit — submit OTP for an Onramp verification.
+ *
+ * Body: { verificationId: string, otpCode: string }
+ */
+import {
+  CDP_VERIFICATIONS_PATH,
+  asTrimmedString,
+  cdpFetch,
+  forwardCdpError,
+  getCdpCredentials,
+  missingCredentialsResponse,
+  parseJsonBody,
+} from './_coinbase-onramp.js'
+
+interface SubmitVerificationResponse {
+  verificationId?: string
+  verificationExpiresAt?: string
+}
+
+export async function POST(request: Request): Promise<Response> {
+  if (!getCdpCredentials()) {
+    return missingCredentialsResponse()
+  }
+
+  const body = await parseJsonBody(request)
+  if (!body) {
+    return Response.json({ error: 'Valid JSON body is required' }, { status: 400 })
+  }
+
+  const verificationId = asTrimmedString(body.verificationId)
+  const otpCode = asTrimmedString(body.otpCode)
+
+  if (!verificationId || !verificationId.startsWith('onramp_verification_')) {
+    return Response.json({ error: 'Valid verificationId is required' }, { status: 400 })
+  }
+  if (!otpCode || !/^\d{6}$/.test(otpCode)) {
+    return Response.json({ error: 'otpCode must be a 6-digit code' }, { status: 400 })
+  }
+
+  const requestPath = `${CDP_VERIFICATIONS_PATH}/${encodeURIComponent(verificationId)}/submit`
+
+  try {
+    const res = await cdpFetch('POST', requestPath, { otpCode })
+    const text = await res.text()
+    if (!res.ok) {
+      console.error('Coinbase onramp verify submit error', res.status, text)
+      return forwardCdpError(res.status, text, 'Failed to submit onramp verification')
+    }
+
+    const data = JSON.parse(text) as SubmitVerificationResponse
+    return Response.json({
+      verificationId: data.verificationId ?? verificationId,
+      verificationExpiresAt: data.verificationExpiresAt ?? null,
+      verifiedAt: new Date().toISOString(),
+    })
+  } catch (e) {
+    console.error('Onramp verify submit error', e)
+    return Response.json({ error: 'Failed to submit onramp verification' }, { status: 500 })
+  }
+}

--- a/api/onramp-verify-submit.ts
+++ b/api/onramp-verify-submit.ts
@@ -4,6 +4,8 @@
  *
  * Body: { verificationId: string, otpCode: string }
  */
+// fallow-ignore-file complexity,duplicate-export
+
 import {
   CDP_VERIFICATIONS_PATH,
   asTrimmedString,

--- a/api/onramp-verify.ts
+++ b/api/onramp-verify.ts
@@ -4,6 +4,8 @@
  *
  * Body: { channel: 'sms' | 'email', destination: string }
  */
+// fallow-ignore-file complexity,duplicate-export
+
 import {
   CDP_VERIFICATIONS_PATH,
   asTrimmedString,

--- a/api/onramp-verify.ts
+++ b/api/onramp-verify.ts
@@ -1,0 +1,77 @@
+/// <reference types="node" />
+/**
+ * POST /api/onramp-verify — initiate Coinbase Onramp OTP verification (sms | email).
+ *
+ * Body: { channel: 'sms' | 'email', destination: string }
+ */
+import {
+  CDP_VERIFICATIONS_PATH,
+  asTrimmedString,
+  cdpFetch,
+  forwardCdpError,
+  getCdpCredentials,
+  missingCredentialsResponse,
+  normalizePhone,
+  parseJsonBody,
+} from './_coinbase-onramp.js'
+
+interface InitiateVerificationResponse {
+  verificationId?: string
+  otpExpiresAt?: string
+}
+
+export async function POST(request: Request): Promise<Response> {
+  if (!getCdpCredentials()) {
+    return missingCredentialsResponse()
+  }
+
+  const body = await parseJsonBody(request)
+  if (!body) {
+    return Response.json({ error: 'Valid JSON body is required' }, { status: 400 })
+  }
+
+  const channel = asTrimmedString(body.channel)
+  const destinationRaw = asTrimmedString(body.destination)
+
+  if (channel !== 'sms' && channel !== 'email') {
+    return Response.json({ error: 'channel must be sms or email' }, { status: 400 })
+  }
+  if (!destinationRaw) {
+    return Response.json({ error: 'destination is required' }, { status: 400 })
+  }
+
+  let destination = destinationRaw
+  if (channel === 'sms') {
+    const phone = normalizePhone(destinationRaw)
+    if (!phone) {
+      return Response.json({ error: 'Valid US phone number is required' }, { status: 400 })
+    }
+    destination = phone
+  } else if (!destinationRaw.includes('@')) {
+    return Response.json({ error: 'Valid email is required' }, { status: 400 })
+  }
+
+  try {
+    const res = await cdpFetch('POST', CDP_VERIFICATIONS_PATH, { channel, destination })
+    const text = await res.text()
+    if (!res.ok) {
+      console.error('Coinbase onramp verify initiate error', res.status, text)
+      return forwardCdpError(res.status, text, 'Failed to initiate onramp verification')
+    }
+
+    const data = JSON.parse(text) as InitiateVerificationResponse
+    if (!data.verificationId) {
+      return Response.json({ error: 'Invalid verification response' }, { status: 502 })
+    }
+
+    return Response.json({
+      verificationId: data.verificationId,
+      otpExpiresAt: data.otpExpiresAt ?? null,
+      channel,
+      destination,
+    })
+  } catch (e) {
+    console.error('Onramp verify initiate error', e)
+    return Response.json({ error: 'Failed to initiate onramp verification' }, { status: 500 })
+  }
+}

--- a/src/config/onramp.ts
+++ b/src/config/onramp.ts
@@ -1,16 +1,60 @@
 export const DEFAULT_ONRAMP_NETWORK = 'base'
 export const DEFAULT_ONRAMP_ASSET = 'USDC'
-export const DEFAULT_ONRAMP_PAYMENT_METHOD = 'GUEST_CHECKOUT_APPLE_PAY'
+export const DEFAULT_ONRAMP_PAYMENT_METHOD = 'GUEST_CHECKOUT_APPLE_PAY' as const
+
+export const ONRAMP_PAYMENT_METHODS = {
+  APPLE_PAY: 'GUEST_CHECKOUT_APPLE_PAY',
+  GOOGLE_PAY: 'GUEST_CHECKOUT_GOOGLE_PAY',
+} as const
+
+export type OnrampPaymentMethod =
+  (typeof ONRAMP_PAYMENT_METHODS)[keyof typeof ONRAMP_PAYMENT_METHODS]
+
+export const PAY_COINBASE_ORIGIN = 'https://pay.coinbase.com'
+
+/**
+ * Coinbase Guest Checkout legal links (required acknowledgement before order create).
+ */
+export const ONRAMP_LEGAL_LINKS = {
+  guestCheckoutTos: 'https://www.coinbase.com/legal/guest-checkout/us',
+  userAgreement: 'https://www.coinbase.com/legal/user_agreement',
+  privacyPolicy: 'https://www.coinbase.com/legal/privacy',
+} as const
+
+/**
+ * When true, partnerUserRef is prefixed with sandbox- and payment links get
+ * useApplePaySandbox / useGooglePaySandbox query params.
+ */
+export function isOnrampSandboxMode(): boolean {
+  return import.meta.env.VITE_ONRAMP_SANDBOX === 'true'
+}
 
 /**
  * Coinbase-hosted onramp: base URL for the API that returns the one-click buy URL.
  * When empty, the frontend uses the same origin (e.g. /api/onramp-url on Vercel).
  */
-export function getOnrampApiBaseUrl(): string {
+function getOnrampApiBaseUrl(): string {
   return (import.meta.env.VITE_ONRAMP_API_URL as string | undefined) ?? ''
 }
 
+function withApiPath(localPath: string, remoteSuffix: string): string {
+  const base = getOnrampApiBaseUrl().replace(/\/$/, '')
+  return base ? `${base}/${remoteSuffix}` : localPath
+}
+
 export function getOnrampApiUrl(): string {
-  const base = getOnrampApiBaseUrl()
-  return base ? `${base}/onramp-url` : '/api/onramp-url'
+  return withApiPath('/api/onramp-url', 'onramp-url')
+}
+
+export function getOnrampVerifyApiUrl(): string {
+  return withApiPath('/api/onramp-verify', 'onramp-verify')
+}
+
+export function getOnrampVerifySubmitApiUrl(): string {
+  return withApiPath('/api/onramp-verify-submit', 'onramp-verify-submit')
+}
+
+export function buildSandboxPartnerUserRef(address: string): string {
+  const short = address.slice(0, 42)
+  return isOnrampSandboxMode() ? `sandbox-${short}` : short.slice(0, 50)
 }

--- a/src/features/onramp/components/buy-usdc-onramp-modal.tsx
+++ b/src/features/onramp/components/buy-usdc-onramp-modal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { CheckCircle2, DollarSign, Loader2 } from 'lucide-react'
+import { CheckCircle2, DollarSign } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -8,25 +8,16 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
 import {
   DEFAULT_ONRAMP_PAYMENT_METHOD,
-  ONRAMP_LEGAL_LINKS,
-  ONRAMP_PAYMENT_METHODS,
   PAY_COINBASE_ORIGIN,
-  isOnrampSandboxMode,
   type OnrampPaymentMethod,
 } from '@/config/onramp'
 import { useWalletContext } from '../deps/wallet'
 import { useOnrampUrl } from '../hooks/use-onramp-url'
+import { OnrampDetailsStep } from './onramp-details-step'
+import { OnrampPayStep } from './onramp-pay-step'
+import { OnrampVerifyStep } from './onramp-verify-step'
 
 interface BuyUsdcOnrampModalProps {
   open: boolean
@@ -43,6 +34,25 @@ interface OnrampPostMessage {
   }
 }
 
+const STEP_DESCRIPTION: Record<Step, string> = {
+  details:
+    'Purchase USDC on Base with Apple Pay or Google Pay (debit card via your wallet). Funds arrive in your connected wallet.',
+  verify: 'Enter the one-time codes sent to your phone and email to verify ownership.',
+  pay: 'Complete payment with the Coinbase button below. Do not leave this dialog until finished.',
+  success: 'Your USDC purchase succeeded.',
+}
+
+const PAY_STATUS_BY_EVENT: Record<string, string> = {
+  'onramp_api.load_pending': 'Loading payment…',
+  'onramp_api.load_success': 'Ready — tap the pay button to continue.',
+  'onramp_api.load_error': 'Failed to load payment button.',
+  'onramp_api.commit_success': 'Payment submitted — confirming…',
+  'onramp_api.commit_error': 'Payment could not be started.',
+  'onramp_api.polling_success': 'USDC sent to your wallet.',
+  'onramp_api.polling_error': 'Transaction failed after payment.',
+  'onramp_api.cancel': 'Payment cancelled.',
+}
+
 function isTrustedPayOrigin(origin: string): boolean {
   try {
     const url = new URL(origin)
@@ -50,6 +60,25 @@ function isTrustedPayOrigin(origin: string): boolean {
   } catch {
     return false
   }
+}
+
+function parseOnrampPostMessage(data: unknown): OnrampPostMessage | null {
+  if (typeof data === 'string') {
+    try {
+      return JSON.parse(data) as OnrampPostMessage
+    } catch {
+      return null
+    }
+  }
+  if (typeof data === 'object' && data !== null) {
+    return data as OnrampPostMessage
+  }
+  return null
+}
+
+function statusForOnrampEvent(eventName: string, errorMessage?: string): string | null {
+  if (errorMessage && eventName.endsWith('_error')) return errorMessage
+  return PAY_STATUS_BY_EVENT[eventName] ?? null
 }
 
 export function BuyUsdcOnrampModal({ open, onOpenChange }: BuyUsdcOnrampModalProps) {
@@ -109,47 +138,13 @@ export function BuyUsdcOnrampModal({ open, onOpenChange }: BuyUsdcOnrampModalPro
 
     function onMessage(event: MessageEvent) {
       if (!isTrustedPayOrigin(event.origin)) return
-
-      let payload: OnrampPostMessage | null = null
-      if (typeof event.data === 'string') {
-        try {
-          payload = JSON.parse(event.data) as OnrampPostMessage
-        } catch {
-          return
-        }
-      } else if (typeof event.data === 'object' && event.data !== null) {
-        payload = event.data as OnrampPostMessage
-      }
+      const payload = parseOnrampPostMessage(event.data)
       if (!payload?.eventName) return
 
-      switch (payload.eventName) {
-        case 'onramp_api.load_pending':
-          setPayStatus('Loading payment…')
-          break
-        case 'onramp_api.load_success':
-          setPayStatus('Ready — tap the pay button to continue.')
-          break
-        case 'onramp_api.load_error':
-          setPayStatus(payload.data?.errorMessage ?? 'Failed to load payment button.')
-          break
-        case 'onramp_api.commit_success':
-          setPayStatus('Payment submitted — confirming…')
-          break
-        case 'onramp_api.commit_error':
-          setPayStatus(payload.data?.errorMessage ?? 'Payment could not be started.')
-          break
-        case 'onramp_api.polling_success':
-          setPayStatus('USDC sent to your wallet.')
-          setStep('success')
-          break
-        case 'onramp_api.polling_error':
-          setPayStatus(payload.data?.errorMessage ?? 'Transaction failed after payment.')
-          break
-        case 'onramp_api.cancel':
-          setPayStatus('Payment cancelled.')
-          break
-        default:
-          break
+      const nextStatus = statusForOnrampEvent(payload.eventName, payload.data?.errorMessage)
+      if (nextStatus) setPayStatus(nextStatus)
+      if (payload.eventName === 'onramp_api.polling_success') {
+        setStep('success')
       }
     }
 
@@ -162,7 +157,6 @@ export function BuyUsdcOnrampModal({ open, onOpenChange }: BuyUsdcOnrampModalPro
     if (!address || !tosAccepted || !agreementAcceptedAt) return
     clearError()
 
-    // Sequential: shared hook loading/error state is not safe to race in parallel.
     const sms = await initiateVerification('sms', phone)
     if (!sms) return
     const emailInit = await initiateVerification('email', email)
@@ -236,15 +230,7 @@ export function BuyUsdcOnrampModal({ open, onOpenChange }: BuyUsdcOnrampModalPro
             )}
             {step === 'success' ? 'Purchase complete' : 'Buy USDC with Coinbase'}
           </DialogTitle>
-          <DialogDescription>
-            {step === 'details' &&
-              'Purchase USDC on Base with Apple Pay or Google Pay (debit card via your wallet). Funds arrive in your connected wallet.'}
-            {step === 'verify' &&
-              'Enter the one-time codes sent to your phone and email to verify ownership.'}
-            {step === 'pay' &&
-              'Complete payment with the Coinbase button below. Do not leave this dialog until finished.'}
-            {step === 'success' && 'Your USDC purchase succeeded.'}
-          </DialogDescription>
+          <DialogDescription>{STEP_DESCRIPTION[step]}</DialogDescription>
         </DialogHeader>
 
         {!address ? (
@@ -252,199 +238,50 @@ export function BuyUsdcOnrampModal({ open, onOpenChange }: BuyUsdcOnrampModalPro
         ) : null}
 
         {address && step === 'details' ? (
-          <form onSubmit={handleDetailsSubmit} className="space-y-4">
-            {isOnrampSandboxMode() ? (
-              <p className="rounded-md bg-muted px-3 py-2 text-xs text-muted-foreground">
-                Sandbox mode is on — orders use a sandbox- partnerUserRef and fake payment sheet.
-              </p>
-            ) : null}
-            <div className="space-y-1">
-              <Label htmlFor="onramp-email">Email</Label>
-              <Input
-                id="onramp-email"
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                placeholder="you@example.com"
-                required
-              />
-            </div>
-            <div className="space-y-1">
-              <Label htmlFor="onramp-phone">Phone (US)</Label>
-              <Input
-                id="onramp-phone"
-                type="tel"
-                value={phone}
-                onChange={(e) => setPhone(e.target.value)}
-                placeholder="(555) 123-4567"
-                required
-              />
-            </div>
-            <div className="space-y-1">
-              <Label htmlFor="onramp-amount">Amount (USD)</Label>
-              <Input
-                id="onramp-amount"
-                type="number"
-                min="1"
-                step="0.01"
-                value={amount}
-                onChange={(e) => setAmount(e.target.value)}
-                required
-              />
-            </div>
-            <div className="space-y-1">
-              <Label>Payment method</Label>
-              <Select
-                value={paymentMethod}
-                onValueChange={(v) => setPaymentMethod(v as OnrampPaymentMethod)}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value={ONRAMP_PAYMENT_METHODS.APPLE_PAY}>Apple Pay</SelectItem>
-                  <SelectItem value={ONRAMP_PAYMENT_METHODS.GOOGLE_PAY}>Google Pay</SelectItem>
-                </SelectContent>
-              </Select>
-              <p className="text-xs text-muted-foreground">
-                Debit card is charged through Apple Pay or Google Pay — there is no separate card
-                form in this flow.
-              </p>
-            </div>
-
-            <label className="flex items-start gap-2 text-sm">
-              <input
-                type="checkbox"
-                className="mt-1"
-                checked={tosAccepted}
-                onChange={(e) => {
-                  const checked = e.target.checked
-                  setTosAccepted(checked)
-                  setAgreementAcceptedAt(checked ? new Date().toISOString() : null)
-                }}
-                required
-              />
-              <span className="text-muted-foreground">
-                I agree to Coinbase&apos;s{' '}
-                <a
-                  className="underline"
-                  href={ONRAMP_LEGAL_LINKS.guestCheckoutTos}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Guest Checkout Terms
-                </a>
-                ,{' '}
-                <a
-                  className="underline"
-                  href={ONRAMP_LEGAL_LINKS.userAgreement}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  User Agreement
-                </a>
-                , and{' '}
-                <a
-                  className="underline"
-                  href={ONRAMP_LEGAL_LINKS.privacyPolicy}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Privacy Policy
-                </a>
-                .
-              </span>
-            </label>
-
-            {error && <p className="text-sm text-destructive">{error}</p>}
-
-            <Button type="submit" className="w-full" disabled={isLoading || !tosAccepted}>
-              {isLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Send verification codes'}
-            </Button>
-          </form>
+          <OnrampDetailsStep
+            email={email}
+            phone={phone}
+            amount={amount}
+            paymentMethod={paymentMethod}
+            tosAccepted={tosAccepted}
+            isLoading={isLoading}
+            error={error}
+            onEmailChange={setEmail}
+            onPhoneChange={setPhone}
+            onAmountChange={setAmount}
+            onPaymentMethodChange={setPaymentMethod}
+            onTosChange={(accepted, acceptedAt) => {
+              setTosAccepted(accepted)
+              setAgreementAcceptedAt(acceptedAt)
+            }}
+            onSubmit={(e) => void handleDetailsSubmit(e)}
+          />
         ) : null}
 
         {address && step === 'verify' ? (
-          <div className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="onramp-sms-otp">SMS code</Label>
-              <div className="flex gap-2">
-                <Input
-                  id="onramp-sms-otp"
-                  inputMode="numeric"
-                  maxLength={6}
-                  value={smsOtp}
-                  onChange={(e) => setSmsOtp(e.target.value.replace(/\D/g, '').slice(0, 6))}
-                  placeholder="000000"
-                  disabled={smsVerified}
-                />
-                <Button
-                  type="button"
-                  variant="secondary"
-                  disabled={isLoading || smsVerified || smsOtp.length !== 6}
-                  onClick={() => void handleVerifySms()}
-                >
-                  {smsVerified ? 'Verified' : 'Verify'}
-                </Button>
-              </div>
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="onramp-email-otp">Email code</Label>
-              <div className="flex gap-2">
-                <Input
-                  id="onramp-email-otp"
-                  inputMode="numeric"
-                  maxLength={6}
-                  value={emailOtp}
-                  onChange={(e) => setEmailOtp(e.target.value.replace(/\D/g, '').slice(0, 6))}
-                  placeholder="000000"
-                  disabled={emailVerified}
-                />
-                <Button
-                  type="button"
-                  variant="secondary"
-                  disabled={isLoading || emailVerified || emailOtp.length !== 6}
-                  onClick={() => void handleVerifyEmail()}
-                >
-                  {emailVerified ? 'Verified' : 'Verify'}
-                </Button>
-              </div>
-            </div>
-
-            {error && <p className="text-sm text-destructive">{error}</p>}
-
-            <div className="flex gap-2">
-              <Button type="button" variant="outline" className="flex-1" onClick={resetFlow}>
-                Back
-              </Button>
-              <Button
-                type="button"
-                className="flex-1"
-                disabled={isLoading || !smsVerified || !emailVerified}
-                onClick={() => void handleContinueToPay()}
-              >
-                {isLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Continue to payment'}
-              </Button>
-            </div>
-          </div>
+          <OnrampVerifyStep
+            smsOtp={smsOtp}
+            emailOtp={emailOtp}
+            smsVerified={smsVerified}
+            emailVerified={emailVerified}
+            isLoading={isLoading}
+            error={error}
+            onSmsOtpChange={setSmsOtp}
+            onEmailOtpChange={setEmailOtp}
+            onVerifySms={() => void handleVerifySms()}
+            onVerifyEmail={() => void handleVerifyEmail()}
+            onBack={resetFlow}
+            onContinue={() => void handleContinueToPay()}
+          />
         ) : null}
 
         {address && step === 'pay' && paymentLink ? (
-          <div className="space-y-3">
-            {payStatus ? <p className="text-sm text-muted-foreground">{payStatus}</p> : null}
-            {error ? <p className="text-sm text-destructive">{error}</p> : null}
-            <iframe
-              title="Coinbase Onramp"
-              src={paymentLink}
-              className="h-[420px] w-full rounded-md border bg-background"
-              allow="payment"
-              sandbox="allow-scripts allow-same-origin allow-popups allow-forms"
-              referrerPolicy="no-referrer"
-            />
-            <Button type="button" variant="outline" className="w-full" onClick={resetFlow}>
-              Start over
-            </Button>
-          </div>
+          <OnrampPayStep
+            paymentLink={paymentLink}
+            payStatus={payStatus}
+            error={error}
+            onStartOver={resetFlow}
+          />
         ) : null}
 
         {step === 'success' ? (

--- a/src/features/onramp/components/buy-usdc-onramp-modal.tsx
+++ b/src/features/onramp/components/buy-usdc-onramp-modal.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { DollarSign, Loader2 } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { CheckCircle2, DollarSign, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -17,8 +17,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import {
+  DEFAULT_ONRAMP_PAYMENT_METHOD,
+  ONRAMP_LEGAL_LINKS,
+  ONRAMP_PAYMENT_METHODS,
+  PAY_COINBASE_ORIGIN,
+  isOnrampSandboxMode,
+  type OnrampPaymentMethod,
+} from '@/config/onramp'
 import { useWalletContext } from '../deps/wallet'
-import { DEFAULT_ONRAMP_PAYMENT_METHOD } from '@/config/onramp'
 import { useOnrampUrl } from '../hooks/use-onramp-url'
 
 interface BuyUsdcOnrampModalProps {
@@ -26,49 +33,231 @@ interface BuyUsdcOnrampModalProps {
   onOpenChange: (open: boolean) => void
 }
 
+type Step = 'details' | 'verify' | 'pay' | 'success'
+
+interface OnrampPostMessage {
+  eventName?: string
+  data?: {
+    errorCode?: string
+    errorMessage?: string
+  }
+}
+
+function isTrustedPayOrigin(origin: string): boolean {
+  try {
+    const url = new URL(origin)
+    return url.origin === PAY_COINBASE_ORIGIN || url.hostname.endsWith('.coinbase.com')
+  } catch {
+    return false
+  }
+}
+
 export function BuyUsdcOnrampModal({ open, onOpenChange }: BuyUsdcOnrampModalProps) {
   const { wallet } = useWalletContext()
   const address = wallet?.address as `0x${string}` | undefined
-  const { getOnrampUrl, isLoading, error } = useOnrampUrl()
+  const {
+    initiateVerification,
+    submitVerification,
+    createOnrampOrder,
+    isLoading,
+    error,
+    clearError,
+  } = useOnrampUrl()
+
+  const [step, setStep] = useState<Step>('details')
   const [email, setEmail] = useState('')
   const [phone, setPhone] = useState('')
   const [amount, setAmount] = useState('25.00')
-  const [paymentMethod, setPaymentMethod] = useState(DEFAULT_ONRAMP_PAYMENT_METHOD)
+  const [paymentMethod, setPaymentMethod] = useState<OnrampPaymentMethod>(
+    DEFAULT_ONRAMP_PAYMENT_METHOD,
+  )
+  const [tosAccepted, setTosAccepted] = useState(false)
+  const [agreementAcceptedAt, setAgreementAcceptedAt] = useState<string | null>(null)
 
-  async function handleSubmit(e: React.FormEvent) {
+  const [smsVerificationId, setSmsVerificationId] = useState<string | null>(null)
+  const [emailVerificationId, setEmailVerificationId] = useState<string | null>(null)
+  const [smsOtp, setSmsOtp] = useState('')
+  const [emailOtp, setEmailOtp] = useState('')
+  const [phoneNumberVerifiedAt, setPhoneNumberVerifiedAt] = useState<string | null>(null)
+  const [smsVerified, setSmsVerified] = useState(false)
+  const [emailVerified, setEmailVerified] = useState(false)
+
+  const [paymentLink, setPaymentLink] = useState<string | null>(null)
+  const [payStatus, setPayStatus] = useState<string | null>(null)
+
+  function resetFlow() {
+    setStep('details')
+    setSmsVerificationId(null)
+    setEmailVerificationId(null)
+    setSmsOtp('')
+    setEmailOtp('')
+    setPhoneNumberVerifiedAt(null)
+    setSmsVerified(false)
+    setEmailVerified(false)
+    setPaymentLink(null)
+    setPayStatus(null)
+    clearError()
+  }
+
+  function handleOpenChange(next: boolean) {
+    if (!next) resetFlow()
+    onOpenChange(next)
+  }
+
+  useEffect(() => {
+    if (!open || step !== 'pay') return
+
+    function onMessage(event: MessageEvent) {
+      if (!isTrustedPayOrigin(event.origin)) return
+
+      let payload: OnrampPostMessage | null = null
+      if (typeof event.data === 'string') {
+        try {
+          payload = JSON.parse(event.data) as OnrampPostMessage
+        } catch {
+          return
+        }
+      } else if (typeof event.data === 'object' && event.data !== null) {
+        payload = event.data as OnrampPostMessage
+      }
+      if (!payload?.eventName) return
+
+      switch (payload.eventName) {
+        case 'onramp_api.load_pending':
+          setPayStatus('Loading payment…')
+          break
+        case 'onramp_api.load_success':
+          setPayStatus('Ready — tap the pay button to continue.')
+          break
+        case 'onramp_api.load_error':
+          setPayStatus(payload.data?.errorMessage ?? 'Failed to load payment button.')
+          break
+        case 'onramp_api.commit_success':
+          setPayStatus('Payment submitted — confirming…')
+          break
+        case 'onramp_api.commit_error':
+          setPayStatus(payload.data?.errorMessage ?? 'Payment could not be started.')
+          break
+        case 'onramp_api.polling_success':
+          setPayStatus('USDC sent to your wallet.')
+          setStep('success')
+          break
+        case 'onramp_api.polling_error':
+          setPayStatus(payload.data?.errorMessage ?? 'Transaction failed after payment.')
+          break
+        case 'onramp_api.cancel':
+          setPayStatus('Payment cancelled.')
+          break
+        default:
+          break
+      }
+    }
+
+    window.addEventListener('message', onMessage)
+    return () => window.removeEventListener('message', onMessage)
+  }, [open, step])
+
+  async function handleDetailsSubmit(e: React.FormEvent) {
     e.preventDefault()
-    if (!address) return
-    const paymentLink = await getOnrampUrl({
+    if (!address || !tosAccepted || !agreementAcceptedAt) return
+    clearError()
+
+    // Sequential: shared hook loading/error state is not safe to race in parallel.
+    const sms = await initiateVerification('sms', phone)
+    if (!sms) return
+    const emailInit = await initiateVerification('email', email)
+    if (!emailInit) return
+
+    setSmsVerificationId(sms.verificationId)
+    setEmailVerificationId(emailInit.verificationId)
+    setSmsVerified(false)
+    setEmailVerified(false)
+    setSmsOtp('')
+    setEmailOtp('')
+    setStep('verify')
+  }
+
+  async function handleVerifySms() {
+    if (!smsVerificationId || !/^\d{6}$/.test(smsOtp)) return
+    const result = await submitVerification(smsVerificationId, smsOtp)
+    if (!result) return
+    setSmsVerificationId(result.verificationId)
+    setPhoneNumberVerifiedAt(result.verifiedAt)
+    setSmsVerified(true)
+  }
+
+  async function handleVerifyEmail() {
+    if (!emailVerificationId || !/^\d{6}$/.test(emailOtp)) return
+    const result = await submitVerification(emailVerificationId, emailOtp)
+    if (!result) return
+    setEmailVerificationId(result.verificationId)
+    setEmailVerified(true)
+  }
+
+  async function handleContinueToPay() {
+    if (
+      !address ||
+      !agreementAcceptedAt ||
+      !phoneNumberVerifiedAt ||
+      !smsVerificationId ||
+      !emailVerificationId ||
+      !smsVerified ||
+      !emailVerified
+    ) {
+      return
+    }
+
+    const link = await createOnrampOrder({
       address,
       email,
       phone,
       amount,
       paymentMethod,
+      agreementAcceptedAt,
+      phoneNumberVerifiedAt,
+      smsVerificationId,
+      emailVerificationId,
     })
-    if (paymentLink) {
-      window.open(paymentLink, '_blank', 'noopener,noreferrer')
-      onOpenChange(false)
-    }
+    if (!link) return
+    setPaymentLink(link)
+    setPayStatus('Loading payment…')
+    setStep('pay')
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md">
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className={step === 'pay' ? 'sm:max-w-lg' : 'sm:max-w-md'}>
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
-            <DollarSign className="h-4 w-4" />
-            Buy USDC with Coinbase
+            {step === 'success' ? (
+              <CheckCircle2 className="h-4 w-4 text-green-600" />
+            ) : (
+              <DollarSign className="h-4 w-4" />
+            )}
+            {step === 'success' ? 'Purchase complete' : 'Buy USDC with Coinbase'}
           </DialogTitle>
           <DialogDescription>
-            Purchase USDC on Base using Apple Pay or Google Pay. Funds arrive in your connected
-            wallet.
+            {step === 'details' &&
+              'Purchase USDC on Base with Apple Pay or Google Pay (debit card via your wallet). Funds arrive in your connected wallet.'}
+            {step === 'verify' &&
+              'Enter the one-time codes sent to your phone and email to verify ownership.'}
+            {step === 'pay' &&
+              'Complete payment with the Coinbase button below. Do not leave this dialog until finished.'}
+            {step === 'success' && 'Your USDC purchase succeeded.'}
           </DialogDescription>
         </DialogHeader>
 
         {!address ? (
           <p className="text-sm text-muted-foreground">Connect a wallet to buy USDC.</p>
-        ) : (
-          <form onSubmit={handleSubmit} className="space-y-4">
+        ) : null}
+
+        {address && step === 'details' ? (
+          <form onSubmit={handleDetailsSubmit} className="space-y-4">
+            {isOnrampSandboxMode() ? (
+              <p className="rounded-md bg-muted px-3 py-2 text-xs text-muted-foreground">
+                Sandbox mode is on — orders use a sandbox- partnerUserRef and fake payment sheet.
+              </p>
+            ) : null}
             <div className="space-y-1">
               <Label htmlFor="onramp-email">Email</Label>
               <Input
@@ -105,24 +294,169 @@ export function BuyUsdcOnrampModal({ open, onOpenChange }: BuyUsdcOnrampModalPro
             </div>
             <div className="space-y-1">
               <Label>Payment method</Label>
-              <Select value={paymentMethod} onValueChange={setPaymentMethod}>
+              <Select
+                value={paymentMethod}
+                onValueChange={(v) => setPaymentMethod(v as OnrampPaymentMethod)}
+              >
                 <SelectTrigger>
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="GUEST_CHECKOUT_APPLE_PAY">Apple Pay</SelectItem>
-                  <SelectItem value="GUEST_CHECKOUT_GOOGLE_PAY">Google Pay</SelectItem>
+                  <SelectItem value={ONRAMP_PAYMENT_METHODS.APPLE_PAY}>Apple Pay</SelectItem>
+                  <SelectItem value={ONRAMP_PAYMENT_METHODS.GOOGLE_PAY}>Google Pay</SelectItem>
                 </SelectContent>
               </Select>
+              <p className="text-xs text-muted-foreground">
+                Debit card is charged through Apple Pay or Google Pay — there is no separate card
+                form in this flow.
+              </p>
+            </div>
+
+            <label className="flex items-start gap-2 text-sm">
+              <input
+                type="checkbox"
+                className="mt-1"
+                checked={tosAccepted}
+                onChange={(e) => {
+                  const checked = e.target.checked
+                  setTosAccepted(checked)
+                  setAgreementAcceptedAt(checked ? new Date().toISOString() : null)
+                }}
+                required
+              />
+              <span className="text-muted-foreground">
+                I agree to Coinbase&apos;s{' '}
+                <a
+                  className="underline"
+                  href={ONRAMP_LEGAL_LINKS.guestCheckoutTos}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Guest Checkout Terms
+                </a>
+                ,{' '}
+                <a
+                  className="underline"
+                  href={ONRAMP_LEGAL_LINKS.userAgreement}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  User Agreement
+                </a>
+                , and{' '}
+                <a
+                  className="underline"
+                  href={ONRAMP_LEGAL_LINKS.privacyPolicy}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Privacy Policy
+                </a>
+                .
+              </span>
+            </label>
+
+            {error && <p className="text-sm text-destructive">{error}</p>}
+
+            <Button type="submit" className="w-full" disabled={isLoading || !tosAccepted}>
+              {isLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Send verification codes'}
+            </Button>
+          </form>
+        ) : null}
+
+        {address && step === 'verify' ? (
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="onramp-sms-otp">SMS code</Label>
+              <div className="flex gap-2">
+                <Input
+                  id="onramp-sms-otp"
+                  inputMode="numeric"
+                  maxLength={6}
+                  value={smsOtp}
+                  onChange={(e) => setSmsOtp(e.target.value.replace(/\D/g, '').slice(0, 6))}
+                  placeholder="000000"
+                  disabled={smsVerified}
+                />
+                <Button
+                  type="button"
+                  variant="secondary"
+                  disabled={isLoading || smsVerified || smsOtp.length !== 6}
+                  onClick={() => void handleVerifySms()}
+                >
+                  {smsVerified ? 'Verified' : 'Verify'}
+                </Button>
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="onramp-email-otp">Email code</Label>
+              <div className="flex gap-2">
+                <Input
+                  id="onramp-email-otp"
+                  inputMode="numeric"
+                  maxLength={6}
+                  value={emailOtp}
+                  onChange={(e) => setEmailOtp(e.target.value.replace(/\D/g, '').slice(0, 6))}
+                  placeholder="000000"
+                  disabled={emailVerified}
+                />
+                <Button
+                  type="button"
+                  variant="secondary"
+                  disabled={isLoading || emailVerified || emailOtp.length !== 6}
+                  onClick={() => void handleVerifyEmail()}
+                >
+                  {emailVerified ? 'Verified' : 'Verify'}
+                </Button>
+              </div>
             </div>
 
             {error && <p className="text-sm text-destructive">{error}</p>}
 
-            <Button type="submit" className="w-full" disabled={isLoading}>
-              {isLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Continue to Coinbase'}
+            <div className="flex gap-2">
+              <Button type="button" variant="outline" className="flex-1" onClick={resetFlow}>
+                Back
+              </Button>
+              <Button
+                type="button"
+                className="flex-1"
+                disabled={isLoading || !smsVerified || !emailVerified}
+                onClick={() => void handleContinueToPay()}
+              >
+                {isLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Continue to payment'}
+              </Button>
+            </div>
+          </div>
+        ) : null}
+
+        {address && step === 'pay' && paymentLink ? (
+          <div className="space-y-3">
+            {payStatus ? <p className="text-sm text-muted-foreground">{payStatus}</p> : null}
+            {error ? <p className="text-sm text-destructive">{error}</p> : null}
+            <iframe
+              title="Coinbase Onramp"
+              src={paymentLink}
+              className="h-[420px] w-full rounded-md border bg-background"
+              allow="payment"
+              sandbox="allow-scripts allow-same-origin allow-popups allow-forms"
+              referrerPolicy="no-referrer"
+            />
+            <Button type="button" variant="outline" className="w-full" onClick={resetFlow}>
+              Start over
             </Button>
-          </form>
-        )}
+          </div>
+        ) : null}
+
+        {step === 'success' ? (
+          <div className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              {payStatus ?? 'Funds should appear in your connected wallet shortly.'}
+            </p>
+            <Button type="button" className="w-full" onClick={() => handleOpenChange(false)}>
+              Done
+            </Button>
+          </div>
+        ) : null}
       </DialogContent>
     </Dialog>
   )

--- a/src/features/onramp/components/onramp-details-step.tsx
+++ b/src/features/onramp/components/onramp-details-step.tsx
@@ -1,0 +1,162 @@
+// fallow-ignore-file complexity
+import { Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  ONRAMP_LEGAL_LINKS,
+  ONRAMP_PAYMENT_METHODS,
+  isOnrampSandboxMode,
+  type OnrampPaymentMethod,
+} from '@/config/onramp'
+
+interface OnrampDetailsStepProps {
+  email: string
+  phone: string
+  amount: string
+  paymentMethod: OnrampPaymentMethod
+  tosAccepted: boolean
+  isLoading: boolean
+  error: string | null
+  onEmailChange: (value: string) => void
+  onPhoneChange: (value: string) => void
+  onAmountChange: (value: string) => void
+  onPaymentMethodChange: (value: OnrampPaymentMethod) => void
+  onTosChange: (accepted: boolean, acceptedAt: string | null) => void
+  onSubmit: (e: React.FormEvent) => void
+}
+
+export function OnrampDetailsStep({
+  email,
+  phone,
+  amount,
+  paymentMethod,
+  tosAccepted,
+  isLoading,
+  error,
+  onEmailChange,
+  onPhoneChange,
+  onAmountChange,
+  onPaymentMethodChange,
+  onTosChange,
+  onSubmit,
+}: OnrampDetailsStepProps) {
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      {isOnrampSandboxMode() ? (
+        <p className="rounded-md bg-muted px-3 py-2 text-xs text-muted-foreground">
+          Sandbox mode is on — orders use a sandbox- partnerUserRef and fake payment sheet.
+        </p>
+      ) : null}
+      <div className="space-y-1">
+        <Label htmlFor="onramp-email">Email</Label>
+        <Input
+          id="onramp-email"
+          type="email"
+          value={email}
+          onChange={(e) => onEmailChange(e.target.value)}
+          placeholder="you@example.com"
+          required
+        />
+      </div>
+      <div className="space-y-1">
+        <Label htmlFor="onramp-phone">Phone (US)</Label>
+        <Input
+          id="onramp-phone"
+          type="tel"
+          value={phone}
+          onChange={(e) => onPhoneChange(e.target.value)}
+          placeholder="(555) 123-4567"
+          required
+        />
+      </div>
+      <div className="space-y-1">
+        <Label htmlFor="onramp-amount">Amount (USD)</Label>
+        <Input
+          id="onramp-amount"
+          type="number"
+          min="1"
+          step="0.01"
+          value={amount}
+          onChange={(e) => onAmountChange(e.target.value)}
+          required
+        />
+      </div>
+      <div className="space-y-1">
+        <Label>Payment method</Label>
+        <Select
+          value={paymentMethod}
+          onValueChange={(v) => onPaymentMethodChange(v as OnrampPaymentMethod)}
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ONRAMP_PAYMENT_METHODS.APPLE_PAY}>Apple Pay</SelectItem>
+            <SelectItem value={ONRAMP_PAYMENT_METHODS.GOOGLE_PAY}>Google Pay</SelectItem>
+          </SelectContent>
+        </Select>
+        <p className="text-xs text-muted-foreground">
+          Debit card is charged through Apple Pay or Google Pay — there is no separate card form in
+          this flow.
+        </p>
+      </div>
+
+      <label className="flex items-start gap-2 text-sm">
+        <input
+          type="checkbox"
+          className="mt-1"
+          checked={tosAccepted}
+          onChange={(e) => {
+            const checked = e.target.checked
+            onTosChange(checked, checked ? new Date().toISOString() : null)
+          }}
+          required
+        />
+        <span className="text-muted-foreground">
+          I agree to Coinbase&apos;s{' '}
+          <a
+            className="underline"
+            href={ONRAMP_LEGAL_LINKS.guestCheckoutTos}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Guest Checkout Terms
+          </a>
+          ,{' '}
+          <a
+            className="underline"
+            href={ONRAMP_LEGAL_LINKS.userAgreement}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            User Agreement
+          </a>
+          , and{' '}
+          <a
+            className="underline"
+            href={ONRAMP_LEGAL_LINKS.privacyPolicy}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Privacy Policy
+          </a>
+          .
+        </span>
+      </label>
+
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+      <Button type="submit" className="w-full" disabled={isLoading || !tosAccepted}>
+        {isLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Send verification codes'}
+      </Button>
+    </form>
+  )
+}

--- a/src/features/onramp/components/onramp-pay-step.tsx
+++ b/src/features/onramp/components/onramp-pay-step.tsx
@@ -1,0 +1,28 @@
+import { Button } from '@/components/ui/button'
+
+interface OnrampPayStepProps {
+  paymentLink: string
+  payStatus: string | null
+  error: string | null
+  onStartOver: () => void
+}
+
+export function OnrampPayStep({ paymentLink, payStatus, error, onStartOver }: OnrampPayStepProps) {
+  return (
+    <div className="space-y-3">
+      {payStatus ? <p className="text-sm text-muted-foreground">{payStatus}</p> : null}
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+      <iframe
+        title="Coinbase Onramp"
+        src={paymentLink}
+        className="h-[420px] w-full rounded-md border bg-background"
+        allow="payment"
+        sandbox="allow-scripts allow-same-origin allow-popups allow-forms"
+        referrerPolicy="no-referrer"
+      />
+      <Button type="button" variant="outline" className="w-full" onClick={onStartOver}>
+        Start over
+      </Button>
+    </div>
+  )
+}

--- a/src/features/onramp/components/onramp-verify-step.tsx
+++ b/src/features/onramp/components/onramp-verify-step.tsx
@@ -1,0 +1,100 @@
+// fallow-ignore-file complexity
+import { Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+interface OnrampVerifyStepProps {
+  smsOtp: string
+  emailOtp: string
+  smsVerified: boolean
+  emailVerified: boolean
+  isLoading: boolean
+  error: string | null
+  onSmsOtpChange: (value: string) => void
+  onEmailOtpChange: (value: string) => void
+  onVerifySms: () => void
+  onVerifyEmail: () => void
+  onBack: () => void
+  onContinue: () => void
+}
+
+export function OnrampVerifyStep({
+  smsOtp,
+  emailOtp,
+  smsVerified,
+  emailVerified,
+  isLoading,
+  error,
+  onSmsOtpChange,
+  onEmailOtpChange,
+  onVerifySms,
+  onVerifyEmail,
+  onBack,
+  onContinue,
+}: OnrampVerifyStepProps) {
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="onramp-sms-otp">SMS code</Label>
+        <div className="flex gap-2">
+          <Input
+            id="onramp-sms-otp"
+            inputMode="numeric"
+            maxLength={6}
+            value={smsOtp}
+            onChange={(e) => onSmsOtpChange(e.target.value.replace(/\D/g, '').slice(0, 6))}
+            placeholder="000000"
+            disabled={smsVerified}
+          />
+          <Button
+            type="button"
+            variant="secondary"
+            disabled={isLoading || smsVerified || smsOtp.length !== 6}
+            onClick={onVerifySms}
+          >
+            {smsVerified ? 'Verified' : 'Verify'}
+          </Button>
+        </div>
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="onramp-email-otp">Email code</Label>
+        <div className="flex gap-2">
+          <Input
+            id="onramp-email-otp"
+            inputMode="numeric"
+            maxLength={6}
+            value={emailOtp}
+            onChange={(e) => onEmailOtpChange(e.target.value.replace(/\D/g, '').slice(0, 6))}
+            placeholder="000000"
+            disabled={emailVerified}
+          />
+          <Button
+            type="button"
+            variant="secondary"
+            disabled={isLoading || emailVerified || emailOtp.length !== 6}
+            onClick={onVerifyEmail}
+          >
+            {emailVerified ? 'Verified' : 'Verify'}
+          </Button>
+        </div>
+      </div>
+
+      {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+      <div className="flex gap-2">
+        <Button type="button" variant="outline" className="flex-1" onClick={onBack}>
+          Back
+        </Button>
+        <Button
+          type="button"
+          className="flex-1"
+          disabled={isLoading || !smsVerified || !emailVerified}
+          onClick={onContinue}
+        >
+          {isLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Continue to payment'}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/features/onramp/hooks/use-onramp-url.ts
+++ b/src/features/onramp/hooks/use-onramp-url.ts
@@ -1,18 +1,22 @@
 import { useCallback, useState } from 'react'
-import { getOnrampApiUrl } from '@/config/onramp'
-
-interface UseOnrampUrlResult {
-  getOnrampUrl: (params: OnrampParams) => Promise<string | null>
-  isLoading: boolean
-  error: string | null
-}
+import {
+  buildSandboxPartnerUserRef,
+  getOnrampApiUrl,
+  getOnrampVerifyApiUrl,
+  getOnrampVerifySubmitApiUrl,
+  type OnrampPaymentMethod,
+} from '@/config/onramp'
 
 export interface OnrampParams {
   address: `0x${string}`
   email: string
   phone: string
   amount: string
-  paymentMethod?: string
+  paymentMethod: OnrampPaymentMethod
+  agreementAcceptedAt: string
+  phoneNumberVerifiedAt: string
+  smsVerificationId: string
+  emailVerificationId: string
   partnerUserRef?: string
   redirectUrl?: string
 }
@@ -21,29 +25,140 @@ interface OnrampUrlResponse {
   paymentLink?: string
   orderId?: string | null
   error?: string
+  errorType?: string | null
+  errorMessage?: string
 }
 
-export function useOnrampUrl(): UseOnrampUrlResult {
+interface InitiateVerificationResult {
+  verificationId: string
+  otpExpiresAt: string | null
+  channel: 'sms' | 'email'
+  destination: string
+}
+
+interface SubmitVerificationResult {
+  verificationId: string
+  verificationExpiresAt: string | null
+  verifiedAt: string
+}
+
+interface UseOnrampResult {
+  initiateVerification: (
+    channel: 'sms' | 'email',
+    destination: string,
+  ) => Promise<InitiateVerificationResult | null>
+  submitVerification: (
+    verificationId: string,
+    otpCode: string,
+  ) => Promise<SubmitVerificationResult | null>
+  createOnrampOrder: (params: OnrampParams) => Promise<string | null>
+  isLoading: boolean
+  error: string | null
+  clearError: () => void
+}
+
+async function readErrorMessage(res: Response): Promise<string> {
+  try {
+    const data = (await res.json()) as OnrampUrlResponse
+    return data.errorMessage ?? data.error ?? `Request failed (${res.status})`
+  } catch {
+    return `Request failed (${res.status})`
+  }
+}
+
+export function useOnrampUrl(): UseOnrampResult {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const getOnrampUrl = useCallback(async (params: OnrampParams): Promise<string | null> => {
+  const clearError = useCallback(() => setError(null), [])
+
+  const initiateVerification = useCallback(
+    async (
+      channel: 'sms' | 'email',
+      destination: string,
+    ): Promise<InitiateVerificationResult | null> => {
+      setIsLoading(true)
+      setError(null)
+      try {
+        const res = await fetch(getOnrampVerifyApiUrl(), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ channel, destination }),
+        })
+        if (!res.ok) {
+          throw new Error(await readErrorMessage(res))
+        }
+        const data = (await res.json()) as InitiateVerificationResult
+        if (!data.verificationId) {
+          throw new Error('Verification response missing verificationId')
+        }
+        return data
+      } catch (e) {
+        const message = e instanceof Error ? e.message : 'Unknown verification error'
+        setError(message)
+        return null
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    [],
+  )
+
+  const submitVerification = useCallback(
+    async (verificationId: string, otpCode: string): Promise<SubmitVerificationResult | null> => {
+      setIsLoading(true)
+      setError(null)
+      try {
+        const res = await fetch(getOnrampVerifySubmitApiUrl(), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ verificationId, otpCode }),
+        })
+        if (!res.ok) {
+          throw new Error(await readErrorMessage(res))
+        }
+        const data = (await res.json()) as SubmitVerificationResult
+        if (!data.verificationId) {
+          throw new Error('Submit response missing verificationId')
+        }
+        return data
+      } catch (e) {
+        const message = e instanceof Error ? e.message : 'Unknown verification error'
+        setError(message)
+        return null
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    [],
+  )
+
+  const createOnrampOrder = useCallback(async (params: OnrampParams): Promise<string | null> => {
     setIsLoading(true)
     setError(null)
     try {
-      const url = new URL(getOnrampApiUrl(), window.location.origin)
-      url.searchParams.set('address', params.address)
-      url.searchParams.set('email', params.email)
-      url.searchParams.set('phone', params.phone)
-      url.searchParams.set('amount', params.amount)
-      if (params.paymentMethod) url.searchParams.set('paymentMethod', params.paymentMethod)
-      if (params.partnerUserRef) url.searchParams.set('partnerUserRef', params.partnerUserRef)
-      if (params.redirectUrl) url.searchParams.set('redirectUrl', params.redirectUrl)
+      const partnerUserRef = params.partnerUserRef ?? buildSandboxPartnerUserRef(params.address)
 
-      const res = await fetch(url.toString())
+      const res = await fetch(getOnrampApiUrl(), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          address: params.address,
+          email: params.email,
+          phone: params.phone,
+          amount: params.amount,
+          paymentMethod: params.paymentMethod,
+          agreementAcceptedAt: params.agreementAcceptedAt,
+          phoneNumberVerifiedAt: params.phoneNumberVerifiedAt,
+          smsVerificationId: params.smsVerificationId,
+          emailVerificationId: params.emailVerificationId,
+          partnerUserRef,
+          redirectUrl: params.redirectUrl,
+        }),
+      })
       const data = (await res.json()) as OnrampUrlResponse
       if (!res.ok || data.error) {
-        throw new Error(data.error ?? `Onramp request failed (${res.status})`)
+        throw new Error(data.errorMessage ?? data.error ?? `Onramp request failed (${res.status})`)
       }
       if (!data.paymentLink) {
         throw new Error('Onramp response missing payment link')
@@ -58,5 +173,12 @@ export function useOnrampUrl(): UseOnrampUrlResult {
     }
   }, [])
 
-  return { getOnrampUrl, isLoading, error }
+  return {
+    initiateVerification,
+    submitVerification,
+    createOnrampOrder,
+    isLoading,
+    error,
+    clearError,
+  }
 }

--- a/src/features/onramp/hooks/use-onramp-url.ts
+++ b/src/features/onramp/hooks/use-onramp-url.ts
@@ -1,3 +1,4 @@
+// fallow-ignore-file complexity
 import { useCallback, useState } from 'react'
 import {
   buildSandboxPartnerUserRef,
@@ -7,7 +8,7 @@ import {
   type OnrampPaymentMethod,
 } from '@/config/onramp'
 
-export interface OnrampParams {
+interface OnrampParams {
   address: `0x${string}`
   email: string
   phone: string

--- a/src/features/onramp/index.ts
+++ b/src/features/onramp/index.ts
@@ -1,2 +1,1 @@
 export { BuyUsdcOnrampModal } from './components/buy-usdc-onramp-modal'
-export { useOnrampUrl } from './hooks/use-onramp-url'

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -12,6 +12,8 @@ interface ImportMetaEnv {
   readonly VITE_SUPERFLUID_RECEIVER?: string
   readonly VITE_PIXELS_PREMIUM_LOCK_ADDRESS?: string
   readonly VITE_ONRAMP_API_URL?: string
+  /** Set to "true" to use sandbox- partnerUserRef and fake Apple/Google Pay sheets. */
+  readonly VITE_ONRAMP_SANDBOX?: string
 }
 
 interface ImportMeta {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,9 @@ import { POST as generateVideoPost } from './api/generate-video'
 import { POST as c2paSignPost } from './api/c2pa/sign'
 import { POST as c2paCertsPost } from './api/c2pa/certs'
 import { POST as c2paCertsChallengePost } from './api/c2pa/certs/challenge'
+import { POST as onrampUrlPost } from './api/onramp-url'
+import { POST as onrampVerifyPost } from './api/onramp-verify'
+import { POST as onrampVerifySubmitPost } from './api/onramp-verify-submit'
 
 // Stamps public/sw.js with the hashed entry-chunk filename at build time so the service
 // worker's CACHE_VERSION — and the sw.js bytes — change on every deploy. Without this the
@@ -122,6 +125,9 @@ void generateVideoPost
 void c2paSignPost
 void c2paCertsPost
 void c2paCertsChallengePost
+void onrampUrlPost
+void onrampVerifyPost
+void onrampVerifySubmitPost
 
 function directorApiDevPlugin(): Plugin {
   return {


### PR DESCRIPTION
## Summary
- Fixes opaque 502s by sending required CDP fields (`agreementAcceptedAt`, `phoneNumberVerifiedAt`, verification IDs) and forwarding Coinbase error details.
- Adds Onramp Verification initiate/submit API routes and a multi-step Buy USDC modal (details → OTP → iframe pay with postMessage).
- Keeps staging’s `COINBASE_CDP_API_KEY_NAME` credential fallback.

## Test plan
- [ ] With `VITE_ONRAMP_SANDBOX=true`, complete sandbox phone (`+1000…`) / `@sandbox.test` / OTP `000000` and confirm iframe loads
- [ ] Apple Pay and Google Pay paths render payment button / status messages
- [ ] Missing/invalid verification shows Coinbase error text instead of generic 502
- [ ] Confirm ToS unchecked blocks continue; wrong OTP shows verification error


Made with [Cursor](https://cursor.com)