### PR TITLE
fix(wallet): avoid EIP-7702 signAuthorization on CRTVAI mint (#86)

### DIFF
--- a/src/context/wallet-context.tsx
+++ b/src/context/wallet-context.tsx
@@ -64,6 +64,9 @@ const PRIVY_APP_ID = import.meta.env.VITE_PRIVY_APP_ID
 const PRIVY_CLIENT_ID = import.meta.env.VITE_PRIVY_CLIENT_ID
 const isPrivyConfigured = Boolean(PRIVY_APP_ID)
 
+/** Stable Alchemy smart-account id — forces ERC-4337 (sma-b), not EIP-7702. */
+const PIXELS_SMART_ACCOUNT_ID = 'pixels-sca'
+
 function WalletContextInner({ children }: { children: ReactNode }) {
   const { ready, authenticated, user, login, logout, connectWallet, getAccessToken } = usePrivy()
   const { wallets, ready: walletsReady } = useWallets()
@@ -116,8 +119,9 @@ function WalletContextInner({ children }: { children: ReactNode }) {
     }
   }, [activeWallet, activeWallet?.chainId, authenticated, chain])
 
-  // Bootstrap client (no account) — used only to call requestAccount and avoid EIP-7702.
-  const bootstrapSmartWalletClient = useMemo<SmartWalletClient | null>(() => {
+  // Single smart wallet client — requestAccount runs on this instance so internal
+  // account state stays aligned with prepareCalls/sendCalls (avoids EIP-7702).
+  const smartWalletClient = useMemo<SmartWalletClient | null>(() => {
     if (!walletClient || !ALCHEMY_API_KEY) return null
     return createSmartWalletClient({
       transport: alchemyWalletTransport({ apiKey: ALCHEMY_API_KEY }),
@@ -128,14 +132,18 @@ function WalletContextInner({ children }: { children: ReactNode }) {
   }, [walletClient, chain])
 
   useEffect(() => {
-    if (!bootstrapSmartWalletClient || !signerAddress) {
+    if (!smartWalletClient || !signerAddress) {
       setSmartAccountAddress(undefined)
       return
     }
     let cancelled = false
     void (async () => {
       try {
-        const smartAccount = await bootstrapSmartWalletClient.requestAccount({ signerAddress })
+        const smartAccount = await smartWalletClient.requestAccount({
+          signerAddress,
+          id: PIXELS_SMART_ACCOUNT_ID,
+          creationHint: { accountType: 'sma-b' },
+        })
         if (!cancelled) {
           setSmartAccountAddress(smartAccount.address)
           setError(null)
@@ -150,18 +158,7 @@ function WalletContextInner({ children }: { children: ReactNode }) {
     return () => {
       cancelled = true
     }
-  }, [bootstrapSmartWalletClient, signerAddress])
-
-  const smartWalletClient = useMemo<SmartWalletClient | null>(() => {
-    if (!walletClient || !ALCHEMY_API_KEY || !smartAccountAddress) return null
-    return createSmartWalletClient({
-      transport: alchemyWalletTransport({ apiKey: ALCHEMY_API_KEY }),
-      chain,
-      signer: walletClient as never,
-      account: smartAccountAddress,
-      ...(ALCHEMY_POLICY_ID ? { paymaster: { policyId: ALCHEMY_POLICY_ID } } : {}),
-    }).extend(swapActions) as SmartWalletClient
-  }, [walletClient, chain, smartAccountAddress])
+  }, [smartWalletClient, signerAddress])
 
   const connect = useCallback(() => {
     setError(null)
@@ -186,7 +183,9 @@ function WalletContextInner({ children }: { children: ReactNode }) {
   )
 
   const walletReady =
-    ready && walletsReady && (!authenticated || !ALCHEMY_API_KEY || Boolean(smartAccountAddress))
+    ready &&
+    walletsReady &&
+    (!authenticated || !ALCHEMY_API_KEY || Boolean(smartWalletClient && smartAccountAddress))
 
   const value = useMemo(
     () => ({

--- a/src/features/metoken/hooks/use-buy-metoken-form.ts
+++ b/src/features/metoken/hooks/use-buy-metoken-form.ts
@@ -14,7 +14,7 @@ import {
   readCrtvaiMintQuote,
 } from '@/config/metoken'
 import { buildBuyMetokenOps } from '@/features/metoken/api/buy-metoken'
-import { moveUsdcToSmartWallet } from '@/features/metoken/api/move-usdc-to-smart-wallet'
+import { moveUsdcToSmartWallet } from '@/hooks/usdc-wallet-transfers'
 import { totalUsdcForPurchase } from '@/features/metoken/deps/credits-contract'
 import {
   getErrorMessage,

--- a/src/features/wallet/api/execute-token-send.ts
+++ b/src/features/wallet/api/execute-token-send.ts
@@ -1,0 +1,65 @@
+import type { Chain, WalletClient } from 'viem'
+import type { Address, Hex } from 'viem'
+import { USDC_ADDRESS_BY_CHAIN_ID } from '@/config/chains'
+import { CRTVAI_METOKEN_ADDRESS } from '@/config/metoken'
+import { buildErc20TransferOp } from '@/features/wallet/api/build-erc20-transfer-op'
+import { transferUsdcFromSigner } from '@/hooks/usdc-wallet-transfers'
+import type { SmartWalletOp, SendOpsResult } from '@/hooks/use-smart-wallet-ops'
+import type { SendToken } from '@/features/wallet/lib/send-token-math'
+
+export interface ExecuteTokenSendParams {
+  token: SendToken
+  chain: Chain
+  amountWei: bigint
+  recipient: Address
+  canSendFromSigner: boolean
+  walletClient: WalletClient | null
+  signerAddress: Address | undefined
+  account: Address | undefined
+  sendOps: (ops: SmartWalletOp[]) => Promise<SendOpsResult>
+}
+
+export interface ExecuteTokenSendResult {
+  usedSigner: boolean
+  txHash?: Hex
+}
+
+export async function executeTokenSend({
+  token,
+  chain,
+  amountWei,
+  recipient,
+  canSendFromSigner,
+  walletClient,
+  signerAddress,
+  account,
+  sendOps,
+}: ExecuteTokenSendParams): Promise<ExecuteTokenSendResult> {
+  if (canSendFromSigner) {
+    if (!walletClient || !signerAddress) {
+      throw new Error('Signer wallet not ready')
+    }
+    const txHash = await transferUsdcFromSigner({
+      walletClient,
+      chain,
+      signerAddress,
+      recipient,
+      amountWei,
+    })
+    return { usedSigner: true, txHash }
+  }
+
+  if (!account) {
+    throw new Error('Smart account not provisioned yet')
+  }
+
+  const tokenAddress =
+    token === 'usdc' ? USDC_ADDRESS_BY_CHAIN_ID[chain.id] : CRTVAI_METOKEN_ADDRESS
+  if (!tokenAddress) {
+    throw new Error('Token not available on this network')
+  }
+
+  const op = buildErc20TransferOp(tokenAddress, recipient, amountWei)
+  const { txHash } = await sendOps([op])
+  return { usedSigner: false, txHash }
+}

--- a/src/features/wallet/api/submit-token-send.ts
+++ b/src/features/wallet/api/submit-token-send.ts
@@ -1,0 +1,52 @@
+import type { QueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+import {
+  getErrorMessage,
+  invalidateUsdcBalance,
+  invalidateWalletTokenBalances,
+} from '@/hooks/invalidate-wallet-balances'
+import {
+  executeTokenSend,
+  type ExecuteTokenSendParams,
+} from '@/features/wallet/api/execute-token-send'
+
+function truncateTxHash(hash: string): string {
+  return `${hash.slice(0, 8)}…${hash.slice(-6)}`
+}
+
+export async function submitTokenSend(
+  params: ExecuteTokenSendParams & {
+    queryClient: QueryClient
+    amountInput: string
+    tokenSymbol: string
+    onOpenChange: (open: boolean) => void
+    clearForm: () => void
+  },
+): Promise<void> {
+  const { queryClient, amountInput, tokenSymbol, onOpenChange, clearForm, chain, ...sendParams } =
+    params
+
+  const { usedSigner, txHash } = await executeTokenSend({ chain, ...sendParams })
+  const successSuffix = txHash ? ` · ${truncateTxHash(txHash)}` : ''
+  toast.success(
+    usedSigner
+      ? `Sent ${amountInput} ${tokenSymbol} from signer wallet`
+      : `Sent ${amountInput} ${tokenSymbol}${successSuffix}`,
+  )
+  clearForm()
+  onOpenChange(false)
+
+  if (usedSigner && sendParams.signerAddress) {
+    invalidateUsdcBalance(queryClient, chain.id, sendParams.signerAddress)
+  }
+  if (sendParams.account) {
+    invalidateUsdcBalance(queryClient, chain.id, sendParams.account)
+    if (!usedSigner) {
+      invalidateWalletTokenBalances(queryClient, chain.id, sendParams.account)
+    }
+  }
+}
+
+export function tokenSendErrorMessage(error: unknown): string {
+  return `Send failed: ${getErrorMessage(error)}`
+}

--- a/src/features/wallet/components/send-token-funding-hints.tsx
+++ b/src/features/wallet/components/send-token-funding-hints.tsx
@@ -1,0 +1,66 @@
+import { Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+interface SendTokenFundingHintsProps {
+  token: 'usdc' | 'crtvai'
+  amountInput: string
+  gasBufferUsdc6: number
+  insufficientBalance: boolean
+  canSendFromSigner: boolean
+  needsMoveToSmartWallet: boolean
+  transferring: boolean
+  sending: boolean
+  onMoveUsdcToSmartWallet: () => void
+}
+
+export function SendTokenFundingHints({
+  token,
+  amountInput,
+  gasBufferUsdc6,
+  insufficientBalance,
+  canSendFromSigner,
+  needsMoveToSmartWallet,
+  transferring,
+  sending,
+  onMoveUsdcToSmartWallet,
+}: SendTokenFundingHintsProps) {
+  return (
+    <>
+      {token === 'usdc' && gasBufferUsdc6 > 0 && (
+        <p className="text-xs text-muted-foreground">
+          A small USDC reserve is kept for transaction gas.
+        </p>
+      )}
+      {insufficientBalance && amountInput && !canSendFromSigner && (
+        <p className="text-xs text-destructive">Insufficient smart wallet balance.</p>
+      )}
+      {canSendFromSigner && (
+        <p className="text-xs text-amber-200/90">
+          USDC is in your signer wallet — send will use that balance directly.
+        </p>
+      )}
+      {needsMoveToSmartWallet && (
+        <div className="space-y-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+          <p>USDC is in your signer wallet. Move it to your smart wallet to send CRTVAI later.</p>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="w-full"
+            disabled={transferring || sending}
+            onClick={onMoveUsdcToSmartWallet}
+          >
+            {transferring ? (
+              <>
+                <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                Moving USDC…
+              </>
+            ) : (
+              'Move USDC to smart wallet'
+            )}
+          </Button>
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/features/wallet/components/send-token-modal.tsx
+++ b/src/features/wallet/components/send-token-modal.tsx
@@ -16,6 +16,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { useSendTokenForm } from '@/features/wallet/hooks/use-send-token-form'
+import { SendTokenFundingHints } from '@/features/wallet/components/send-token-funding-hints'
 import type { SendToken } from '@/features/wallet/lib/send-token-math'
 import { cn } from '@/shared/ui/cn'
 
@@ -113,14 +114,17 @@ export function SendTokenModal({ open, onOpenChange }: SendTokenModalProps) {
               onChange={(e) => form.setAmountInput(e.target.value)}
               disabled={form.sending}
             />
-            {form.token === 'usdc' && form.gasBufferUsdc6 > 0 && (
-              <p className="text-xs text-muted-foreground">
-                A small USDC reserve is kept for transaction gas.
-              </p>
-            )}
-            {form.insufficientBalance && form.amountInput && (
-              <p className="text-xs text-destructive">Insufficient balance.</p>
-            )}
+            <SendTokenFundingHints
+              token={form.token}
+              amountInput={form.amountInput}
+              gasBufferUsdc6={form.gasBufferUsdc6}
+              insufficientBalance={form.insufficientBalance}
+              canSendFromSigner={form.canSendFromSigner}
+              needsMoveToSmartWallet={form.needsMoveToSmartWallet}
+              transferring={form.transferring}
+              sending={form.sending}
+              onMoveUsdcToSmartWallet={() => void form.handleMoveUsdcToSmartWallet()}
+            />
           </div>
 
           {!form.onBase && form.token === 'crtvai' && (
@@ -137,6 +141,8 @@ export function SendTokenModal({ open, onOpenChange }: SendTokenModalProps) {
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />
                 Sending…
               </>
+            ) : form.canSendFromSigner ? (
+              `Send ${form.tokenSymbol} from signer`
             ) : (
               `Send ${form.tokenSymbol}`
             )}

--- a/src/features/wallet/hooks/use-send-token-form.ts
+++ b/src/features/wallet/hooks/use-send-token-form.ts
@@ -1,17 +1,17 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
-import { isAddress } from 'viem'
+import { isAddress, parseUnits } from 'viem'
 import { useQueryClient } from '@tanstack/react-query'
 import { base } from 'viem/chains'
 import { useWalletContext } from '@/context/wallet-context'
 import { useSmartWalletOps } from '@/hooks/use-smart-wallet-ops'
 import { useUsdcBalance } from '@/hooks/use-usdc-balance'
 import { useCrtvaiBalance } from '@/hooks/use-crtvai-balance'
-import { getErrorMessage, invalidateWalletTokenBalances } from '@/hooks/invalidate-wallet-balances'
-import { USDC_ADDRESS_BY_CHAIN_ID } from '@/config/chains'
-import { CRTVAI_DECIMALS, CRTVAI_METOKEN_ADDRESS, USDC_DECIMALS } from '@/config/metoken'
+import { getErrorMessage, invalidateUsdcBalance } from '@/hooks/invalidate-wallet-balances'
+import { CRTVAI_DECIMALS, USDC_DECIMALS } from '@/config/metoken'
 import { getPurchaseGasBufferUsdc6 } from '@/config/gas-sponsorship'
-import { buildErc20TransferOp } from '@/features/wallet/api/build-erc20-transfer-op'
+import { submitTokenSend, tokenSendErrorMessage } from '@/features/wallet/api/submit-token-send'
+import { moveUsdcToSmartWallet } from '@/hooks/usdc-wallet-transfers'
 import {
   computeMaxSendableWei,
   formatMaxSendAmount,
@@ -22,15 +22,12 @@ import {
 
 const BASE_CHAIN_ID = base.id
 
-function truncateTxHash(hash: string): string {
-  return `${hash.slice(0, 8)}…${hash.slice(-6)}`
-}
-
 export function useSendTokenForm(open: boolean, onOpenChange: (open: boolean) => void) {
-  const { account, chain } = useWalletContext()
+  const { account, signerAddress, chain, walletClient } = useWalletContext()
   const queryClient = useQueryClient()
   const { sendOps, ready: walletReady } = useSmartWalletOps()
   const { balance: usdcBalance, formatted: usdcFormatted } = useUsdcBalance(chain, account)
+  const { balance: signerUsdcBalance } = useUsdcBalance(chain, signerAddress)
   const {
     balance: crtvaiBalance,
     formatted: crtvaiFormatted,
@@ -41,6 +38,7 @@ export function useSendTokenForm(open: boolean, onOpenChange: (open: boolean) =>
   const [recipient, setRecipient] = useState('')
   const [amountInput, setAmountInput] = useState('')
   const [sending, setSending] = useState(false)
+  const [transferring, setTransferring] = useState(false)
 
   const onBase = chain?.id === BASE_CHAIN_ID
   const crtvaiAvailable = onBase
@@ -83,31 +81,96 @@ export function useSendTokenForm(open: boolean, onOpenChange: (open: boolean) =>
     [amountWei, token, crtvaiBalance, usdcBalance, gasBufferUsdc6],
   )
 
+  const canSendFromSigner = useMemo(() => {
+    if (token !== 'usdc' || !amountWei || !signerUsdcBalance || !onBase) return false
+    try {
+      const signerRaw = parseUnits(signerUsdcBalance, USDC_DECIMALS)
+      return signerRaw >= amountWei && insufficientBalance
+    } catch {
+      return false
+    }
+  }, [token, amountWei, signerUsdcBalance, onBase, insufficientBalance])
+
+  const needsMoveToSmartWallet = useMemo(() => {
+    if (token !== 'usdc' || !amountWei || !account || !signerUsdcBalance || !usdcBalance)
+      return false
+    try {
+      const smartRaw = parseUnits(usdcBalance, USDC_DECIMALS)
+      const signerRaw = parseUnits(signerUsdcBalance, USDC_DECIMALS)
+      const required = amountWei + BigInt(gasBufferUsdc6)
+      return smartRaw < required && signerRaw > 0n && !canSendFromSigner
+    } catch {
+      return false
+    }
+  }, [token, amountWei, account, signerUsdcBalance, usdcBalance, gasBufferUsdc6, canSendFromSigner])
+
   const handleMax = useCallback(() => {
     setAmountInput(formatMaxSendAmount(maxSendableWei, decimals))
   }, [maxSendableWei, decimals])
 
-  const handleSend = useCallback(async () => {
-    if (!account || !chain || !amountWei || !recipientValid || sendToSelf) return
-
-    const tokenAddress =
-      token === 'usdc' ? USDC_ADDRESS_BY_CHAIN_ID[chain.id] : CRTVAI_METOKEN_ADDRESS
-    if (!tokenAddress) {
-      toast.error('Token not available on this network')
+  const handleMoveUsdcToSmartWallet = useCallback(async () => {
+    if (!walletClient || !account || !signerAddress || !signerUsdcBalance || !chain || !amountWei)
       return
+
+    setTransferring(true)
+    try {
+      const requiredUsdc6 = Number(amountWei + BigInt(gasBufferUsdc6))
+      await moveUsdcToSmartWallet({
+        walletClient,
+        chain,
+        smartAccount: account,
+        signerAddress,
+        signerUsdcBalance,
+        smartUsdcBalance: usdcBalance,
+        requiredUsdc6,
+      })
+      toast.success('USDC moved to smart wallet')
+      invalidateUsdcBalance(queryClient, chain.id, account)
+      invalidateUsdcBalance(queryClient, chain.id, signerAddress)
+    } catch (error) {
+      toast.error(`Transfer failed: ${getErrorMessage(error)}`)
+    } finally {
+      setTransferring(false)
     }
+  }, [
+    walletClient,
+    account,
+    signerAddress,
+    signerUsdcBalance,
+    chain,
+    amountWei,
+    gasBufferUsdc6,
+    usdcBalance,
+    queryClient,
+  ])
+
+  const handleSend = useCallback(async () => {
+    if (!chain || !amountWei || !recipientValid || sendToSelf) return
+    if (!canSendFromSigner && !account) return
 
     setSending(true)
     try {
-      const op = buildErc20TransferOp(tokenAddress, recipient, amountWei)
-      const { txHash } = await sendOps([op])
-      toast.success(`Sent ${amountInput} ${tokenSymbol} · ${truncateTxHash(txHash)}`)
-      setRecipient('')
-      setAmountInput('')
-      onOpenChange(false)
-      invalidateWalletTokenBalances(queryClient, chain.id, account)
+      await submitTokenSend({
+        token,
+        chain,
+        amountWei,
+        recipient,
+        canSendFromSigner,
+        walletClient,
+        signerAddress,
+        account,
+        sendOps,
+        queryClient,
+        amountInput,
+        tokenSymbol,
+        onOpenChange,
+        clearForm: () => {
+          setRecipient('')
+          setAmountInput('')
+        },
+      })
     } catch (error) {
-      toast.error(`Send failed: ${getErrorMessage(error)}`)
+      toast.error(tokenSendErrorMessage(error))
     } finally {
       setSending(false)
     }
@@ -118,6 +181,9 @@ export function useSendTokenForm(open: boolean, onOpenChange: (open: boolean) =>
     recipient,
     recipientValid,
     sendToSelf,
+    canSendFromSigner,
+    walletClient,
+    signerAddress,
     token,
     sendOps,
     amountInput,
@@ -127,12 +193,13 @@ export function useSendTokenForm(open: boolean, onOpenChange: (open: boolean) =>
   ])
 
   const canSend =
-    walletReady &&
+    (walletReady || canSendFromSigner) &&
     recipientValid &&
     !sendToSelf &&
     amountWei !== null &&
-    !insufficientBalance &&
+    (!insufficientBalance || canSendFromSigner) &&
     !sending &&
+    !transferring &&
     (token !== 'crtvai' || onBase)
 
   return {
@@ -154,6 +221,10 @@ export function useSendTokenForm(open: boolean, onOpenChange: (open: boolean) =>
     onBase,
     handleMax,
     handleSend,
+    handleMoveUsdcToSmartWallet,
     canSend,
+    canSendFromSigner,
+    needsMoveToSmartWallet,
+    transferring,
   }
 }

--- a/src/hooks/usdc-wallet-transfers.ts
+++ b/src/hooks/usdc-wallet-transfers.ts
@@ -41,3 +41,34 @@ export async function moveUsdcToSmartWallet({
   await getBasePublicClient().waitForTransactionReceipt({ hash })
   return hash
 }
+
+export interface TransferUsdcFromSignerParams {
+  walletClient: WalletClient
+  chain: Chain
+  signerAddress: Address
+  recipient: Address
+  amountWei: bigint
+}
+
+export async function transferUsdcFromSigner({
+  walletClient,
+  chain,
+  signerAddress,
+  recipient,
+  amountWei,
+}: TransferUsdcFromSignerParams): Promise<`0x${string}`> {
+  if (amountWei <= 0n) {
+    throw new Error('Transfer amount must be positive')
+  }
+
+  const hash = await walletClient.writeContract({
+    address: USDC_BASE_ADDRESS,
+    abi: erc20Abi,
+    functionName: 'transfer',
+    args: [recipient, amountWei],
+    chain,
+    account: signerAddress,
+  })
+  await getBasePublicClient().waitForTransactionReceipt({ hash })
+  return hash
+}


### PR DESCRIPTION
* fix(wallet): request sma-b smart account to avoid EIP-7702 mint failure

Privy embedded wallets cannot sign EIP-7702 authorizations. Pin Alchemy requestAccount to a stable pixels-sca ERC-4337 (sma-b) account so CRTVAI mint uses standard UserOps instead of signAuthorization.



* fix(wallet): repair send flow and signer USDC fallback

Mint and send both failed on production because Alchemy defaulted to EIP-7702 authorization. Consolidate smart-account provisioning, add signer-wallet USDC send fallback, and extract send helpers for fallow.



---------