### PR TITLE
feat(wallet): receive QR, send tokens, and smart wallet fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "motion": "12.40.0",
         "music-metadata": "11.15.0",
         "onnxruntime-web": "1.26.0-dev.20260410-5e55544225",
+        "qrcode.react": "^4.2.0",
         "react": "19.2.5",
         "react-colorful": "5.6.1",
         "react-dom": "19.2.5",
@@ -16795,6 +16796,15 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/qrcode/node_modules/ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "motion": "12.40.0",
     "music-metadata": "11.15.0",
     "onnxruntime-web": "1.26.0-dev.20260410-5e55544225",
+    "qrcode.react": "4.2.0",
     "react": "19.2.5",
     "react-colorful": "5.6.1",
     "react-dom": "19.2.5",

--- a/src/components/wallet-connect-button.tsx
+++ b/src/components/wallet-connect-button.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react'
-import { Copy, DollarSign, Sparkles, Wallet } from 'lucide-react'
+import { ArrowUpRight, Copy, DollarSign, QrCode, Sparkles, Wallet } from 'lucide-react'
 import { useWalletContext } from '@/context/wallet-context'
 import { Button } from '@/components/ui/button'
 import {
@@ -21,6 +21,7 @@ import { useUsdcBalance } from '@/hooks/use-usdc-balance'
 import { useCrtvaiBalance } from '@/hooks/use-crtvai-balance'
 import { BuyUsdcOnrampModal } from '@/features/onramp'
 import { BuyCreditsModal } from '@/features/credits'
+import { ReceiveFundsModal, SendTokenModal } from '@/features/wallet'
 import { cn } from '@/shared/ui/cn'
 
 function truncateAddress(address: string): string {
@@ -47,19 +48,19 @@ export function WalletConnectButton({
     configured,
     connect,
     disconnect,
-    wallet,
+    account,
     chain,
     switchChain,
     isConnecting,
   } = useWalletContext()
-  const address = wallet?.address
-  const { formatted: usdcFormatted } = useUsdcBalance(chain, address as `0x${string}` | undefined)
-  const { formatted: crtvaiFormatted, symbol: crtvaiSymbol } = useCrtvaiBalance(
-    address as `0x${string}` | undefined,
-  )
+  const address = account
+  const { formatted: usdcFormatted } = useUsdcBalance(chain, address)
+  const { formatted: crtvaiFormatted, symbol: crtvaiSymbol } = useCrtvaiBalance(address)
   const [copied, setCopied] = useState(false)
   const [buyCreditsOpen, setBuyCreditsOpen] = useState(false)
   const [buyOnrampOpen, setBuyOnrampOpen] = useState(false)
+  const [receiveOpen, setReceiveOpen] = useState(false)
+  const [sendOpen, setSendOpen] = useState(false)
 
   const handleCopyAddress = useCallback(() => {
     if (!address) return
@@ -70,7 +71,7 @@ export function WalletConnectButton({
   }, [address])
 
   const isInitializing = configured && (!ready || isConnecting)
-  const isConnected = Boolean(authenticated && wallet)
+  const isConnected = Boolean(authenticated && account)
 
   if (isInitializing) {
     return (
@@ -133,6 +134,24 @@ export function WalletConnectButton({
             {crtvaiSymbol}: {crtvaiFormatted}
           </DropdownMenuItem>
           <DropdownMenuItem
+            onClick={() => setReceiveOpen(true)}
+            className="flex cursor-pointer items-center gap-2"
+            aria-label="Receive funds"
+          >
+            <QrCode className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden />
+            Receive
+          </DropdownMenuItem>
+
+          <DropdownMenuItem
+            onClick={() => setSendOpen(true)}
+            className="flex cursor-pointer items-center gap-2"
+            aria-label="Send tokens"
+          >
+            <ArrowUpRight className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden />
+            Send
+          </DropdownMenuItem>
+
+          <DropdownMenuItem
             onClick={() => setBuyOnrampOpen(true)}
             className="flex cursor-pointer items-center gap-2"
             aria-label="Buy USDC"
@@ -180,6 +199,8 @@ export function WalletConnectButton({
 
       <BuyCreditsModal open={buyCreditsOpen} onOpenChange={setBuyCreditsOpen} />
       <BuyUsdcOnrampModal open={buyOnrampOpen} onOpenChange={setBuyOnrampOpen} />
+      <ReceiveFundsModal open={receiveOpen} onOpenChange={setReceiveOpen} />
+      <SendTokenModal open={sendOpen} onOpenChange={setSendOpen} />
     </>
   )
 }

--- a/src/context/wallet-context.tsx
+++ b/src/context/wallet-context.tsx
@@ -36,7 +36,10 @@ export interface WalletContextValue {
   connect: () => void
   disconnect: () => Promise<void>
   wallet: ConnectedWallet | null
+  /** Alchemy ERC-4337 smart account — used for balances, onramp, and on-chain ops. */
   account: Address | undefined
+  /** Privy signer EOA (embedded or external wallet). */
+  signerAddress: Address | undefined
   user: User | null
   walletClient: WalletClient | null
   smartWalletClient: SmartWalletClient | null
@@ -65,6 +68,7 @@ function WalletContextInner({ children }: { children: ReactNode }) {
   const { ready, authenticated, user, login, logout, connectWallet, getAccessToken } = usePrivy()
   const { wallets, ready: walletsReady } = useWallets()
   const [walletClient, setWalletClient] = useState<WalletClient | null>(null)
+  const [smartAccountAddress, setSmartAccountAddress] = useState<Address | undefined>()
   const [chain, setChain] = useState<Chain>(DEFAULT_CHAIN)
   const [isConnecting, setIsConnecting] = useState(false)
   const [error, setError] = useState<Error | null>(null)
@@ -74,6 +78,8 @@ function WalletContextInner({ children }: { children: ReactNode }) {
     const embedded = getEmbeddedConnectedWallet(wallets)
     return embedded ?? wallets[0] ?? null
   }, [wallets, walletsReady])
+
+  const signerAddress = activeWallet ? (activeWallet.address as Address) : undefined
 
   useEffect(() => {
     let cancelled = false
@@ -110,7 +116,8 @@ function WalletContextInner({ children }: { children: ReactNode }) {
     }
   }, [activeWallet, activeWallet?.chainId, authenticated, chain])
 
-  const smartWalletClient = useMemo<SmartWalletClient | null>(() => {
+  // Bootstrap client (no account) — used only to call requestAccount and avoid EIP-7702.
+  const bootstrapSmartWalletClient = useMemo<SmartWalletClient | null>(() => {
     if (!walletClient || !ALCHEMY_API_KEY) return null
     return createSmartWalletClient({
       transport: alchemyWalletTransport({ apiKey: ALCHEMY_API_KEY }),
@@ -119,6 +126,42 @@ function WalletContextInner({ children }: { children: ReactNode }) {
       ...(ALCHEMY_POLICY_ID ? { paymaster: { policyId: ALCHEMY_POLICY_ID } } : {}),
     }).extend(swapActions) as SmartWalletClient
   }, [walletClient, chain])
+
+  useEffect(() => {
+    if (!bootstrapSmartWalletClient || !signerAddress) {
+      setSmartAccountAddress(undefined)
+      return
+    }
+    let cancelled = false
+    void (async () => {
+      try {
+        const smartAccount = await bootstrapSmartWalletClient.requestAccount({ signerAddress })
+        if (!cancelled) {
+          setSmartAccountAddress(smartAccount.address)
+          setError(null)
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setSmartAccountAddress(undefined)
+          setError(e instanceof Error ? e : new Error(String(e)))
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [bootstrapSmartWalletClient, signerAddress])
+
+  const smartWalletClient = useMemo<SmartWalletClient | null>(() => {
+    if (!walletClient || !ALCHEMY_API_KEY || !smartAccountAddress) return null
+    return createSmartWalletClient({
+      transport: alchemyWalletTransport({ apiKey: ALCHEMY_API_KEY }),
+      chain,
+      signer: walletClient as never,
+      account: smartAccountAddress,
+      ...(ALCHEMY_POLICY_ID ? { paymaster: { policyId: ALCHEMY_POLICY_ID } } : {}),
+    }).extend(swapActions) as SmartWalletClient
+  }, [walletClient, chain, smartAccountAddress])
 
   const connect = useCallback(() => {
     setError(null)
@@ -142,15 +185,19 @@ function WalletContextInner({ children }: { children: ReactNode }) {
     [activeWallet],
   )
 
+  const walletReady =
+    ready && walletsReady && (!authenticated || !ALCHEMY_API_KEY || Boolean(smartAccountAddress))
+
   const value = useMemo(
     () => ({
-      ready: ready && walletsReady,
+      ready: walletReady,
       authenticated,
       configured: true,
       connect,
       disconnect,
       wallet: activeWallet,
-      account: activeWallet ? (activeWallet.address as Address) : undefined,
+      account: smartAccountAddress,
+      signerAddress,
       user,
       walletClient,
       smartWalletClient,
@@ -161,12 +208,13 @@ function WalletContextInner({ children }: { children: ReactNode }) {
       getAccessToken,
     }),
     [
-      ready,
-      walletsReady,
+      walletReady,
       authenticated,
       connect,
       disconnect,
       activeWallet,
+      smartAccountAddress,
+      signerAddress,
       user,
       walletClient,
       smartWalletClient,
@@ -201,6 +249,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       disconnect: async () => {},
       wallet: null,
       account: undefined,
+      signerAddress: undefined,
       user: null,
       walletClient: null,
       smartWalletClient: null,

--- a/src/features/credits/components/credit-pack-checkout.tsx
+++ b/src/features/credits/components/credit-pack-checkout.tsx
@@ -8,6 +8,7 @@ import { useSmartWalletOps } from '@/hooks/use-smart-wallet-ops'
 import { useUsdcBalance } from '@/hooks/use-usdc-balance'
 import { SETTLEMENT_CREDIT_PACKS, type CreditPackDefinition } from '@/config/credit-pack-settlement'
 import { buildSettlePackOps } from '@/features/credits/api/settle-pack'
+import { totalUsdcForPurchase } from '@/features/credits/usdc-for-purchase'
 import { base } from 'viem/chains'
 import { cn } from '@/shared/ui/cn'
 
@@ -58,6 +59,7 @@ export function CreditPackCheckout() {
         <PackCard
           key={pack.id}
           pack={pack}
+          chainId={chain?.id}
           onBase={onBase}
           walletReady={walletReady}
           usdcBalance={usdcBalance}
@@ -71,6 +73,7 @@ export function CreditPackCheckout() {
 
 function PackCard({
   pack,
+  chainId,
   onBase,
   walletReady,
   usdcBalance,
@@ -78,6 +81,7 @@ function PackCard({
   onBuy,
 }: {
   pack: CreditPackDefinition
+  chainId: number | undefined
   onBase: boolean
   walletReady: boolean
   usdcBalance: string | null
@@ -87,9 +91,10 @@ function PackCard({
   const priceUsd = (pack.usdc6 / 1_000_000).toFixed(0)
 
   const insufficient = useMemo(() => {
-    if (usdcBalance === null) return false
-    return Number(usdcBalance) < pack.usdc6 / 1_000_000
-  }, [usdcBalance, pack.usdc6])
+    if (usdcBalance === null || !chainId) return false
+    const requiredUsd = totalUsdcForPurchase(pack.usdc6, chainId) / 1_000_000
+    return Number(usdcBalance) < requiredUsd
+  }, [usdcBalance, pack.usdc6, chainId])
 
   const disabled = !onBase || !walletReady || settling || insufficient
 
@@ -107,7 +112,9 @@ function PackCard({
 
       {!onBase && <p className="mt-2 text-[11px] text-amber-500">Switch to Base to buy.</p>}
       {insufficient && (
-        <p className="mt-2 text-[11px] text-destructive">Insufficient USDC balance.</p>
+        <p className="mt-2 text-[11px] text-destructive">
+          Insufficient USDC balance (includes gas reserve).
+        </p>
       )}
 
       <Button

--- a/src/features/credits/components/credit-pack-checkout.tsx
+++ b/src/features/credits/components/credit-pack-checkout.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from 'react'
 import { Coins, Loader2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { useQueryClient } from '@tanstack/react-query'
+import { getErrorMessage, invalidateWalletTokenBalances } from '@/hooks/invalidate-wallet-balances'
 import { Button } from '@/components/ui/button'
 import { useWalletContext } from '@/context/wallet-context'
 import { useSmartWalletOps } from '@/hooks/use-smart-wallet-ops'
@@ -41,11 +42,9 @@ export function CreditPackCheckout() {
         const { ops } = buildSettlePackOps(pack.id, usdc6, account)
         await sendOps(ops)
         toast.success(`Purchased ${pack.credits} credits`)
-        void queryClient.invalidateQueries({ queryKey: ['usdc-balance', chain?.id, account] })
-        void queryClient.invalidateQueries({ queryKey: ['crtvai-balance', account] })
-      } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e)
-        toast.error(`Purchase failed: ${msg}`)
+        invalidateWalletTokenBalances(queryClient, chain?.id, account)
+      } catch (error) {
+        toast.error(`Purchase failed: ${getErrorMessage(error)}`)
       } finally {
         setSettlingId(null)
       }

--- a/src/features/editor/director/director-chat-panel.tsx
+++ b/src/features/editor/director/director-chat-panel.tsx
@@ -403,19 +403,12 @@ export const DirectorChatPanel = memo(function DirectorChatPanel() {
                           'Drop a track onto the timeline first. The Director builds beat-synced storyboards from audio already in your edit.',
                       })}
                 </p>
-                {isPremiumMember ? (
-                  <p className="text-[11px] text-emerald-300/90">
-                    {t('director.empty.premium', {
-                      defaultValue: 'Pro rate active — half-price Director minutes.',
-                    })}
-                  </p>
-                ) : (
-                  <p className="text-[11px] text-muted-foreground/90">
-                    {t('director.empty.proValue', {
-                      defaultValue: 'Cloud Director · beat-synced research · Pro members pay half.',
-                    })}
-                  </p>
-                )}
+                <p className="text-[11px] text-muted-foreground/90">
+                  {t('director.empty.tagline', {
+                    defaultValue:
+                      'Cloud Director · beat-synced research · pay per minute of audio.',
+                  })}
+                </p>
               </div>
 
               {walletConfigured && authenticated && !hasCrtvai && <DirectorSessionPacks />}

--- a/src/features/editor/director/director-invoice-card.tsx
+++ b/src/features/editor/director/director-invoice-card.tsx
@@ -50,21 +50,6 @@ export function DirectorInvoiceCard({
         })}
       </p>
 
-      {quote.tier === 'premium' ? (
-        <p className="mt-2 rounded-md border border-emerald-500/30 bg-emerald-500/10 px-2 py-1.5 text-[11px] text-emerald-200/90">
-          {t('director.invoice.premium', {
-            defaultValue: 'Pro rate — Creative Org / Pixels Premium members save 50% vs retail.',
-          })}
-        </p>
-      ) : (
-        <p className="mt-2 rounded-md border border-border/70 bg-secondary/40 px-2 py-1.5 text-[11px] text-muted-foreground">
-          {t('director.invoice.proUpsell', {
-            defaultValue:
-              'Pro tip: Creative Org DAO or Pixels Premium unlocks half-price Director minutes plus cloud research tools.',
-          })}
-        </p>
-      )}
-
       <dl className="mt-3 space-y-1.5 font-mono text-[11px]">
         <div className="flex justify-between gap-3">
           <dt className="text-muted-foreground">Audio</dt>
@@ -77,7 +62,6 @@ export function DirectorInvoiceCard({
           <dt className="text-muted-foreground">Rate</dt>
           <dd className="text-foreground">
             {(quote.usdc6PerMinute / 1_000_000).toFixed(2)} USD / min
-            <span className="ml-1 text-muted-foreground">({quote.tier})</span>
           </dd>
         </div>
         <div className="flex justify-between gap-3 border-t border-border/60 pt-1.5">

--- a/src/features/editor/director/director-session-packs.tsx
+++ b/src/features/editor/director/director-session-packs.tsx
@@ -21,8 +21,7 @@ export function DirectorSessionPacks() {
       </p>
       <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
         {t('director.packs.blurb', {
-          defaultValue:
-            'Top up CRTVAI for multiple Director briefs. Packs estimate retail audio minutes; Pro members stretch further.',
+          defaultValue: 'Top up CRTVAI for multiple Director briefs.',
         })}
       </p>
       <ul className="mt-2.5 space-y-1.5">

--- a/src/features/live-ai/components/live-ai-popover.tsx
+++ b/src/features/live-ai/components/live-ai-popover.tsx
@@ -19,8 +19,8 @@ import { isLiveAiBillingEnvReady, getLiveAiBillingConfigIssues } from '../config
 export function LiveAiPopover() {
   const [open, setOpen] = useState(false)
   const [streaming, setStreaming] = useState(false)
-  const { wallet, chain } = useWalletContext()
-  const address = wallet?.address as `0x${string}` | undefined
+  const { account, chain } = useWalletContext()
+  const address = account
   const {
     isPremiumMember,
     isLoading: membershipLoading,

--- a/src/features/live-ai/components/usage-meter.tsx
+++ b/src/features/live-ai/components/usage-meter.tsx
@@ -24,11 +24,9 @@ function formatUsdStreamed(usdc6: number): string {
  * Shows elapsed time and current hourly USDC rate.
  */
 export function UsageMeter({ streamActive }: { streamActive: boolean }) {
-  const { wallet } = useWalletContext()
-  const address = wallet?.address
-  const { intervalCostUsdc6, isPremiumMember, isLoading } = usePremiumMembership(
-    address as `0x${string}` | undefined,
-  )
+  const { account } = useWalletContext()
+  const address = account
+  const { intervalCostUsdc6, isPremiumMember, isLoading } = usePremiumMembership(address)
   const [elapsedMs, setElapsedMs] = useState(0)
 
   const hourlyRate = hourlyUsdcFromInterval(intervalCostUsdc6)

--- a/src/features/metoken/api/move-usdc-to-smart-wallet.ts
+++ b/src/features/metoken/api/move-usdc-to-smart-wallet.ts
@@ -1,0 +1,43 @@
+import type { Chain, WalletClient } from 'viem'
+import { erc20Abi, parseUnits, type Address } from 'viem'
+import { USDC_BASE_ADDRESS, USDC_DECIMALS } from '@/config/metoken'
+import { getBasePublicClient } from '@/config/base-client'
+
+export interface MoveUsdcToSmartWalletParams {
+  walletClient: WalletClient
+  chain: Chain
+  smartAccount: Address
+  signerAddress: Address
+  signerUsdcBalance: string
+  smartUsdcBalance: string | null
+  requiredUsdc6: number
+}
+
+export async function moveUsdcToSmartWallet({
+  walletClient,
+  chain,
+  smartAccount,
+  signerAddress,
+  signerUsdcBalance,
+  smartUsdcBalance,
+  requiredUsdc6,
+}: MoveUsdcToSmartWalletParams): Promise<`0x${string}`> {
+  const eoaRaw = parseUnits(signerUsdcBalance, USDC_DECIMALS)
+  const smartRaw = parseUnits(smartUsdcBalance ?? '0', USDC_DECIMALS)
+  const shortfall = BigInt(requiredUsdc6) > smartRaw ? BigInt(requiredUsdc6) - smartRaw : 0n
+  const amount = shortfall > 0n && shortfall < eoaRaw ? shortfall : eoaRaw
+  if (amount <= 0n) {
+    throw new Error('No USDC available to move')
+  }
+
+  const hash = await walletClient.writeContract({
+    address: USDC_BASE_ADDRESS,
+    abi: erc20Abi,
+    functionName: 'transfer',
+    args: [smartAccount, amount],
+    chain,
+    account: signerAddress,
+  })
+  await getBasePublicClient().waitForTransactionReceipt({ hash })
+  return hash
+}

--- a/src/features/metoken/components/buy-metoken-modal.tsx
+++ b/src/features/metoken/components/buy-metoken-modal.tsx
@@ -1,8 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Coins, Loader2 } from 'lucide-react'
-import { toast } from 'sonner'
-import { parseUnits, formatUnits, erc20Abi } from 'viem'
-import { useQueryClient } from '@tanstack/react-query'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -12,21 +8,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
-import { useWalletContext } from '@/context/wallet-context'
-import { useSmartWalletOps } from '@/hooks/use-smart-wallet-ops'
-import { useUsdcBalance } from '@/hooks/use-usdc-balance'
-import { useCrtvaiBalance } from '@/hooks/use-crtvai-balance'
-import {
-  CRTVAI_DECIMALS,
-  USDC_BASE_ADDRESS,
-  USDC_DECIMALS,
-  readCrtvaiCurrentPrice,
-  readCrtvaiMintQuote,
-} from '@/config/metoken'
-import { buildBuyMetokenOps } from '@/features/metoken/api/buy-metoken'
-import { totalUsdcForPurchase } from '@/features/metoken/deps/credits-contract'
-import { getBasePublicClient } from '@/config/base-client'
-import { base } from 'viem/chains'
+import { useBuyMetokenForm } from '@/features/metoken/hooks/use-buy-metoken-form'
 import { cn } from '@/shared/ui/cn'
 
 interface BuyMetokenModalProps {
@@ -36,193 +18,8 @@ interface BuyMetokenModalProps {
   initialUsdcAmount?: string
 }
 
-const BASE_CHAIN_ID = base.id
-
 export function BuyMetokenModal({ open, onOpenChange, initialUsdcAmount }: BuyMetokenModalProps) {
-  const { account, signerAddress, chain, walletClient } = useWalletContext()
-  const queryClient = useQueryClient()
-  const { sendOps, ready: walletReady } = useSmartWalletOps()
-  const { balance: usdcBalance, formatted: usdcFormatted } = useUsdcBalance(chain, account)
-  const { balance: signerUsdcBalance } = useUsdcBalance(chain, signerAddress)
-  const { formatted: crtvaiFormatted, symbol } = useCrtvaiBalance(account)
-
-  const [usdcInput, setUsdcInput] = useState('')
-  const [estimatedOutput, setEstimatedOutput] = useState<string | null>(null)
-  const [currentPrice, setCurrentPrice] = useState<string | null>(null)
-  const [quoting, setQuoting] = useState(false)
-  const [minting, setMinting] = useState(false)
-  const [transferring, setTransferring] = useState(false)
-
-  const onBase = chain?.id === BASE_CHAIN_ID
-
-  const requiredUsdc6 = useMemo(() => {
-    if (!usdcInput || !onBase || !chain?.id) return 0
-    try {
-      const inputUsdc6 = Number(parseUnits(usdcInput, USDC_DECIMALS))
-      return totalUsdcForPurchase(inputUsdc6, chain.id)
-    } catch {
-      return 0
-    }
-  }, [usdcInput, onBase, chain?.id])
-
-  const hasSufficientUsdc = useMemo(() => {
-    if (!usdcInput || !usdcBalance || requiredUsdc6 === 0) return true
-    try {
-      const balanceRaw = parseUnits(usdcBalance, USDC_DECIMALS)
-      return BigInt(requiredUsdc6) <= balanceRaw
-    } catch {
-      return false
-    }
-  }, [usdcInput, usdcBalance, requiredUsdc6])
-
-  const needsEoaTransfer = useMemo(() => {
-    if (!signerUsdcBalance || !usdcBalance || requiredUsdc6 === 0) return false
-    try {
-      const smartRaw = parseUnits(usdcBalance, USDC_DECIMALS)
-      const eoaRaw = parseUnits(signerUsdcBalance, USDC_DECIMALS)
-      return smartRaw < BigInt(requiredUsdc6) && eoaRaw > 0n
-    } catch {
-      return false
-    }
-  }, [signerUsdcBalance, usdcBalance, requiredUsdc6])
-
-  // Prefill + fetch current price on open
-  useEffect(() => {
-    if (!open) return
-    if (initialUsdcAmount) setUsdcInput(initialUsdcAmount)
-    if (!onBase) return
-    let cancelled = false
-    void (async () => {
-      try {
-        const price = await readCrtvaiCurrentPrice()
-        if (!cancelled) {
-          setCurrentPrice(formatUnits(price, USDC_DECIMALS))
-        }
-      } catch {
-        // Price read failed — non-fatal, UI still works
-      }
-    })()
-    return () => {
-      cancelled = true
-    }
-  }, [open, onBase, initialUsdcAmount])
-
-  // Debounced mint quote
-  useEffect(() => {
-    if (!open || !onBase || !usdcInput) {
-      setEstimatedOutput(null)
-      return
-    }
-    let usdcRaw: bigint
-    try {
-      usdcRaw = parseUnits(usdcInput, USDC_DECIMALS)
-    } catch {
-      setEstimatedOutput(null)
-      return
-    }
-    if (usdcRaw <= 0n) {
-      setEstimatedOutput(null)
-      return
-    }
-    let cancelled = false
-    setQuoting(true)
-    const timer = window.setTimeout(async () => {
-      try {
-        const quote = await readCrtvaiMintQuote(usdcRaw)
-        if (!cancelled) {
-          setEstimatedOutput(formatUnits(quote, CRTVAI_DECIMALS))
-        }
-      } catch {
-        if (!cancelled) setEstimatedOutput(null)
-      } finally {
-        if (!cancelled) setQuoting(false)
-      }
-    }, 400)
-    return () => {
-      cancelled = true
-      window.clearTimeout(timer)
-      if (!cancelled) setQuoting(false)
-    }
-  }, [open, onBase, usdcInput])
-
-  const handleMoveUsdcToSmartWallet = useCallback(async () => {
-    if (!walletClient || !account || !signerAddress || !signerUsdcBalance) return
-    let eoaRaw: bigint
-    let smartRaw: bigint
-    try {
-      eoaRaw = parseUnits(signerUsdcBalance, USDC_DECIMALS)
-      smartRaw = parseUnits(usdcBalance ?? '0', USDC_DECIMALS)
-    } catch {
-      toast.error('Invalid USDC balance')
-      return
-    }
-    const shortfall = BigInt(requiredUsdc6) > smartRaw ? BigInt(requiredUsdc6) - smartRaw : 0n
-    const amount = shortfall > 0n && shortfall < eoaRaw ? shortfall : eoaRaw
-    if (amount <= 0n) return
-
-    setTransferring(true)
-    try {
-      const hash = await walletClient.writeContract({
-        address: USDC_BASE_ADDRESS,
-        abi: erc20Abi,
-        functionName: 'transfer',
-        args: [account, amount],
-        chain,
-        account: signerAddress,
-      })
-      await getBasePublicClient().waitForTransactionReceipt({ hash })
-      toast.success('USDC moved to smart wallet')
-      void queryClient.invalidateQueries({ queryKey: ['usdc-balance', chain?.id, account] })
-      void queryClient.invalidateQueries({ queryKey: ['usdc-balance', chain?.id, signerAddress] })
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e)
-      toast.error(`Transfer failed: ${msg}`)
-    } finally {
-      setTransferring(false)
-    }
-  }, [
-    walletClient,
-    account,
-    signerAddress,
-    signerUsdcBalance,
-    usdcBalance,
-    requiredUsdc6,
-    chain,
-    queryClient,
-  ])
-
-  const handleMint = useCallback(async () => {
-    if (!account || !usdcInput || !onBase) return
-    let usdcRaw: bigint
-    try {
-      usdcRaw = parseUnits(usdcInput, USDC_DECIMALS)
-    } catch {
-      toast.error('Invalid USDC amount')
-      return
-    }
-    if (usdcRaw <= 0n) {
-      toast.error('Amount must be greater than 0')
-      return
-    }
-    setMinting(true)
-    try {
-      const { ops } = buildBuyMetokenOps(usdcRaw, account)
-      await sendOps(ops)
-      toast.success(`Minted CRTVAI with ${usdcInput} USDC`)
-      setUsdcInput('')
-      onOpenChange(false)
-      void queryClient.invalidateQueries({ queryKey: ['usdc-balance', chain?.id, account] })
-      void queryClient.invalidateQueries({ queryKey: ['crtvai-balance', account] })
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e)
-      toast.error(`Mint failed: ${msg}`)
-    } finally {
-      setMinting(false)
-    }
-  }, [account, usdcInput, onBase, chain?.id, sendOps, onOpenChange, queryClient])
-
-  const canMint =
-    onBase && walletReady && usdcInput && hasSufficientUsdc && !quoting && !minting && !transferring
+  const form = useBuyMetokenForm(open, onOpenChange, initialUsdcAmount)
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -240,20 +37,20 @@ export function BuyMetokenModal({ open, onOpenChange, initialUsdcAmount }: BuyMe
         <div className="space-y-4 py-2">
           <div className="flex items-center justify-between text-sm">
             <span className="text-muted-foreground">Wallet USDC:</span>
-            <span className="font-medium">{usdcFormatted} USDC</span>
+            <span className="font-medium">{form.usdcFormatted} USDC</span>
           </div>
           <div className="flex items-center justify-between text-sm">
-            <span className="text-muted-foreground">Wallet {symbol}:</span>
+            <span className="text-muted-foreground">Wallet {form.symbol}:</span>
             <span className="font-medium">
-              {crtvaiFormatted} {symbol}
+              {form.crtvaiFormatted} {form.symbol}
             </span>
           </div>
-          {currentPrice && (
+          {form.currentPrice && (
             <div className="flex items-center justify-between text-sm">
               <span className="text-muted-foreground">Current price:</span>
               <span className="font-medium">
-                {Number(currentPrice).toLocaleString(undefined, { maximumFractionDigits: 6 })} USDC/
-                {symbol}
+                {Number(form.currentPrice).toLocaleString(undefined, { maximumFractionDigits: 6 })}{' '}
+                USDC/{form.symbol}
               </span>
             </div>
           )}
@@ -268,34 +65,34 @@ export function BuyMetokenModal({ open, onOpenChange, initialUsdcAmount }: BuyMe
               min="0"
               step="0.01"
               placeholder="0.00"
-              value={usdcInput}
-              onChange={(e) => setUsdcInput(e.target.value)}
-              disabled={minting}
+              value={form.usdcInput}
+              onChange={(e) => form.setUsdcInput(e.target.value)}
+              disabled={form.minting}
             />
           </div>
 
           <div className="rounded-md border bg-muted/40 px-3 py-2 text-sm">
             <span className="text-muted-foreground">Estimated receive: </span>
             <span className="font-medium">
-              {quoting ? (
+              {form.quoting ? (
                 <Loader2 className="inline h-3.5 w-3.5 animate-spin" />
-              ) : estimatedOutput ? (
-                `${Number(estimatedOutput).toLocaleString(undefined, { maximumFractionDigits: 4 })} ${symbol}`
+              ) : form.estimatedOutput ? (
+                `${Number(form.estimatedOutput).toLocaleString(undefined, { maximumFractionDigits: 4 })} ${form.symbol}`
               ) : (
                 '—'
               )}
             </span>
           </div>
 
-          {!onBase && (
+          {!form.onBase && (
             <p className="text-xs text-amber-500">Switch to Base network to mint CRTVAI.</p>
           )}
-          {!hasSufficientUsdc && usdcInput && !needsEoaTransfer && (
+          {!form.hasSufficientUsdc && form.usdcInput && !form.needsEoaTransfer && (
             <p className="text-xs text-destructive">
               Insufficient USDC balance (includes gas reserve).
             </p>
           )}
-          {needsEoaTransfer && (
+          {form.needsEoaTransfer && (
             <div className="space-y-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
               <p>USDC is in your signer wallet. Move it to your smart wallet before minting.</p>
               <Button
@@ -303,10 +100,10 @@ export function BuyMetokenModal({ open, onOpenChange, initialUsdcAmount }: BuyMe
                 variant="outline"
                 size="sm"
                 className="w-full"
-                disabled={transferring || minting}
-                onClick={() => void handleMoveUsdcToSmartWallet()}
+                disabled={form.transferring || form.minting}
+                onClick={() => void form.handleMoveUsdcToSmartWallet()}
               >
-                {transferring ? (
+                {form.transferring ? (
                   <>
                     <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
                     Moving USDC…
@@ -319,11 +116,11 @@ export function BuyMetokenModal({ open, onOpenChange, initialUsdcAmount }: BuyMe
           )}
 
           <Button
-            onClick={handleMint}
-            disabled={!canMint}
-            className={cn('w-full', minting && 'opacity-80')}
+            onClick={() => void form.handleMint()}
+            disabled={!form.canMint}
+            className={cn('w-full', form.minting && 'opacity-80')}
           >
-            {minting ? (
+            {form.minting ? (
               <>
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                 Minting…

--- a/src/features/metoken/components/buy-metoken-modal.tsx
+++ b/src/features/metoken/components/buy-metoken-modal.tsx
@@ -24,7 +24,7 @@ import {
   readCrtvaiMintQuote,
 } from '@/config/metoken'
 import { buildBuyMetokenOps } from '@/features/metoken/api/buy-metoken'
-import { totalUsdcForPurchase } from '@/features/credits/usdc-for-purchase'
+import { totalUsdcForPurchase } from '@/features/metoken/deps/credits-contract'
 import { getBasePublicClient } from '@/config/base-client'
 import { base } from 'viem/chains'
 import { cn } from '@/shared/ui/cn'

--- a/src/features/metoken/components/buy-metoken-modal.tsx
+++ b/src/features/metoken/components/buy-metoken-modal.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Coins, Loader2 } from 'lucide-react'
 import { toast } from 'sonner'
-import { parseUnits, formatUnits } from 'viem'
+import { parseUnits, formatUnits, erc20Abi } from 'viem'
 import { useQueryClient } from '@tanstack/react-query'
 import { Button } from '@/components/ui/button'
 import {
@@ -18,11 +18,14 @@ import { useUsdcBalance } from '@/hooks/use-usdc-balance'
 import { useCrtvaiBalance } from '@/hooks/use-crtvai-balance'
 import {
   CRTVAI_DECIMALS,
+  USDC_BASE_ADDRESS,
   USDC_DECIMALS,
   readCrtvaiCurrentPrice,
   readCrtvaiMintQuote,
 } from '@/config/metoken'
 import { buildBuyMetokenOps } from '@/features/metoken/api/buy-metoken'
+import { totalUsdcForPurchase } from '@/features/credits/usdc-for-purchase'
+import { getBasePublicClient } from '@/config/base-client'
 import { base } from 'viem/chains'
 import { cn } from '@/shared/ui/cn'
 
@@ -36,10 +39,11 @@ interface BuyMetokenModalProps {
 const BASE_CHAIN_ID = base.id
 
 export function BuyMetokenModal({ open, onOpenChange, initialUsdcAmount }: BuyMetokenModalProps) {
-  const { account, chain } = useWalletContext()
+  const { account, signerAddress, chain, walletClient } = useWalletContext()
   const queryClient = useQueryClient()
   const { sendOps, ready: walletReady } = useSmartWalletOps()
   const { balance: usdcBalance, formatted: usdcFormatted } = useUsdcBalance(chain, account)
+  const { balance: signerUsdcBalance } = useUsdcBalance(chain, signerAddress)
   const { formatted: crtvaiFormatted, symbol } = useCrtvaiBalance(account)
 
   const [usdcInput, setUsdcInput] = useState('')
@@ -47,19 +51,40 @@ export function BuyMetokenModal({ open, onOpenChange, initialUsdcAmount }: BuyMe
   const [currentPrice, setCurrentPrice] = useState<string | null>(null)
   const [quoting, setQuoting] = useState(false)
   const [minting, setMinting] = useState(false)
+  const [transferring, setTransferring] = useState(false)
 
   const onBase = chain?.id === BASE_CHAIN_ID
 
-  const hasSufficientUsdc = useMemo(() => {
-    if (!usdcInput || !usdcBalance) return true
+  const requiredUsdc6 = useMemo(() => {
+    if (!usdcInput || !onBase || !chain?.id) return 0
     try {
-      const inputRaw = parseUnits(usdcInput, USDC_DECIMALS)
+      const inputUsdc6 = Number(parseUnits(usdcInput, USDC_DECIMALS))
+      return totalUsdcForPurchase(inputUsdc6, chain.id)
+    } catch {
+      return 0
+    }
+  }, [usdcInput, onBase, chain?.id])
+
+  const hasSufficientUsdc = useMemo(() => {
+    if (!usdcInput || !usdcBalance || requiredUsdc6 === 0) return true
+    try {
       const balanceRaw = parseUnits(usdcBalance, USDC_DECIMALS)
-      return inputRaw <= balanceRaw
+      return BigInt(requiredUsdc6) <= balanceRaw
     } catch {
       return false
     }
-  }, [usdcInput, usdcBalance])
+  }, [usdcInput, usdcBalance, requiredUsdc6])
+
+  const needsEoaTransfer = useMemo(() => {
+    if (!signerUsdcBalance || !usdcBalance || requiredUsdc6 === 0) return false
+    try {
+      const smartRaw = parseUnits(usdcBalance, USDC_DECIMALS)
+      const eoaRaw = parseUnits(signerUsdcBalance, USDC_DECIMALS)
+      return smartRaw < BigInt(requiredUsdc6) && eoaRaw > 0n
+    } catch {
+      return false
+    }
+  }, [signerUsdcBalance, usdcBalance, requiredUsdc6])
 
   // Prefill + fetch current price on open
   useEffect(() => {
@@ -120,6 +145,52 @@ export function BuyMetokenModal({ open, onOpenChange, initialUsdcAmount }: BuyMe
     }
   }, [open, onBase, usdcInput])
 
+  const handleMoveUsdcToSmartWallet = useCallback(async () => {
+    if (!walletClient || !account || !signerAddress || !signerUsdcBalance) return
+    let eoaRaw: bigint
+    let smartRaw: bigint
+    try {
+      eoaRaw = parseUnits(signerUsdcBalance, USDC_DECIMALS)
+      smartRaw = parseUnits(usdcBalance ?? '0', USDC_DECIMALS)
+    } catch {
+      toast.error('Invalid USDC balance')
+      return
+    }
+    const shortfall = BigInt(requiredUsdc6) > smartRaw ? BigInt(requiredUsdc6) - smartRaw : 0n
+    const amount = shortfall > 0n && shortfall < eoaRaw ? shortfall : eoaRaw
+    if (amount <= 0n) return
+
+    setTransferring(true)
+    try {
+      const hash = await walletClient.writeContract({
+        address: USDC_BASE_ADDRESS,
+        abi: erc20Abi,
+        functionName: 'transfer',
+        args: [account, amount],
+        chain,
+        account: signerAddress,
+      })
+      await getBasePublicClient().waitForTransactionReceipt({ hash })
+      toast.success('USDC moved to smart wallet')
+      void queryClient.invalidateQueries({ queryKey: ['usdc-balance', chain?.id, account] })
+      void queryClient.invalidateQueries({ queryKey: ['usdc-balance', chain?.id, signerAddress] })
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
+      toast.error(`Transfer failed: ${msg}`)
+    } finally {
+      setTransferring(false)
+    }
+  }, [
+    walletClient,
+    account,
+    signerAddress,
+    signerUsdcBalance,
+    usdcBalance,
+    requiredUsdc6,
+    chain,
+    queryClient,
+  ])
+
   const handleMint = useCallback(async () => {
     if (!account || !usdcInput || !onBase) return
     let usdcRaw: bigint
@@ -150,7 +221,8 @@ export function BuyMetokenModal({ open, onOpenChange, initialUsdcAmount }: BuyMe
     }
   }, [account, usdcInput, onBase, chain?.id, sendOps, onOpenChange, queryClient])
 
-  const canMint = onBase && walletReady && usdcInput && hasSufficientUsdc && !quoting && !minting
+  const canMint =
+    onBase && walletReady && usdcInput && hasSufficientUsdc && !quoting && !minting && !transferring
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -218,8 +290,32 @@ export function BuyMetokenModal({ open, onOpenChange, initialUsdcAmount }: BuyMe
           {!onBase && (
             <p className="text-xs text-amber-500">Switch to Base network to mint CRTVAI.</p>
           )}
-          {!hasSufficientUsdc && usdcInput && (
-            <p className="text-xs text-destructive">Insufficient USDC balance.</p>
+          {!hasSufficientUsdc && usdcInput && !needsEoaTransfer && (
+            <p className="text-xs text-destructive">
+              Insufficient USDC balance (includes gas reserve).
+            </p>
+          )}
+          {needsEoaTransfer && (
+            <div className="space-y-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+              <p>USDC is in your signer wallet. Move it to your smart wallet before minting.</p>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="w-full"
+                disabled={transferring || minting}
+                onClick={() => void handleMoveUsdcToSmartWallet()}
+              >
+                {transferring ? (
+                  <>
+                    <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                    Moving USDC…
+                  </>
+                ) : (
+                  'Move USDC to smart wallet'
+                )}
+              </Button>
+            </div>
           )}
 
           <Button

--- a/src/features/metoken/deps/credits-contract.ts
+++ b/src/features/metoken/deps/credits-contract.ts
@@ -1,0 +1,4 @@
+/**
+ * Cross-feature dependency contract: credits / USDC purchase helpers.
+ */
+export { totalUsdcForPurchase } from '@/features/credits/usdc-for-purchase'

--- a/src/features/metoken/hooks/use-buy-metoken-form.ts
+++ b/src/features/metoken/hooks/use-buy-metoken-form.ts
@@ -1,0 +1,218 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { toast } from 'sonner'
+import { formatUnits, parseUnits } from 'viem'
+import { useQueryClient } from '@tanstack/react-query'
+import { base } from 'viem/chains'
+import { useWalletContext } from '@/context/wallet-context'
+import { useSmartWalletOps } from '@/hooks/use-smart-wallet-ops'
+import { useUsdcBalance } from '@/hooks/use-usdc-balance'
+import { useCrtvaiBalance } from '@/hooks/use-crtvai-balance'
+import {
+  CRTVAI_DECIMALS,
+  USDC_DECIMALS,
+  readCrtvaiCurrentPrice,
+  readCrtvaiMintQuote,
+} from '@/config/metoken'
+import { buildBuyMetokenOps } from '@/features/metoken/api/buy-metoken'
+import { moveUsdcToSmartWallet } from '@/features/metoken/api/move-usdc-to-smart-wallet'
+import { totalUsdcForPurchase } from '@/features/metoken/deps/credits-contract'
+import {
+  getErrorMessage,
+  invalidateUsdcBalance,
+  invalidateWalletTokenBalances,
+} from '@/hooks/invalidate-wallet-balances'
+
+const BASE_CHAIN_ID = base.id
+
+export function useBuyMetokenForm(
+  open: boolean,
+  onOpenChange: (open: boolean) => void,
+  initialUsdcAmount?: string,
+) {
+  const { account, signerAddress, chain, walletClient } = useWalletContext()
+  const queryClient = useQueryClient()
+  const { sendOps, ready: walletReady } = useSmartWalletOps()
+  const { balance: usdcBalance, formatted: usdcFormatted } = useUsdcBalance(chain, account)
+  const { balance: signerUsdcBalance } = useUsdcBalance(chain, signerAddress)
+  const { formatted: crtvaiFormatted, symbol } = useCrtvaiBalance(account)
+
+  const [usdcInput, setUsdcInput] = useState('')
+  const [estimatedOutput, setEstimatedOutput] = useState<string | null>(null)
+  const [currentPrice, setCurrentPrice] = useState<string | null>(null)
+  const [quoting, setQuoting] = useState(false)
+  const [minting, setMinting] = useState(false)
+  const [transferring, setTransferring] = useState(false)
+
+  const onBase = chain?.id === BASE_CHAIN_ID
+
+  const requiredUsdc6 = useMemo(() => {
+    if (!usdcInput || !onBase || !chain?.id) return 0
+    try {
+      const inputUsdc6 = Number(parseUnits(usdcInput, USDC_DECIMALS))
+      return totalUsdcForPurchase(inputUsdc6, chain.id)
+    } catch {
+      return 0
+    }
+  }, [usdcInput, onBase, chain?.id])
+
+  const hasSufficientUsdc = useMemo(() => {
+    if (!usdcInput || !usdcBalance || requiredUsdc6 === 0) return true
+    try {
+      const balanceRaw = parseUnits(usdcBalance, USDC_DECIMALS)
+      return BigInt(requiredUsdc6) <= balanceRaw
+    } catch {
+      return false
+    }
+  }, [usdcInput, usdcBalance, requiredUsdc6])
+
+  const needsEoaTransfer = useMemo(() => {
+    if (!signerUsdcBalance || !usdcBalance || requiredUsdc6 === 0) return false
+    try {
+      const smartRaw = parseUnits(usdcBalance, USDC_DECIMALS)
+      const eoaRaw = parseUnits(signerUsdcBalance, USDC_DECIMALS)
+      return smartRaw < BigInt(requiredUsdc6) && eoaRaw > 0n
+    } catch {
+      return false
+    }
+  }, [signerUsdcBalance, usdcBalance, requiredUsdc6])
+
+  useEffect(() => {
+    if (!open) return
+    if (initialUsdcAmount) setUsdcInput(initialUsdcAmount)
+    if (!onBase) return
+    let cancelled = false
+    void (async () => {
+      try {
+        const price = await readCrtvaiCurrentPrice()
+        if (!cancelled) {
+          setCurrentPrice(formatUnits(price, USDC_DECIMALS))
+        }
+      } catch {
+        // Price read failed — non-fatal
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [open, onBase, initialUsdcAmount])
+
+  useEffect(() => {
+    if (!open || !onBase || !usdcInput) {
+      setEstimatedOutput(null)
+      return
+    }
+    let usdcRaw: bigint
+    try {
+      usdcRaw = parseUnits(usdcInput, USDC_DECIMALS)
+    } catch {
+      setEstimatedOutput(null)
+      return
+    }
+    if (usdcRaw <= 0n) {
+      setEstimatedOutput(null)
+      return
+    }
+    let cancelled = false
+    setQuoting(true)
+    const timer = window.setTimeout(async () => {
+      try {
+        const quote = await readCrtvaiMintQuote(usdcRaw)
+        if (!cancelled) {
+          setEstimatedOutput(formatUnits(quote, CRTVAI_DECIMALS))
+        }
+      } catch {
+        if (!cancelled) setEstimatedOutput(null)
+      } finally {
+        if (!cancelled) setQuoting(false)
+      }
+    }, 400)
+    return () => {
+      cancelled = true
+      window.clearTimeout(timer)
+      if (!cancelled) setQuoting(false)
+    }
+  }, [open, onBase, usdcInput])
+
+  const handleMoveUsdcToSmartWallet = useCallback(async () => {
+    if (!walletClient || !account || !signerAddress || !signerUsdcBalance || !chain) return
+
+    setTransferring(true)
+    try {
+      await moveUsdcToSmartWallet({
+        walletClient,
+        chain,
+        smartAccount: account,
+        signerAddress,
+        signerUsdcBalance,
+        smartUsdcBalance: usdcBalance,
+        requiredUsdc6,
+      })
+      toast.success('USDC moved to smart wallet')
+      invalidateUsdcBalance(queryClient, chain.id, account)
+      invalidateUsdcBalance(queryClient, chain.id, signerAddress)
+    } catch (error) {
+      toast.error(`Transfer failed: ${getErrorMessage(error)}`)
+    } finally {
+      setTransferring(false)
+    }
+  }, [
+    walletClient,
+    account,
+    signerAddress,
+    signerUsdcBalance,
+    usdcBalance,
+    requiredUsdc6,
+    chain,
+    queryClient,
+  ])
+
+  const handleMint = useCallback(async () => {
+    if (!account || !usdcInput || !onBase) return
+    let usdcRaw: bigint
+    try {
+      usdcRaw = parseUnits(usdcInput, USDC_DECIMALS)
+    } catch {
+      toast.error('Invalid USDC amount')
+      return
+    }
+    if (usdcRaw <= 0n) {
+      toast.error('Amount must be greater than 0')
+      return
+    }
+    setMinting(true)
+    try {
+      const { ops } = buildBuyMetokenOps(usdcRaw, account)
+      await sendOps(ops)
+      toast.success(`Minted CRTVAI with ${usdcInput} USDC`)
+      setUsdcInput('')
+      onOpenChange(false)
+      invalidateWalletTokenBalances(queryClient, chain?.id, account)
+    } catch (error) {
+      toast.error(`Mint failed: ${getErrorMessage(error)}`)
+    } finally {
+      setMinting(false)
+    }
+  }, [account, usdcInput, onBase, chain?.id, sendOps, onOpenChange, queryClient])
+
+  const canMint =
+    onBase && walletReady && usdcInput && hasSufficientUsdc && !quoting && !minting && !transferring
+
+  return {
+    usdcInput,
+    setUsdcInput,
+    estimatedOutput,
+    currentPrice,
+    quoting,
+    minting,
+    transferring,
+    onBase,
+    usdcFormatted,
+    crtvaiFormatted,
+    symbol,
+    hasSufficientUsdc,
+    needsEoaTransfer,
+    handleMoveUsdcToSmartWallet,
+    handleMint,
+    canMint,
+  }
+}

--- a/src/features/onramp/components/buy-usdc-onramp-modal.tsx
+++ b/src/features/onramp/components/buy-usdc-onramp-modal.tsx
@@ -36,7 +36,7 @@ interface OnrampPostMessage {
 
 const STEP_DESCRIPTION: Record<Step, string> = {
   details:
-    'Purchase USDC on Base with Apple Pay or Google Pay (debit card via your wallet). Funds arrive in your connected wallet.',
+    'Purchase USDC on Base with Apple Pay or Google Pay (debit card via your wallet). Funds arrive in your smart wallet.',
   verify: 'Enter the one-time codes sent to your phone and email to verify ownership.',
   pay: 'Complete payment with the Coinbase button below. Do not leave this dialog until finished.',
   success: 'Your USDC purchase succeeded.',
@@ -82,8 +82,8 @@ function statusForOnrampEvent(eventName: string, errorMessage?: string): string 
 }
 
 export function BuyUsdcOnrampModal({ open, onOpenChange }: BuyUsdcOnrampModalProps) {
-  const { wallet } = useWalletContext()
-  const address = wallet?.address as `0x${string}` | undefined
+  const { account } = useWalletContext()
+  const address = account
   const {
     initiateVerification,
     submitVerification,

--- a/src/features/wallet/api/build-erc20-transfer-op.ts
+++ b/src/features/wallet/api/build-erc20-transfer-op.ts
@@ -1,0 +1,24 @@
+import { encodeFunctionData, erc20Abi, type Address, type Hex } from 'viem'
+import type { SmartWalletOp } from '@/hooks/use-smart-wallet-ops'
+
+export function buildErc20TransferOp(
+  tokenAddress: Address,
+  recipient: Address,
+  amountWei: bigint,
+): SmartWalletOp {
+  if (amountWei <= 0n) {
+    throw new Error('Transfer amount must be positive')
+  }
+
+  const data = encodeFunctionData({
+    abi: erc20Abi,
+    functionName: 'transfer',
+    args: [recipient, amountWei],
+  }) as Hex
+
+  return {
+    target: tokenAddress,
+    data,
+    value: 0n,
+  }
+}

--- a/src/features/wallet/components/receive-funds-modal.tsx
+++ b/src/features/wallet/components/receive-funds-modal.tsx
@@ -1,0 +1,114 @@
+import { useCallback, useMemo, useState } from 'react'
+import { Copy, ExternalLink, QrCode } from 'lucide-react'
+import { QRCodeSVG } from 'qrcode.react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { useWalletContext } from '@/context/wallet-context'
+
+interface ReceiveFundsModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+function buildEip681Uri(address: string, chainId: number): string {
+  return `ethereum:${address}@${chainId}`
+}
+
+function getExplorerAddressUrl(chainId: number, address: string): string | null {
+  if (chainId === 8453) return `https://basescan.org/address/${address}`
+  if (chainId === 42161) return `https://arbiscan.io/address/${address}`
+  return null
+}
+
+export function ReceiveFundsModal({ open, onOpenChange }: ReceiveFundsModalProps) {
+  const { account, chain } = useWalletContext()
+  const [copied, setCopied] = useState(false)
+
+  const qrValue = useMemo(() => {
+    if (!account || !chain) return ''
+    return buildEip681Uri(account, chain.id)
+  }, [account, chain])
+
+  const explorerUrl = useMemo(() => {
+    if (!account || !chain) return null
+    return getExplorerAddressUrl(chain.id, account)
+  }, [account, chain])
+
+  const handleCopy = useCallback(() => {
+    if (!account) return
+    void navigator.clipboard.writeText(account).then(() => {
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1500)
+    })
+  }, [account])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <QrCode className="h-5 w-5" aria-hidden />
+            Receive funds
+          </DialogTitle>
+          <DialogDescription>
+            Scan with your phone wallet or copy your smart wallet address to receive USDC or CRTVAI.
+          </DialogDescription>
+        </DialogHeader>
+
+        {account && chain ? (
+          <div className="space-y-4 py-2">
+            <div className="flex justify-center rounded-lg border bg-white p-4">
+              <QRCodeSVG value={qrValue} size={192} level="M" includeMargin />
+            </div>
+
+            <div className="space-y-1.5">
+              <p className="text-xs font-medium text-muted-foreground">Smart wallet address</p>
+              <div className="flex items-start gap-2 rounded-md border bg-muted/40 px-3 py-2">
+                <p className="min-w-0 flex-1 break-all font-mono text-xs text-foreground">
+                  {account}
+                </p>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 shrink-0"
+                  onClick={handleCopy}
+                  aria-label="Copy address"
+                >
+                  <Copy className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+              {copied && <p className="text-xs text-emerald-400">Copied</p>}
+            </div>
+
+            <p className="text-xs text-amber-200/90">
+              Send only on {chain.name}. Funds sent on the wrong network may be lost.
+            </p>
+
+            {explorerUrl && (
+              <a
+                href={explorerUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 text-xs text-primary hover:underline"
+              >
+                View on explorer
+                <ExternalLink className="h-3 w-3" aria-hidden />
+              </a>
+            )}
+          </div>
+        ) : (
+          <p className="py-4 text-sm text-muted-foreground">
+            Connect your wallet to receive funds.
+          </p>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/features/wallet/components/send-token-modal.tsx
+++ b/src/features/wallet/components/send-token-modal.tsx
@@ -1,0 +1,303 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { ArrowUpRight, Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { formatUnits, isAddress, parseUnits } from 'viem'
+import { useQueryClient } from '@tanstack/react-query'
+import { base } from 'viem/chains'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useWalletContext } from '@/context/wallet-context'
+import { useSmartWalletOps } from '@/hooks/use-smart-wallet-ops'
+import { useUsdcBalance } from '@/hooks/use-usdc-balance'
+import { useCrtvaiBalance } from '@/hooks/use-crtvai-balance'
+import { USDC_ADDRESS_BY_CHAIN_ID } from '@/config/chains'
+import { CRTVAI_DECIMALS, CRTVAI_METOKEN_ADDRESS, USDC_DECIMALS } from '@/config/metoken'
+import { getPurchaseGasBufferUsdc6 } from '@/config/gas-sponsorship'
+import { buildErc20TransferOp } from '@/features/wallet/api/build-erc20-transfer-op'
+import { cn } from '@/shared/ui/cn'
+
+type SendToken = 'usdc' | 'crtvai'
+
+interface SendTokenModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const BASE_CHAIN_ID = base.id
+
+function truncateTxHash(hash: string): string {
+  return `${hash.slice(0, 8)}…${hash.slice(-6)}`
+}
+
+export function SendTokenModal({ open, onOpenChange }: SendTokenModalProps) {
+  const { account, chain } = useWalletContext()
+  const queryClient = useQueryClient()
+  const { sendOps, ready: walletReady } = useSmartWalletOps()
+  const { balance: usdcBalance, formatted: usdcFormatted } = useUsdcBalance(chain, account)
+  const {
+    balance: crtvaiBalance,
+    formatted: crtvaiFormatted,
+    symbol: crtvaiSymbol,
+  } = useCrtvaiBalance(account)
+
+  const [token, setToken] = useState<SendToken>('usdc')
+  const [recipient, setRecipient] = useState('')
+  const [amountInput, setAmountInput] = useState('')
+  const [sending, setSending] = useState(false)
+
+  const onBase = chain?.id === BASE_CHAIN_ID
+  const crtvaiAvailable = onBase
+
+  useEffect(() => {
+    if (!open) {
+      setRecipient('')
+      setAmountInput('')
+      setSending(false)
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (token === 'crtvai' && !crtvaiAvailable) {
+      setToken('usdc')
+    }
+  }, [token, crtvaiAvailable])
+
+  const decimals = token === 'usdc' ? USDC_DECIMALS : CRTVAI_DECIMALS
+  const balanceFormatted = token === 'usdc' ? usdcFormatted : crtvaiFormatted
+  const tokenSymbol = token === 'usdc' ? 'USDC' : crtvaiSymbol
+
+  const gasBufferUsdc6 = chain?.id ? getPurchaseGasBufferUsdc6(chain.id) : 0
+
+  const maxSendableWei = useMemo(() => {
+    if (token === 'crtvai') {
+      return crtvaiBalance ?? 0n
+    }
+    if (!usdcBalance) return 0n
+    try {
+      const balanceRaw = parseUnits(usdcBalance, USDC_DECIMALS)
+      const buffer = BigInt(gasBufferUsdc6)
+      return balanceRaw > buffer ? balanceRaw - buffer : 0n
+    } catch {
+      return 0n
+    }
+  }, [token, crtvaiBalance, usdcBalance, gasBufferUsdc6])
+
+  const amountWei = useMemo(() => {
+    if (!amountInput) return null
+    try {
+      const raw = parseUnits(amountInput, decimals)
+      return raw > 0n ? raw : null
+    } catch {
+      return null
+    }
+  }, [amountInput, decimals])
+
+  const recipientValid = isAddress(recipient)
+  const sendToSelf = recipientValid && account && recipient.toLowerCase() === account.toLowerCase()
+
+  const insufficientBalance = useMemo(() => {
+    if (!amountWei) return false
+    if (token === 'crtvai') {
+      return (crtvaiBalance ?? 0n) < amountWei
+    }
+    if (!usdcBalance) return true
+    try {
+      const balanceRaw = parseUnits(usdcBalance, USDC_DECIMALS)
+      const required = amountWei + BigInt(gasBufferUsdc6)
+      return balanceRaw < required
+    } catch {
+      return true
+    }
+  }, [amountWei, token, crtvaiBalance, usdcBalance, gasBufferUsdc6])
+
+  const handleMax = useCallback(() => {
+    if (maxSendableWei <= 0n) {
+      setAmountInput('0')
+      return
+    }
+    setAmountInput(formatUnits(maxSendableWei, decimals))
+  }, [maxSendableWei, decimals])
+
+  const handleSend = useCallback(async () => {
+    if (!account || !chain || !amountWei || !recipientValid || sendToSelf) return
+
+    const tokenAddress =
+      token === 'usdc' ? USDC_ADDRESS_BY_CHAIN_ID[chain.id] : CRTVAI_METOKEN_ADDRESS
+    if (!tokenAddress) {
+      toast.error('Token not available on this network')
+      return
+    }
+
+    setSending(true)
+    try {
+      const op = buildErc20TransferOp(tokenAddress, recipient, amountWei)
+      const { txHash } = await sendOps([op])
+      toast.success(`Sent ${amountInput} ${tokenSymbol} · ${truncateTxHash(txHash)}`)
+      setRecipient('')
+      setAmountInput('')
+      onOpenChange(false)
+      void queryClient.invalidateQueries({ queryKey: ['usdc-balance', chain.id, account] })
+      void queryClient.invalidateQueries({ queryKey: ['crtvai-balance', account] })
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e)
+      toast.error(`Send failed: ${msg}`)
+    } finally {
+      setSending(false)
+    }
+  }, [
+    account,
+    chain,
+    amountWei,
+    recipient,
+    recipientValid,
+    sendToSelf,
+    token,
+    sendOps,
+    amountInput,
+    tokenSymbol,
+    onOpenChange,
+    queryClient,
+  ])
+
+  const canSend =
+    walletReady &&
+    recipientValid &&
+    !sendToSelf &&
+    amountWei !== null &&
+    !insufficientBalance &&
+    !sending &&
+    (token !== 'crtvai' || onBase)
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <ArrowUpRight className="h-5 w-5" aria-hidden />
+            Send tokens
+          </DialogTitle>
+          <DialogDescription>
+            Send USDC or CRTVAI from your smart wallet to another address.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          <div className="space-y-1.5">
+            <label htmlFor="send-token" className="text-sm font-medium">
+              Token
+            </label>
+            <Select
+              value={token}
+              onValueChange={(value) => setToken(value as SendToken)}
+              disabled={sending}
+            >
+              <SelectTrigger id="send-token" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="usdc">USDC</SelectItem>
+                {crtvaiAvailable && <SelectItem value="crtvai">CRTVAI</SelectItem>}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-muted-foreground">Available:</span>
+            <span className="font-medium">
+              {balanceFormatted} {tokenSymbol}
+            </span>
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="send-recipient" className="text-sm font-medium">
+              Recipient address
+            </label>
+            <Input
+              id="send-recipient"
+              placeholder="0x…"
+              value={recipient}
+              onChange={(e) => setRecipient(e.target.value.trim())}
+              disabled={sending}
+              className="font-mono text-xs"
+            />
+            {recipient && !recipientValid && (
+              <p className="text-xs text-destructive">Enter a valid Ethereum address.</p>
+            )}
+            {sendToSelf && (
+              <p className="text-xs text-destructive">Cannot send to your own wallet.</p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between">
+              <label htmlFor="send-amount" className="text-sm font-medium">
+                Amount
+              </label>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-6 px-2 text-xs"
+                onClick={handleMax}
+                disabled={sending || maxSendableWei <= 0n}
+              >
+                Max
+              </Button>
+            </div>
+            <Input
+              id="send-amount"
+              type="number"
+              min="0"
+              step={token === 'usdc' ? '0.01' : '0.0001'}
+              placeholder="0.00"
+              value={amountInput}
+              onChange={(e) => setAmountInput(e.target.value)}
+              disabled={sending}
+            />
+            {token === 'usdc' && gasBufferUsdc6 > 0 && (
+              <p className="text-xs text-muted-foreground">
+                A small USDC reserve is kept for transaction gas.
+              </p>
+            )}
+            {insufficientBalance && amountInput && (
+              <p className="text-xs text-destructive">Insufficient balance.</p>
+            )}
+          </div>
+
+          {!onBase && token === 'crtvai' && (
+            <p className="text-xs text-amber-500">Switch to Base network to send CRTVAI.</p>
+          )}
+
+          <Button
+            onClick={() => void handleSend()}
+            disabled={!canSend}
+            className={cn('w-full', sending && 'opacity-80')}
+          >
+            {sending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Sending…
+              </>
+            ) : (
+              `Send ${tokenSymbol}`
+            )}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/features/wallet/components/send-token-modal.tsx
+++ b/src/features/wallet/components/send-token-modal.tsx
@@ -1,9 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
 import { ArrowUpRight, Loader2 } from 'lucide-react'
-import { toast } from 'sonner'
-import { formatUnits, isAddress, parseUnits } from 'viem'
-import { useQueryClient } from '@tanstack/react-query'
-import { base } from 'viem/chains'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -20,167 +15,17 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { useWalletContext } from '@/context/wallet-context'
-import { useSmartWalletOps } from '@/hooks/use-smart-wallet-ops'
-import { useUsdcBalance } from '@/hooks/use-usdc-balance'
-import { useCrtvaiBalance } from '@/hooks/use-crtvai-balance'
-import { USDC_ADDRESS_BY_CHAIN_ID } from '@/config/chains'
-import { CRTVAI_DECIMALS, CRTVAI_METOKEN_ADDRESS, USDC_DECIMALS } from '@/config/metoken'
-import { getPurchaseGasBufferUsdc6 } from '@/config/gas-sponsorship'
-import { buildErc20TransferOp } from '@/features/wallet/api/build-erc20-transfer-op'
+import { useSendTokenForm } from '@/features/wallet/hooks/use-send-token-form'
+import type { SendToken } from '@/features/wallet/lib/send-token-math'
 import { cn } from '@/shared/ui/cn'
-
-type SendToken = 'usdc' | 'crtvai'
 
 interface SendTokenModalProps {
   open: boolean
   onOpenChange: (open: boolean) => void
 }
 
-const BASE_CHAIN_ID = base.id
-
-function truncateTxHash(hash: string): string {
-  return `${hash.slice(0, 8)}…${hash.slice(-6)}`
-}
-
 export function SendTokenModal({ open, onOpenChange }: SendTokenModalProps) {
-  const { account, chain } = useWalletContext()
-  const queryClient = useQueryClient()
-  const { sendOps, ready: walletReady } = useSmartWalletOps()
-  const { balance: usdcBalance, formatted: usdcFormatted } = useUsdcBalance(chain, account)
-  const {
-    balance: crtvaiBalance,
-    formatted: crtvaiFormatted,
-    symbol: crtvaiSymbol,
-  } = useCrtvaiBalance(account)
-
-  const [token, setToken] = useState<SendToken>('usdc')
-  const [recipient, setRecipient] = useState('')
-  const [amountInput, setAmountInput] = useState('')
-  const [sending, setSending] = useState(false)
-
-  const onBase = chain?.id === BASE_CHAIN_ID
-  const crtvaiAvailable = onBase
-
-  useEffect(() => {
-    if (!open) {
-      setRecipient('')
-      setAmountInput('')
-      setSending(false)
-    }
-  }, [open])
-
-  useEffect(() => {
-    if (token === 'crtvai' && !crtvaiAvailable) {
-      setToken('usdc')
-    }
-  }, [token, crtvaiAvailable])
-
-  const decimals = token === 'usdc' ? USDC_DECIMALS : CRTVAI_DECIMALS
-  const balanceFormatted = token === 'usdc' ? usdcFormatted : crtvaiFormatted
-  const tokenSymbol = token === 'usdc' ? 'USDC' : crtvaiSymbol
-
-  const gasBufferUsdc6 = chain?.id ? getPurchaseGasBufferUsdc6(chain.id) : 0
-
-  const maxSendableWei = useMemo(() => {
-    if (token === 'crtvai') {
-      return crtvaiBalance ?? 0n
-    }
-    if (!usdcBalance) return 0n
-    try {
-      const balanceRaw = parseUnits(usdcBalance, USDC_DECIMALS)
-      const buffer = BigInt(gasBufferUsdc6)
-      return balanceRaw > buffer ? balanceRaw - buffer : 0n
-    } catch {
-      return 0n
-    }
-  }, [token, crtvaiBalance, usdcBalance, gasBufferUsdc6])
-
-  const amountWei = useMemo(() => {
-    if (!amountInput) return null
-    try {
-      const raw = parseUnits(amountInput, decimals)
-      return raw > 0n ? raw : null
-    } catch {
-      return null
-    }
-  }, [amountInput, decimals])
-
-  const recipientValid = isAddress(recipient)
-  const sendToSelf = recipientValid && account && recipient.toLowerCase() === account.toLowerCase()
-
-  const insufficientBalance = useMemo(() => {
-    if (!amountWei) return false
-    if (token === 'crtvai') {
-      return (crtvaiBalance ?? 0n) < amountWei
-    }
-    if (!usdcBalance) return true
-    try {
-      const balanceRaw = parseUnits(usdcBalance, USDC_DECIMALS)
-      const required = amountWei + BigInt(gasBufferUsdc6)
-      return balanceRaw < required
-    } catch {
-      return true
-    }
-  }, [amountWei, token, crtvaiBalance, usdcBalance, gasBufferUsdc6])
-
-  const handleMax = useCallback(() => {
-    if (maxSendableWei <= 0n) {
-      setAmountInput('0')
-      return
-    }
-    setAmountInput(formatUnits(maxSendableWei, decimals))
-  }, [maxSendableWei, decimals])
-
-  const handleSend = useCallback(async () => {
-    if (!account || !chain || !amountWei || !recipientValid || sendToSelf) return
-
-    const tokenAddress =
-      token === 'usdc' ? USDC_ADDRESS_BY_CHAIN_ID[chain.id] : CRTVAI_METOKEN_ADDRESS
-    if (!tokenAddress) {
-      toast.error('Token not available on this network')
-      return
-    }
-
-    setSending(true)
-    try {
-      const op = buildErc20TransferOp(tokenAddress, recipient, amountWei)
-      const { txHash } = await sendOps([op])
-      toast.success(`Sent ${amountInput} ${tokenSymbol} · ${truncateTxHash(txHash)}`)
-      setRecipient('')
-      setAmountInput('')
-      onOpenChange(false)
-      void queryClient.invalidateQueries({ queryKey: ['usdc-balance', chain.id, account] })
-      void queryClient.invalidateQueries({ queryKey: ['crtvai-balance', account] })
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e)
-      toast.error(`Send failed: ${msg}`)
-    } finally {
-      setSending(false)
-    }
-  }, [
-    account,
-    chain,
-    amountWei,
-    recipient,
-    recipientValid,
-    sendToSelf,
-    token,
-    sendOps,
-    amountInput,
-    tokenSymbol,
-    onOpenChange,
-    queryClient,
-  ])
-
-  const canSend =
-    walletReady &&
-    recipientValid &&
-    !sendToSelf &&
-    amountWei !== null &&
-    !insufficientBalance &&
-    !sending &&
-    (token !== 'crtvai' || onBase)
+  const form = useSendTokenForm(open, onOpenChange)
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -201,16 +46,16 @@ export function SendTokenModal({ open, onOpenChange }: SendTokenModalProps) {
               Token
             </label>
             <Select
-              value={token}
-              onValueChange={(value) => setToken(value as SendToken)}
-              disabled={sending}
+              value={form.token}
+              onValueChange={(value) => form.setToken(value as SendToken)}
+              disabled={form.sending}
             >
               <SelectTrigger id="send-token" className="w-full">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="usdc">USDC</SelectItem>
-                {crtvaiAvailable && <SelectItem value="crtvai">CRTVAI</SelectItem>}
+                {form.crtvaiAvailable && <SelectItem value="crtvai">CRTVAI</SelectItem>}
               </SelectContent>
             </Select>
           </div>
@@ -218,7 +63,7 @@ export function SendTokenModal({ open, onOpenChange }: SendTokenModalProps) {
           <div className="flex items-center justify-between text-sm">
             <span className="text-muted-foreground">Available:</span>
             <span className="font-medium">
-              {balanceFormatted} {tokenSymbol}
+              {form.balanceFormatted} {form.tokenSymbol}
             </span>
           </div>
 
@@ -229,15 +74,15 @@ export function SendTokenModal({ open, onOpenChange }: SendTokenModalProps) {
             <Input
               id="send-recipient"
               placeholder="0x…"
-              value={recipient}
-              onChange={(e) => setRecipient(e.target.value.trim())}
-              disabled={sending}
+              value={form.recipient}
+              onChange={(e) => form.setRecipient(e.target.value.trim())}
+              disabled={form.sending}
               className="font-mono text-xs"
             />
-            {recipient && !recipientValid && (
+            {form.recipient && !form.recipientValid && (
               <p className="text-xs text-destructive">Enter a valid Ethereum address.</p>
             )}
-            {sendToSelf && (
+            {form.sendToSelf && (
               <p className="text-xs text-destructive">Cannot send to your own wallet.</p>
             )}
           </div>
@@ -252,8 +97,8 @@ export function SendTokenModal({ open, onOpenChange }: SendTokenModalProps) {
                 variant="ghost"
                 size="sm"
                 className="h-6 px-2 text-xs"
-                onClick={handleMax}
-                disabled={sending || maxSendableWei <= 0n}
+                onClick={form.handleMax}
+                disabled={form.sending || form.maxSendableWei <= 0n}
               >
                 Max
               </Button>
@@ -262,38 +107,38 @@ export function SendTokenModal({ open, onOpenChange }: SendTokenModalProps) {
               id="send-amount"
               type="number"
               min="0"
-              step={token === 'usdc' ? '0.01' : '0.0001'}
+              step={form.token === 'usdc' ? '0.01' : '0.0001'}
               placeholder="0.00"
-              value={amountInput}
-              onChange={(e) => setAmountInput(e.target.value)}
-              disabled={sending}
+              value={form.amountInput}
+              onChange={(e) => form.setAmountInput(e.target.value)}
+              disabled={form.sending}
             />
-            {token === 'usdc' && gasBufferUsdc6 > 0 && (
+            {form.token === 'usdc' && form.gasBufferUsdc6 > 0 && (
               <p className="text-xs text-muted-foreground">
                 A small USDC reserve is kept for transaction gas.
               </p>
             )}
-            {insufficientBalance && amountInput && (
+            {form.insufficientBalance && form.amountInput && (
               <p className="text-xs text-destructive">Insufficient balance.</p>
             )}
           </div>
 
-          {!onBase && token === 'crtvai' && (
+          {!form.onBase && form.token === 'crtvai' && (
             <p className="text-xs text-amber-500">Switch to Base network to send CRTVAI.</p>
           )}
 
           <Button
-            onClick={() => void handleSend()}
-            disabled={!canSend}
-            className={cn('w-full', sending && 'opacity-80')}
+            onClick={() => void form.handleSend()}
+            disabled={!form.canSend}
+            className={cn('w-full', form.sending && 'opacity-80')}
           >
-            {sending ? (
+            {form.sending ? (
               <>
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                 Sending…
               </>
             ) : (
-              `Send ${tokenSymbol}`
+              `Send ${form.tokenSymbol}`
             )}
           </Button>
         </div>

--- a/src/features/wallet/hooks/use-send-token-form.ts
+++ b/src/features/wallet/hooks/use-send-token-form.ts
@@ -1,0 +1,159 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { toast } from 'sonner'
+import { isAddress } from 'viem'
+import { useQueryClient } from '@tanstack/react-query'
+import { base } from 'viem/chains'
+import { useWalletContext } from '@/context/wallet-context'
+import { useSmartWalletOps } from '@/hooks/use-smart-wallet-ops'
+import { useUsdcBalance } from '@/hooks/use-usdc-balance'
+import { useCrtvaiBalance } from '@/hooks/use-crtvai-balance'
+import { getErrorMessage, invalidateWalletTokenBalances } from '@/hooks/invalidate-wallet-balances'
+import { USDC_ADDRESS_BY_CHAIN_ID } from '@/config/chains'
+import { CRTVAI_DECIMALS, CRTVAI_METOKEN_ADDRESS, USDC_DECIMALS } from '@/config/metoken'
+import { getPurchaseGasBufferUsdc6 } from '@/config/gas-sponsorship'
+import { buildErc20TransferOp } from '@/features/wallet/api/build-erc20-transfer-op'
+import {
+  computeMaxSendableWei,
+  formatMaxSendAmount,
+  hasInsufficientSendBalance,
+  parsePositiveAmountWei,
+  type SendToken,
+} from '@/features/wallet/lib/send-token-math'
+
+const BASE_CHAIN_ID = base.id
+
+function truncateTxHash(hash: string): string {
+  return `${hash.slice(0, 8)}…${hash.slice(-6)}`
+}
+
+export function useSendTokenForm(open: boolean, onOpenChange: (open: boolean) => void) {
+  const { account, chain } = useWalletContext()
+  const queryClient = useQueryClient()
+  const { sendOps, ready: walletReady } = useSmartWalletOps()
+  const { balance: usdcBalance, formatted: usdcFormatted } = useUsdcBalance(chain, account)
+  const {
+    balance: crtvaiBalance,
+    formatted: crtvaiFormatted,
+    symbol: crtvaiSymbol,
+  } = useCrtvaiBalance(account)
+
+  const [token, setToken] = useState<SendToken>('usdc')
+  const [recipient, setRecipient] = useState('')
+  const [amountInput, setAmountInput] = useState('')
+  const [sending, setSending] = useState(false)
+
+  const onBase = chain?.id === BASE_CHAIN_ID
+  const crtvaiAvailable = onBase
+  const decimals = token === 'usdc' ? USDC_DECIMALS : CRTVAI_DECIMALS
+  const balanceFormatted = token === 'usdc' ? usdcFormatted : crtvaiFormatted
+  const tokenSymbol = token === 'usdc' ? 'USDC' : crtvaiSymbol
+  const gasBufferUsdc6 = chain?.id ? getPurchaseGasBufferUsdc6(chain.id) : 0
+
+  useEffect(() => {
+    if (!open) {
+      setRecipient('')
+      setAmountInput('')
+      setSending(false)
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (token === 'crtvai' && !crtvaiAvailable) {
+      setToken('usdc')
+    }
+  }, [token, crtvaiAvailable])
+
+  const maxSendableWei = useMemo(
+    () => computeMaxSendableWei(token, usdcBalance, crtvaiBalance, gasBufferUsdc6),
+    [token, crtvaiBalance, usdcBalance, gasBufferUsdc6],
+  )
+
+  const amountWei = useMemo(
+    () => parsePositiveAmountWei(amountInput, decimals),
+    [amountInput, decimals],
+  )
+
+  const recipientValid = isAddress(recipient)
+  const sendToSelf = recipientValid && account && recipient.toLowerCase() === account.toLowerCase()
+  const insufficientBalance = useMemo(
+    () =>
+      amountWei
+        ? hasInsufficientSendBalance(token, amountWei, usdcBalance, crtvaiBalance, gasBufferUsdc6)
+        : false,
+    [amountWei, token, crtvaiBalance, usdcBalance, gasBufferUsdc6],
+  )
+
+  const handleMax = useCallback(() => {
+    setAmountInput(formatMaxSendAmount(maxSendableWei, decimals))
+  }, [maxSendableWei, decimals])
+
+  const handleSend = useCallback(async () => {
+    if (!account || !chain || !amountWei || !recipientValid || sendToSelf) return
+
+    const tokenAddress =
+      token === 'usdc' ? USDC_ADDRESS_BY_CHAIN_ID[chain.id] : CRTVAI_METOKEN_ADDRESS
+    if (!tokenAddress) {
+      toast.error('Token not available on this network')
+      return
+    }
+
+    setSending(true)
+    try {
+      const op = buildErc20TransferOp(tokenAddress, recipient, amountWei)
+      const { txHash } = await sendOps([op])
+      toast.success(`Sent ${amountInput} ${tokenSymbol} · ${truncateTxHash(txHash)}`)
+      setRecipient('')
+      setAmountInput('')
+      onOpenChange(false)
+      invalidateWalletTokenBalances(queryClient, chain.id, account)
+    } catch (error) {
+      toast.error(`Send failed: ${getErrorMessage(error)}`)
+    } finally {
+      setSending(false)
+    }
+  }, [
+    account,
+    chain,
+    amountWei,
+    recipient,
+    recipientValid,
+    sendToSelf,
+    token,
+    sendOps,
+    amountInput,
+    tokenSymbol,
+    onOpenChange,
+    queryClient,
+  ])
+
+  const canSend =
+    walletReady &&
+    recipientValid &&
+    !sendToSelf &&
+    amountWei !== null &&
+    !insufficientBalance &&
+    !sending &&
+    (token !== 'crtvai' || onBase)
+
+  return {
+    token,
+    setToken,
+    recipient,
+    setRecipient,
+    amountInput,
+    setAmountInput,
+    sending,
+    crtvaiAvailable,
+    balanceFormatted,
+    tokenSymbol,
+    gasBufferUsdc6,
+    maxSendableWei,
+    recipientValid,
+    sendToSelf,
+    insufficientBalance,
+    onBase,
+    handleMax,
+    handleSend,
+    canSend,
+  }
+}

--- a/src/features/wallet/index.ts
+++ b/src/features/wallet/index.ts
@@ -1,0 +1,3 @@
+export { ReceiveFundsModal } from './components/receive-funds-modal'
+export { SendTokenModal } from './components/send-token-modal'
+export { buildErc20TransferOp } from './api/build-erc20-transfer-op'

--- a/src/features/wallet/index.ts
+++ b/src/features/wallet/index.ts
@@ -1,3 +1,2 @@
 export { ReceiveFundsModal } from './components/receive-funds-modal'
 export { SendTokenModal } from './components/send-token-modal'
-export { buildErc20TransferOp } from './api/build-erc20-transfer-op'

--- a/src/features/wallet/lib/send-token-math.ts
+++ b/src/features/wallet/lib/send-token-math.ts
@@ -1,0 +1,57 @@
+import { formatUnits, parseUnits } from 'viem'
+import { USDC_DECIMALS } from '@/config/metoken'
+
+export type SendToken = 'usdc' | 'crtvai'
+
+export function parsePositiveAmountWei(amountInput: string, decimals: number): bigint | null {
+  if (!amountInput) return null
+  try {
+    const raw = parseUnits(amountInput, decimals)
+    return raw > 0n ? raw : null
+  } catch {
+    return null
+  }
+}
+
+export function computeMaxSendableWei(
+  token: SendToken,
+  usdcBalance: string | null,
+  crtvaiBalance: bigint | null,
+  gasBufferUsdc6: number,
+): bigint {
+  if (token === 'crtvai') {
+    return crtvaiBalance ?? 0n
+  }
+  if (!usdcBalance) return 0n
+  try {
+    const balanceRaw = parseUnits(usdcBalance, USDC_DECIMALS)
+    const buffer = BigInt(gasBufferUsdc6)
+    return balanceRaw > buffer ? balanceRaw - buffer : 0n
+  } catch {
+    return 0n
+  }
+}
+
+export function hasInsufficientSendBalance(
+  token: SendToken,
+  amountWei: bigint,
+  usdcBalance: string | null,
+  crtvaiBalance: bigint | null,
+  gasBufferUsdc6: number,
+): boolean {
+  if (token === 'crtvai') {
+    return (crtvaiBalance ?? 0n) < amountWei
+  }
+  if (!usdcBalance) return true
+  try {
+    const balanceRaw = parseUnits(usdcBalance, USDC_DECIMALS)
+    return balanceRaw < amountWei + BigInt(gasBufferUsdc6)
+  } catch {
+    return true
+  }
+}
+
+export function formatMaxSendAmount(maxSendableWei: bigint, decimals: number): string {
+  if (maxSendableWei <= 0n) return '0'
+  return formatUnits(maxSendableWei, decimals)
+}

--- a/src/hooks/invalidate-wallet-balances.ts
+++ b/src/hooks/invalidate-wallet-balances.ts
@@ -1,0 +1,24 @@
+import type { QueryClient } from '@tanstack/react-query'
+
+export function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export function invalidateWalletTokenBalances(
+  queryClient: QueryClient,
+  chainId: number | undefined,
+  account: `0x${string}` | undefined,
+): void {
+  if (!account) return
+  void queryClient.invalidateQueries({ queryKey: ['usdc-balance', chainId, account] })
+  void queryClient.invalidateQueries({ queryKey: ['crtvai-balance', account] })
+}
+
+export function invalidateUsdcBalance(
+  queryClient: QueryClient,
+  chainId: number | undefined,
+  address: `0x${string}` | undefined,
+): void {
+  if (!address) return
+  void queryClient.invalidateQueries({ queryKey: ['usdc-balance', chainId, address] })
+}

--- a/src/hooks/use-smart-wallet-ops.ts
+++ b/src/hooks/use-smart-wallet-ops.ts
@@ -20,15 +20,17 @@ export interface SendOpsResult {
 }
 
 export function useSmartWalletOps() {
-  const { smartWalletClient, chain } = useWalletContext()
+  const { smartWalletClient, chain, account } = useWalletContext()
 
   const sendOps = useCallback(
     async (ops: SmartWalletOp[]): Promise<SendOpsResult> => {
-      if (!smartWalletClient) throw new Error('Wallet not ready')
+      if (!smartWalletClient) throw new Error('Smart wallet not ready')
+      if (!account) throw new Error('Smart account not provisioned yet')
 
       const capabilities = chain ? buildGasPaymasterCapabilities(chain.id) : null
 
       let prepared = await smartWalletClient.prepareCalls({
+        account,
         calls: ops.map((op) => ({
           to: op.target,
           data: op.data,
@@ -43,6 +45,7 @@ export function useSmartWalletOps() {
         log.warn('Paymaster requested ERC-20 permit; signing and re-preparing')
         const signature = await smartWalletClient.signSignatureRequest(prepared.signatureRequest)
         prepared = await smartWalletClient.prepareCalls({
+          account,
           calls: prepared.modifiedRequest.calls,
           capabilities: prepared.modifiedRequest.capabilities,
           paymasterPermitSignature: signature,
@@ -65,8 +68,8 @@ export function useSmartWalletOps() {
       if (!txHash) throw new Error('Transaction confirmed without a receipt')
       return { txHash, txHashes }
     },
-    [smartWalletClient, chain],
+    [smartWalletClient, chain, account],
   )
 
-  return { sendOps, ready: Boolean(smartWalletClient) }
+  return { sendOps, ready: Boolean(smartWalletClient && account) }
 }


### PR DESCRIPTION
## Summary
- Add **Receive** (QR + copy) and **Send** (USDC / CRTVAI) flows in the wallet dropdown so desktop users can fund from a phone wallet and transfer tokens to other addresses.
- Fix smart wallet provisioning: use Alchemy `requestAccount` for the ERC-4337 smart account (balances, onramp, and on-chain ops) instead of the Privy signer EOA, including USDC signer→smart-wallet funding before CRTVAI mint.
- Remove misleading Director pro-member pricing copy ("Pro members pay half") from the empty state, invoice card, and session packs.

## Test plan
- [ ] Connect wallet on desktop → wallet menu → **Receive** → QR scans to smart wallet on Base; copy address works
- [ ] Switch network → Receive QR updates EIP-681 chain id
- [ ] **Send** USDC to a test address → tx confirms, balance refreshes
- [ ] **Send** CRTVAI on Base → tx confirms; CRTVAI hidden on Arbitrum
- [ ] Buy USDC onramp lands in smart wallet (not signer)
- [ ] Buy CRTVAI when USDC is on signer → "Move USDC to smart wallet" flow works, then mint succeeds
- [ ] Director tab: no pro/half-price messaging in empty state, invoice, or session packs


Made with [Cursor](https://cursor.com)