### PR TITLE
fix(headless): Cloud Run deploy tooling and headless service hardening

### DIFF
--- a/headless/Dockerfile
+++ b/headless/Dockerfile
@@ -11,7 +11,7 @@
 # Run (the lifecycle service requires a writable workspace for locks/atomic writes):
 #   docker run --rm -p 8787:8787 -v /path/to/PixelsProjects:/workspace pixels-headless
 #   curl localhost:8787/health    # -> {"ok":true,"gpu":true,...}
-FROM node:24-bookworm
+FROM node:22-bookworm
 
 # Google Chrome (proprietary codecs) + software Vulkan (lavapipe) for WebGPU + fonts.
 RUN apt-get update \
@@ -34,7 +34,9 @@ ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 
 # Install deps (ignore lifecycle scripts: the prepare hook sets up git hooks,
 # which aren't present/needed in the image).
-COPY package.json package-lock.json ./
+# .npmrc sets legacy-peer-deps (required for wallet/Solana peer graph) and must
+# be present before npm ci — otherwise Docker resolves strictly and fails.
+COPY package.json package-lock.json .npmrc ./
 RUN npm ci --ignore-scripts
 
 # Build the harness (dist/headless.html + assets).
@@ -50,6 +52,9 @@ ENV PIXELS_CHROME_ARGS="--no-sandbox"
 # The container port must accept traffic from the published Docker interface.
 # Native serve.mjs runs remain loopback-only unless explicitly overridden.
 ENV PIXELS_HOST=0.0.0.0
+
+# Cloud Run has no host volume mount; use ephemeral container storage.
+RUN mkdir -p /workspace
 
 EXPOSE 8787
 # Exec form keeps Node as PID 1 so Docker's SIGTERM reaches the graceful

--- a/headless/cloudbuild.yaml
+++ b/headless/cloudbuild.yaml
@@ -1,0 +1,12 @@
+# Cloud Build config for pixels-headless (repo root context, Dockerfile in headless/).
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - -f
+      - headless/Dockerfile
+      - -t
+      - ${_IMAGE}
+      - .
+images:
+  - ${_IMAGE}

--- a/headless/deploy-cloudrun.sh
+++ b/headless/deploy-cloudrun.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Deploy Pixels headless render service to Cloud Run (Phase 2 assembly).
+# Run from edit-pixels repo root:
+#   PIXELS_API_KEY="$(openssl rand -hex 24)" ./headless/deploy-cloudrun.sh
+set -euo pipefail
+
+PROJECT_ID="${GCP_PROJECT_ID:-creative-ai-491118}"
+REGION="${GCP_REGION:-us-central1}"
+SERVICE="${PIXELS_HEADLESS_SERVICE:-pixels-headless}"
+IMAGE="gcr.io/${PROJECT_ID}/${SERVICE}"
+API_KEY="${PIXELS_API_KEY:?Set PIXELS_API_KEY (also used as PIXELS_HEADLESS_API_KEY on the agent)}"
+
+echo "Building ${IMAGE}..."
+gcloud builds submit --project "${PROJECT_ID}" \
+  --config headless/cloudbuild.yaml \
+  --substitutions=_IMAGE="${IMAGE}" \
+  .
+
+echo "Deploying Cloud Run service ${SERVICE}..."
+gcloud run deploy "${SERVICE}" \
+  --project "${PROJECT_ID}" \
+  --region "${REGION}" \
+  --image "${IMAGE}" \
+  --platform managed \
+  --allow-unauthenticated \
+  --memory 4Gi \
+  --cpu 2 \
+  --timeout 3600 \
+  --concurrency 1 \
+  --min-instances 0 \
+  --max-instances 3 \
+  --set-env-vars "PIXELS_HOST=0.0.0.0,PIXELS_API_KEY=${API_KEY}" \
+  --port 8787
+
+URL="$(gcloud run services describe "${SERVICE}" --project "${PROJECT_ID}" --region "${REGION}" --format='value(status.url)')"
+echo ""
+echo "Headless URL: ${URL}"
+echo "Set on Agent Engine:"
+echo "  PIXELS_HEADLESS_URL=${URL}"
+echo "  PIXELS_HEADLESS_API_KEY=${API_KEY}"

--- a/headless/lib/contract.mjs
+++ b/headless/lib/contract.mjs
@@ -558,6 +558,14 @@ export const mediaImportRequestSchema = z
   })
   .strict()
 
+export const mediaImportUrlRequestSchema = z
+  .object({
+    url: z.string().url(),
+    id: z.string().optional(),
+    project: z.string().optional(),
+  })
+  .strict()
+
 const RENDER_OPTIONS = {
   codecs: ['h264', 'h265', 'vp9', 'vp8', 'av1'],
   containers: ['mp4', 'webm', 'mov', 'mkv', 'mp3', 'wav', 'm4a'],
@@ -684,6 +692,7 @@ export function capabilities() {
       lifecycleEdit: z.toJSONSchema(lifecycleEditRequestSchema, { target: 'draft-7' }),
       mediaProbe: z.toJSONSchema(mediaProbeRequestSchema, { target: 'draft-7' }),
       mediaImport: z.toJSONSchema(mediaImportRequestSchema, { target: 'draft-7' }),
+      mediaImportUrl: z.toJSONSchema(mediaImportUrlRequestSchema, { target: 'draft-7' }),
     },
     lifecycle: {
       routes: [
@@ -697,6 +706,7 @@ export function capabilities() {
         'GET /v1/media',
         'GET /v1/media/:id',
         'POST /v1/media/import',
+        'POST /v1/media/import-url',
         'POST /v1/media/:id/probe',
         'POST /v1/render',
       ],

--- a/headless/lib/lifecycle-store.mjs
+++ b/headless/lib/lifecycle-store.mjs
@@ -29,9 +29,11 @@ const MIME_BY_EXT = {
   '.json': 'application/lottie+json',
   '.lottie': 'application/lottie+json',
 }
-const EXT_BY_MIME = Object.fromEntries(
-  Object.entries(MIME_BY_EXT).map(([extension, mimeType]) => [mimeType, extension]),
-)
+/** First registered extension wins when multiple extensions share a MIME type. */
+const EXT_BY_MIME = Object.entries(MIME_BY_EXT).reduce((extByMime, [extension, mimeType]) => {
+  if (!(mimeType in extByMime)) extByMime[mimeType] = extension
+  return extByMime
+}, {})
 
 export function assertPortableId(id, label = 'id') {
   assertSinglePathComponent(id, label)

--- a/headless/lib/lifecycle-store.mjs
+++ b/headless/lib/lifecycle-store.mjs
@@ -29,6 +29,9 @@ const MIME_BY_EXT = {
   '.json': 'application/lottie+json',
   '.lottie': 'application/lottie+json',
 }
+const EXT_BY_MIME = Object.fromEntries(
+  Object.entries(MIME_BY_EXT).map(([extension, mimeType]) => [mimeType, extension]),
+)
 
 export function assertPortableId(id, label = 'id') {
   assertSinglePathComponent(id, label)
@@ -456,6 +459,88 @@ export async function updateMediaMetadata(
     })
     return { ...(await getMediaResource(workspace, id)), revision: revisionOf(bytes) }
   })
+}
+
+function parseHttpMediaUrl(urlString) {
+  let parsed
+  try {
+    parsed = new URL(urlString)
+  } catch {
+    throw new HttpError(400, 'INVALID_URL', 'URL must be a valid http(s) address')
+  }
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new HttpError(400, 'INVALID_URL', 'URL must use http or https')
+  }
+  return parsed
+}
+
+// fallow-ignore-next-line complexity
+function resolveDownloadExtension(parsed, contentTypeHeader) {
+  let ext = path.extname(parsed.pathname).toLowerCase()
+  const contentType = contentTypeHeader?.split(';')[0].trim().toLowerCase()
+  if (!ext && contentType) ext = EXT_BY_MIME[contentType] ?? ''
+  if (!ext || !MIME_BY_EXT[ext]) {
+    throw new HttpError(
+      415,
+      'UNSUPPORTED_MEDIA_TYPE',
+      'Could not determine supported media type from URL or response headers',
+    )
+  }
+  return ext
+}
+
+// fallow-ignore-next-line complexity
+async function readLimitedResponseBody(response, maxBytes) {
+  const contentLength = Number(response.headers.get('content-length'))
+  if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+    throw new HttpError(413, 'MEDIA_SIZE_LIMIT', 'Remote media exceeds size limit')
+  }
+  const reader = response.body?.getReader?.()
+  if (!reader) {
+    throw new HttpError(422, 'DOWNLOAD_FAILED', 'Response body is not readable')
+  }
+  const chunks = []
+  let size = 0
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    size += value.length
+    if (size > maxBytes) {
+      throw new HttpError(413, 'MEDIA_SIZE_LIMIT', 'Remote media exceeds size limit')
+    }
+    chunks.push(value)
+  }
+  return Buffer.concat(chunks)
+}
+
+/** Download remote media to a temp file for import-url staging. */
+export async function downloadMediaUrl(
+  urlString,
+  { maxBytes = 500 * 1024 ** 2 } = {},
+) {
+  const parsed = parseHttpMediaUrl(urlString)
+  const response = await fetch(urlString, { redirect: 'follow' })
+  if (!response.ok) {
+    throw new HttpError(
+      422,
+      'DOWNLOAD_FAILED',
+      `Failed to download media (${response.status})`,
+    )
+  }
+
+  const ext = resolveDownloadExtension(parsed, response.headers.get('content-type'))
+  const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pixels-url-import-'))
+  const target = path.join(tmpDir, `download${ext}`)
+
+  try {
+    const bytes = await readLimitedResponseBody(response, maxBytes)
+    await fs.promises.writeFile(target, bytes, { mode: 0o600 })
+  } catch (error) {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true })
+    throw error
+  }
+
+  return { path: target, tmpDir, ext }
 }
 
 export async function stageLocalMedia(

--- a/headless/lib/lifecycle-store.mjs
+++ b/headless/lib/lifecycle-store.mjs
@@ -477,10 +477,36 @@ function parseHttpMediaUrl(urlString) {
 }
 
 // fallow-ignore-next-line complexity
-function resolveDownloadExtension(parsed, contentTypeHeader) {
-  let ext = path.extname(parsed.pathname).toLowerCase()
+function pathExtensionFromUrl(urlString) {
+  if (!urlString) return ''
+  try {
+    const ext = path.extname(new URL(urlString).pathname).toLowerCase()
+    return ext && MIME_BY_EXT[ext] ? ext : ''
+  } catch {
+    return ''
+  }
+}
+
+// fallow-ignore-next-line complexity
+function resolveDownloadExtension(originalParsed, contentTypeHeader, finalUrlString) {
   const contentType = contentTypeHeader?.split(';')[0].trim().toLowerCase()
-  if (!ext && contentType) ext = EXT_BY_MIME[contentType] ?? ''
+  const mimeExt =
+    contentType && EXT_BY_MIME[contentType] && MIME_BY_EXT[EXT_BY_MIME[contentType]]
+      ? EXT_BY_MIME[contentType]
+      : ''
+
+  let pathExt = pathExtensionFromUrl(finalUrlString)
+  if (!pathExt) pathExt = pathExtensionFromUrl(originalParsed.href)
+
+  let ext = pathExt
+  if (mimeExt) {
+    if (!pathExt) {
+      ext = mimeExt
+    } else if (MIME_BY_EXT[pathExt] !== contentType) {
+      ext = mimeExt
+    }
+  }
+
   if (!ext || !MIME_BY_EXT[ext]) {
     throw new HttpError(
       415,
@@ -530,7 +556,11 @@ export async function downloadMediaUrl(
     )
   }
 
-  const ext = resolveDownloadExtension(parsed, response.headers.get('content-type'))
+  const ext = resolveDownloadExtension(
+    parsed,
+    response.headers.get('content-type'),
+    response.url,
+  )
   const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pixels-url-import-'))
   const target = path.join(tmpDir, `download${ext}`)
 

--- a/headless/lifecycle-contract.test.mjs
+++ b/headless/lifecycle-contract.test.mjs
@@ -91,4 +91,5 @@ test('capabilities publish lifecycle constraints', () => {
   assert.equal(result.lifecycle.writerMode, 'exclusive')
   assert.ok(result.lifecycle.routes.includes('POST /v1/projects/:id/edit'))
   assert.ok(result.lifecycle.routes.includes('POST /v1/media/import'))
+  assert.ok(result.lifecycle.routes.includes('POST /v1/media/import-url'))
 })

--- a/headless/lifecycle-store.test.mjs
+++ b/headless/lifecycle-store.test.mjs
@@ -126,9 +126,10 @@ test('media staging streams supported files and rejects traversal ids', async (t
   )
 })
 
-function mockFetchResponse({ contentType, bytes }) {
+function mockFetchResponse({ contentType, bytes, url }) {
   return {
     ok: true,
+    url,
     headers: {
       get(name) {
         if (name === 'content-type') return contentType
@@ -167,4 +168,32 @@ test('downloadMediaUrl prefers canonical extension for shared MIME types', async
 
   await fs.promises.rm(withoutPathExt.tmpDir, { recursive: true, force: true })
   await fs.promises.rm(withPathExt.tmpDir, { recursive: true, force: true })
+})
+
+test('downloadMediaUrl uses final URL and Content-Type after redirects', async (t) => {
+  const originalFetch = globalThis.fetch
+  t.after(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  globalThis.fetch = async () =>
+    mockFetchResponse({
+      contentType: 'audio/ogg',
+      bytes: Buffer.from([1, 2]),
+      url: 'https://cdn.example.com/voice.ogg',
+    })
+  const redirected = await downloadMediaUrl('https://example.com/download.html')
+  assert.equal(redirected.ext, '.ogg')
+
+  globalThis.fetch = async () =>
+    mockFetchResponse({
+      contentType: 'audio/ogg',
+      bytes: Buffer.from([1, 2]),
+      url: 'https://example.com/download.html',
+    })
+  const misleadingPath = await downloadMediaUrl('https://example.com/download.html')
+  assert.equal(misleadingPath.ext, '.ogg')
+
+  await fs.promises.rm(redirected.tmpDir, { recursive: true, force: true })
+  await fs.promises.rm(misleadingPath.tmpDir, { recursive: true, force: true })
 })

--- a/headless/lifecycle-store.test.mjs
+++ b/headless/lifecycle-store.test.mjs
@@ -7,6 +7,7 @@ import {
   acquireWriterLock,
   atomicWriteFile,
   createProjectResource,
+  downloadMediaUrl,
   getProjectResource,
   listProjectResources,
   resolveHeadlessDir,
@@ -123,4 +124,47 @@ test('media staging streams supported files and rejects traversal ids', async (t
     () => stageLocalMedia(root, source, '../escape'),
     (error) => error.code === 'INVALID_ID',
   )
+})
+
+function mockFetchResponse({ contentType, bytes }) {
+  return {
+    ok: true,
+    headers: {
+      get(name) {
+        if (name === 'content-type') return contentType
+        if (name === 'content-length') return String(bytes.length)
+        return null
+      },
+    },
+    body: {
+      getReader() {
+        let sent = false
+        return {
+          async read() {
+            if (sent) return { done: true }
+            sent = true
+            return { done: false, value: bytes }
+          },
+        }
+      },
+    },
+  }
+}
+
+test('downloadMediaUrl prefers canonical extension for shared MIME types', async (t) => {
+  const originalFetch = globalThis.fetch
+  t.after(() => {
+    globalThis.fetch = originalFetch
+  })
+  globalThis.fetch = async () => mockFetchResponse({ contentType: 'audio/ogg', bytes: Buffer.from([1, 2]) })
+
+  const withoutPathExt = await downloadMediaUrl('https://example.com/audio')
+  assert.equal(withoutPathExt.ext, '.ogg')
+
+  globalThis.fetch = async () => mockFetchResponse({ contentType: 'audio/ogg', bytes: Buffer.from([1, 2]) })
+  const withPathExt = await downloadMediaUrl('https://example.com/voice.opus')
+  assert.equal(withPathExt.ext, '.opus')
+
+  await fs.promises.rm(withoutPathExt.tmpDir, { recursive: true, force: true })
+  await fs.promises.rm(withPathExt.tmpDir, { recursive: true, force: true })
 })

--- a/headless/serve.mjs
+++ b/headless/serve.mjs
@@ -66,6 +66,7 @@ import {
   layoutRequestSchema,
   lifecycleEditRequestSchema,
   mediaImportRequestSchema,
+  mediaImportUrlRequestSchema,
   mediaProbeRequestSchema,
   projectCreateRequestSchema,
   projectSaveRequestSchema,
@@ -78,6 +79,7 @@ import {
   assertAtomicReplace,
   assertPortableId,
   createProjectResource,
+  downloadMediaUrl,
   getMediaResource,
   getProjectResource,
   listMediaResources,
@@ -130,6 +132,17 @@ const IMAGE_EXT_BY_MIME = { 'image/png': 'png', 'image/jpeg': 'jpg', 'image/webp
 /** Strip non-ASCII so a value is always a legal HTTP header (never 500s a response). */
 function asciiHeader(value) {
   return JSON.stringify(value).replace(/[^\t\x20-\x7E]/g, ' ')
+}
+
+/** Optional Bearer auth when PIXELS_API_KEY is set (required for network exposure). */
+// fallow-ignore-next-line complexity
+function assertApiKey(req, route) {
+  const expected = process.env.PIXELS_API_KEY?.trim()
+  if (!expected) return
+  if (route === 'GET /health') return
+  const header = req.headers.authorization ?? ''
+  if (header === `Bearer ${expected}`) return
+  throw new HttpError(401, 'UNAUTHORIZED', 'Missing or invalid Authorization Bearer token')
 }
 
 function sendJson(res, status, obj) {
@@ -470,6 +483,38 @@ async function main() {
     }
   }
 
+  // fallow-ignore-next-line complexity
+  const handleV1MediaImportUrl = async (req, res) => {
+    const body = validate(mediaImportUrlRequestSchema, await readJsonBody(req))
+    let downloaded
+    let staged
+    try {
+      downloaded = await downloadMediaUrl(body.url)
+      staged = await stageLocalMedia(workspace, downloaded.path, body.id)
+      const probe = await queue.enqueue(
+        () =>
+          session.page.evaluate((payload) => window.pixels.probeMedia(payload), {
+            url: mediaUrlOf(staged.id),
+            fileName: path.basename(staged.target),
+            mimeType: staged.mimeType,
+          }),
+        { timeoutMs: editTimeoutMs, kind: 'media-probe' },
+      )
+      const media = await commitStagedMedia(staged, probe, {
+        workspace,
+        projectId: body.project,
+      })
+      sendJson(res, 201, resourceEnvelope(media))
+    } catch (error) {
+      if (staged) await rollbackStagedMedia(staged)
+      throw error
+    } finally {
+      if (downloaded?.tmpDir) {
+        await fs.promises.rm(downloaded.tmpDir, { recursive: true, force: true }).catch(() => {})
+      }
+    }
+  }
+
   const handleV1MediaProbe = async (req, res, id) => {
     const body = validate(
       mediaProbeRequestSchema,
@@ -658,7 +703,9 @@ async function main() {
                               })
                           : route === 'POST /v1/media/import'
                             ? () => handleV1MediaImport(req, res)
-                            : mediaProbeMatch && req.method === 'POST'
+                            : route === 'POST /v1/media/import-url'
+                              ? () => handleV1MediaImportUrl(req, res)
+                              : mediaProbeMatch && req.method === 'POST'
                             ? () =>
                                 handleV1MediaProbe(
                                   req,
@@ -692,6 +739,22 @@ async function main() {
                                           : null
     if (!handler) {
       sendJson(res, 404, { error: `No route: ${route}` })
+      return
+    }
+    try {
+      assertApiKey(req, route)
+    } catch (error) {
+      if (!res.headersSent) {
+        const status = error instanceof HttpError ? error.statusCode : 401
+        sendJson(res, status, {
+          ok: false,
+          apiVersion: HEADLESS_API_VERSION,
+          error: {
+            code: error.code ?? 'UNAUTHORIZED',
+            message: error.message ?? 'Unauthorized',
+          },
+        })
+      }
       return
     }
     handler().catch((e) => {


### PR DESCRIPTION
## Summary
- Fix Cloud Run Docker builds by using Node 22 (matches `engines`), copying `.npmrc` before `npm ci`, and creating ephemeral `/workspace` at image build time.
- Add `headless/cloudbuild.yaml` and `headless/deploy-cloudrun.sh` for one-command Cloud Build + Cloud Run deploy.
- Harden the headless HTTP service for remote agents: Bearer API key auth (`PIXELS_API_KEY`), `POST /v1/media/import-url` for remote clip ingestion, and contract/tests updates.

## Test plan
- [x] Cloud Build image builds successfully (`gcloud builds submit --config headless/cloudbuild.yaml`)
- [x] Cloud Run service deploys and `/health` returns `{"ok":true}`
- [ ] `POST /v1/media/import-url` with a signed HTTPS GCS URL imports media
- [ ] Authenticated render/edit requests succeed with `Authorization: Bearer $PIXELS_API_KEY`
- [ ] `npm run headless:test` passes locally


Made with [Cursor](https://cursor.com)