### PR TITLE
fix(wallet): stop infinite loading on smart account provisioning

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -58,7 +58,8 @@
     "@rolldown/binding-linux-x64-gnu",
     "@tailwindcss/oxide-linux-x64-gnu",
     "@voidzero-dev/vite-plus-linux-x64-gnu",
-    "lightningcss-linux-x64-gnu"
+    "lightningcss-linux-x64-gnu",
+    "mipd"
   ],
   "rules": {},
   "ignoreExports": [
@@ -175,6 +176,11 @@
     {
       "file": "src/features/generative/types.ts",
       "exports": ["*"]
+    },
+    {
+      // Resolved via Vite alias to mipd/dist/esm/store.js at build time.
+      "file": "src/vendor/mipd-store.js",
+      "exports": ["createStore"]
     }
   ]
 }

--- a/src/components/wallet-connect-button.tsx
+++ b/src/components/wallet-connect-button.tsx
@@ -1,5 +1,13 @@
 import { useCallback, useState } from 'react'
-import { ArrowUpRight, Copy, DollarSign, QrCode, Sparkles, Wallet } from 'lucide-react'
+import {
+  AlertTriangle,
+  ArrowUpRight,
+  Copy,
+  DollarSign,
+  QrCode,
+  Sparkles,
+  Wallet,
+} from 'lucide-react'
 import { useWalletContext } from '@/context/wallet-context'
 import { Button } from '@/components/ui/button'
 import {
@@ -49,13 +57,16 @@ export function WalletConnectButton({
     connect,
     disconnect,
     account,
+    signerAddress,
+    smartAccountStatus,
+    retrySmartAccount,
     chain,
     switchChain,
-    isConnecting,
+    error,
   } = useWalletContext()
-  const address = account
-  const { formatted: usdcFormatted } = useUsdcBalance(chain, address)
-  const { formatted: crtvaiFormatted, symbol: crtvaiSymbol } = useCrtvaiBalance(address)
+  const address = account ?? signerAddress
+  const { formatted: usdcFormatted } = useUsdcBalance(chain, account)
+  const { formatted: crtvaiFormatted, symbol: crtvaiSymbol } = useCrtvaiBalance(account)
   const [copied, setCopied] = useState(false)
   const [buyCreditsOpen, setBuyCreditsOpen] = useState(false)
   const [buyOnrampOpen, setBuyOnrampOpen] = useState(false)
@@ -70,8 +81,9 @@ export function WalletConnectButton({
     })
   }, [address])
 
-  const isInitializing = configured && (!ready || isConnecting)
-  const isConnected = Boolean(authenticated && account)
+  const isInitializing = configured && !ready
+  const isConnected = Boolean(authenticated && address)
+  const smartAccountFailed = smartAccountStatus === 'error'
 
   if (isInitializing) {
     return (
@@ -114,6 +126,20 @@ export function WalletConnectButton({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="min-w-[12rem]">
+          {smartAccountFailed && (
+            <DropdownMenuItem
+              onClick={() => retrySmartAccount()}
+              className="flex cursor-pointer items-start gap-2 text-destructive"
+              aria-label="Retry smart wallet setup"
+            >
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
+              <span className="text-xs">
+                Smart wallet setup failed
+                {error?.message ? `: ${error.message}` : ''}. Tap to retry.
+              </span>
+            </DropdownMenuItem>
+          )}
+
           {address && (
             <DropdownMenuItem
               onClick={handleCopyAddress}

--- a/src/components/wallet-connect-button.tsx
+++ b/src/components/wallet-connect-button.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState } from 'react'
+import type { Address, Chain } from 'viem'
 import {
   AlertTriangle,
   ArrowUpRight,
@@ -8,7 +9,10 @@ import {
   Sparkles,
   Wallet,
 } from 'lucide-react'
+import type { SmartAccountStatus } from '@/context/wallet-context'
 import { useWalletContext } from '@/context/wallet-context'
+import { useUsdcBalance } from '@/hooks/use-usdc-balance'
+import { useCrtvaiBalance } from '@/hooks/use-crtvai-balance'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -25,8 +29,6 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { SWITCHABLE_CHAINS } from '@/config/chains'
-import { useUsdcBalance } from '@/hooks/use-usdc-balance'
-import { useCrtvaiBalance } from '@/hooks/use-crtvai-balance'
 import { BuyUsdcOnrampModal } from '@/features/onramp'
 import { BuyCreditsModal } from '@/features/credits'
 import { ReceiveFundsModal, SendTokenModal } from '@/features/wallet'
@@ -37,37 +39,90 @@ function truncateAddress(address: string): string {
   return `${address.slice(0, 6)}…${address.slice(-4)}`
 }
 
-interface WalletConnectButtonProps {
-  connectLabel?: string
-  size?: 'default' | 'sm' | 'lg' | 'icon'
-  compact?: boolean
-  className?: string
+function getWalletDisplayText(
+  account: Address | undefined,
+  signerAddress: Address | undefined,
+): string {
+  if (account) return truncateAddress(account)
+  if (signerAddress) return truncateAddress(signerAddress)
+  return 'Connected'
 }
 
-export function WalletConnectButton({
-  connectLabel = 'Connect wallet',
-  size = 'sm',
-  compact = false,
+interface WalletAddressMenuItemProps {
+  account: Address | undefined
+  isProvisioningSmartAccount: boolean
+  copied: boolean
+  onCopy: () => void
+}
+
+function WalletAddressMenuItem({
+  account,
+  isProvisioningSmartAccount,
+  copied,
+  onCopy,
+}: WalletAddressMenuItemProps) {
+  if (account) {
+    return (
+      <DropdownMenuItem
+        onClick={onCopy}
+        className="flex cursor-pointer items-center justify-between gap-2 font-mono text-xs"
+        aria-label="Copy smart wallet address"
+      >
+        <span>{truncateAddress(account)}</span>
+        <Copy className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden />
+        {copied && <span className="sr-only">Copied</span>}
+      </DropdownMenuItem>
+    )
+  }
+
+  if (isProvisioningSmartAccount) {
+    return (
+      <DropdownMenuItem disabled className="text-xs text-muted-foreground">
+        Smart wallet setting up…
+      </DropdownMenuItem>
+    )
+  }
+
+  return null
+}
+
+interface ConnectedWalletMenuProps {
+  account: Address | undefined
+  signerAddress: Address | undefined
+  smartAccountStatus: SmartAccountStatus
+  isProvisioningSmartAccount: boolean
+  smartAccountActionsReady: boolean
+  error: Error | null
+  chain: Chain
+  usdcFormatted: string
+  crtvaiFormatted: string
+  crtvaiSymbol: string
+  size: 'default' | 'sm' | 'lg' | 'icon'
+  compact: boolean
+  className?: string
+  onRetrySmartAccount: () => void
+  onSwitchChain: (chainId: number) => Promise<void>
+  onDisconnect: () => Promise<void>
+}
+
+function ConnectedWalletMenu({
+  account,
+  signerAddress,
+  smartAccountStatus,
+  isProvisioningSmartAccount,
+  smartAccountActionsReady,
+  error,
+  chain,
+  usdcFormatted,
+  crtvaiFormatted,
+  crtvaiSymbol,
+  size,
+  compact,
   className,
-}: WalletConnectButtonProps) {
-  const {
-    ready,
-    authenticated,
-    configured,
-    connect,
-    disconnect,
-    account,
-    signerAddress,
-    smartAccountStatus,
-    retrySmartAccount,
-    chain,
-    switchChain,
-    error,
-    isProvisioningSmartAccount,
-  } = useWalletContext()
-  const displayAddress = account ?? signerAddress
-  const { formatted: usdcFormatted } = useUsdcBalance(chain, account)
-  const { formatted: crtvaiFormatted, symbol: crtvaiSymbol } = useCrtvaiBalance(account)
+  onRetrySmartAccount,
+  onSwitchChain,
+  onDisconnect,
+}: ConnectedWalletMenuProps) {
   const [copied, setCopied] = useState(false)
   const [buyCreditsOpen, setBuyCreditsOpen] = useState(false)
   const [buyOnrampOpen, setBuyOnrampOpen] = useState(false)
@@ -82,40 +137,8 @@ export function WalletConnectButton({
     })
   }, [account])
 
-  const isInitializing = configured && !ready
-  const isConnected = Boolean(authenticated && displayAddress)
+  const displayText = getWalletDisplayText(account, signerAddress)
   const smartAccountFailed = smartAccountStatus === 'error'
-  const smartAccountActionsReady = Boolean(account)
-
-  if (isInitializing) {
-    return (
-      <Button variant="outline" size={size} className={className} disabled>
-        Loading…
-      </Button>
-    )
-  }
-
-  if (!isConnected) {
-    return (
-      <Button
-        variant="outline"
-        size={size}
-        className={cn('gap-2', className)}
-        onClick={() => connect()}
-        aria-label={configured ? connectLabel : 'Wallet auth not configured'}
-        title={configured ? undefined : 'Set VITE_PRIVY_APP_ID to enable wallet connect'}
-      >
-        <Wallet className="h-4 w-4 shrink-0" />
-        {!compact && <span className="hidden sm:inline">{connectLabel}</span>}
-      </Button>
-    )
-  }
-
-  const displayText = account
-    ? truncateAddress(account)
-    : signerAddress
-      ? truncateAddress(signerAddress)
-      : 'Connected'
 
   return (
     <>
@@ -134,7 +157,7 @@ export function WalletConnectButton({
         <DropdownMenuContent align="end" className="min-w-[12rem]">
           {smartAccountFailed && (
             <DropdownMenuItem
-              onClick={() => retrySmartAccount()}
+              onClick={onRetrySmartAccount}
               className="flex cursor-pointer items-start gap-2 text-destructive"
               aria-label="Retry smart wallet setup"
             >
@@ -146,21 +169,12 @@ export function WalletConnectButton({
             </DropdownMenuItem>
           )}
 
-          {account ? (
-            <DropdownMenuItem
-              onClick={handleCopyAddress}
-              className="flex cursor-pointer items-center justify-between gap-2 font-mono text-xs"
-              aria-label="Copy smart wallet address"
-            >
-              <span>{truncateAddress(account)}</span>
-              <Copy className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden />
-              {copied && <span className="sr-only">Copied</span>}
-            </DropdownMenuItem>
-          ) : isProvisioningSmartAccount ? (
-            <DropdownMenuItem disabled className="text-xs text-muted-foreground">
-              Smart wallet setting up…
-            </DropdownMenuItem>
-          ) : null}
+          <WalletAddressMenuItem
+            account={account}
+            isProvisioningSmartAccount={isProvisioningSmartAccount}
+            copied={copied}
+            onCopy={handleCopyAddress}
+          />
 
           <DropdownMenuItem disabled className="text-muted-foreground">
             USDC: {usdcFormatted}
@@ -169,6 +183,7 @@ export function WalletConnectButton({
           <DropdownMenuItem disabled className="text-muted-foreground">
             {crtvaiSymbol}: {crtvaiFormatted}
           </DropdownMenuItem>
+
           <DropdownMenuItem
             onClick={() => setReceiveOpen(true)}
             disabled={!smartAccountActionsReady}
@@ -217,7 +232,7 @@ export function WalletConnectButton({
               value={chain.id.toString()}
               onValueChange={(value) => {
                 const c = SWITCHABLE_CHAINS.find((ch) => ch.id.toString() === value)
-                if (c) void switchChain(c.id)
+                if (c) void onSwitchChain(c.id)
               }}
             >
               <SelectTrigger className="h-8 w-full text-xs">
@@ -233,7 +248,7 @@ export function WalletConnectButton({
             </Select>
           </div>
           <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={() => disconnect()}>Disconnect</DropdownMenuItem>
+          <DropdownMenuItem onClick={() => void onDisconnect()}>Disconnect</DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
 
@@ -242,5 +257,87 @@ export function WalletConnectButton({
       <ReceiveFundsModal open={receiveOpen} onOpenChange={setReceiveOpen} />
       <SendTokenModal open={sendOpen} onOpenChange={setSendOpen} />
     </>
+  )
+}
+
+interface WalletConnectButtonProps {
+  connectLabel?: string
+  size?: 'default' | 'sm' | 'lg' | 'icon'
+  compact?: boolean
+  className?: string
+}
+
+export function WalletConnectButton({
+  connectLabel = 'Connect wallet',
+  size = 'sm',
+  compact = false,
+  className,
+}: WalletConnectButtonProps) {
+  const {
+    ready,
+    authenticated,
+    configured,
+    connect,
+    disconnect,
+    account,
+    signerAddress,
+    smartAccountStatus,
+    retrySmartAccount,
+    chain,
+    switchChain,
+    error,
+    isProvisioningSmartAccount,
+  } = useWalletContext()
+  const displayAddress = account ?? signerAddress
+  const { formatted: usdcFormatted } = useUsdcBalance(chain, account)
+  const { formatted: crtvaiFormatted, symbol: crtvaiSymbol } = useCrtvaiBalance(account)
+
+  const isInitializing = configured && !ready
+  const isConnected = Boolean(authenticated && displayAddress)
+  const smartAccountActionsReady = Boolean(account)
+
+  if (isInitializing) {
+    return (
+      <Button variant="outline" size={size} className={className} disabled>
+        Loading…
+      </Button>
+    )
+  }
+
+  if (!isConnected) {
+    return (
+      <Button
+        variant="outline"
+        size={size}
+        className={cn('gap-2', className)}
+        onClick={() => connect()}
+        aria-label={configured ? connectLabel : 'Wallet auth not configured'}
+        title={configured ? undefined : 'Set VITE_PRIVY_APP_ID to enable wallet connect'}
+      >
+        <Wallet className="h-4 w-4 shrink-0" />
+        {!compact && <span className="hidden sm:inline">{connectLabel}</span>}
+      </Button>
+    )
+  }
+
+  return (
+    <ConnectedWalletMenu
+      account={account}
+      signerAddress={signerAddress}
+      smartAccountStatus={smartAccountStatus}
+      isProvisioningSmartAccount={isProvisioningSmartAccount}
+      smartAccountActionsReady={smartAccountActionsReady}
+      error={error}
+      chain={chain}
+      usdcFormatted={usdcFormatted}
+      crtvaiFormatted={crtvaiFormatted}
+      crtvaiSymbol={crtvaiSymbol}
+      size={size}
+      compact={compact}
+      className={className}
+      onRetrySmartAccount={retrySmartAccount}
+      onSwitchChain={switchChain}
+      onDisconnect={disconnect}
+    />
   )
 }

--- a/src/components/wallet-connect-button.tsx
+++ b/src/components/wallet-connect-button.tsx
@@ -63,8 +63,9 @@ export function WalletConnectButton({
     chain,
     switchChain,
     error,
+    isProvisioningSmartAccount,
   } = useWalletContext()
-  const address = account ?? signerAddress
+  const displayAddress = account ?? signerAddress
   const { formatted: usdcFormatted } = useUsdcBalance(chain, account)
   const { formatted: crtvaiFormatted, symbol: crtvaiSymbol } = useCrtvaiBalance(account)
   const [copied, setCopied] = useState(false)
@@ -74,16 +75,17 @@ export function WalletConnectButton({
   const [sendOpen, setSendOpen] = useState(false)
 
   const handleCopyAddress = useCallback(() => {
-    if (!address) return
-    void navigator.clipboard.writeText(address).then(() => {
+    if (!account) return
+    void navigator.clipboard.writeText(account).then(() => {
       setCopied(true)
       window.setTimeout(() => setCopied(false), 1500)
     })
-  }, [address])
+  }, [account])
 
   const isInitializing = configured && !ready
-  const isConnected = Boolean(authenticated && address)
+  const isConnected = Boolean(authenticated && displayAddress)
   const smartAccountFailed = smartAccountStatus === 'error'
+  const smartAccountActionsReady = Boolean(account)
 
   if (isInitializing) {
     return (
@@ -109,7 +111,11 @@ export function WalletConnectButton({
     )
   }
 
-  const displayText = address ? truncateAddress(address) : 'Connected'
+  const displayText = account
+    ? truncateAddress(account)
+    : signerAddress
+      ? truncateAddress(signerAddress)
+      : 'Connected'
 
   return (
     <>
@@ -140,17 +146,21 @@ export function WalletConnectButton({
             </DropdownMenuItem>
           )}
 
-          {address && (
+          {account ? (
             <DropdownMenuItem
               onClick={handleCopyAddress}
               className="flex cursor-pointer items-center justify-between gap-2 font-mono text-xs"
-              aria-label="Copy full address"
+              aria-label="Copy smart wallet address"
             >
-              <span>{truncateAddress(address)}</span>
+              <span>{truncateAddress(account)}</span>
               <Copy className="h-3.5 w-3.5 shrink-0 opacity-70" aria-hidden />
               {copied && <span className="sr-only">Copied</span>}
             </DropdownMenuItem>
-          )}
+          ) : isProvisioningSmartAccount ? (
+            <DropdownMenuItem disabled className="text-xs text-muted-foreground">
+              Smart wallet setting up…
+            </DropdownMenuItem>
+          ) : null}
 
           <DropdownMenuItem disabled className="text-muted-foreground">
             USDC: {usdcFormatted}
@@ -161,6 +171,7 @@ export function WalletConnectButton({
           </DropdownMenuItem>
           <DropdownMenuItem
             onClick={() => setReceiveOpen(true)}
+            disabled={!smartAccountActionsReady}
             className="flex cursor-pointer items-center gap-2"
             aria-label="Receive funds"
           >
@@ -170,6 +181,7 @@ export function WalletConnectButton({
 
           <DropdownMenuItem
             onClick={() => setSendOpen(true)}
+            disabled={!smartAccountActionsReady}
             className="flex cursor-pointer items-center gap-2"
             aria-label="Send tokens"
           >
@@ -179,6 +191,7 @@ export function WalletConnectButton({
 
           <DropdownMenuItem
             onClick={() => setBuyOnrampOpen(true)}
+            disabled={!smartAccountActionsReady}
             className="flex cursor-pointer items-center gap-2"
             aria-label="Buy USDC"
           >
@@ -188,6 +201,7 @@ export function WalletConnectButton({
 
           <DropdownMenuItem
             onClick={() => setBuyCreditsOpen(true)}
+            disabled={!smartAccountActionsReady}
             className="flex cursor-pointer items-center gap-2"
             aria-label="Buy CRTVAI"
           >

--- a/src/context/wallet-context.tsx
+++ b/src/context/wallet-context.tsx
@@ -28,6 +28,10 @@ import { DEFAULT_CHAIN, getChainById } from '@/config/chains'
 
 type SmartWalletClient = AlchemySmartWalletClient & SwapActions
 
+export type SmartAccountStatus = 'idle' | 'pending' | 'ready' | 'error'
+
+const SMART_ACCOUNT_REQUEST_TIMEOUT_MS = 30_000
+
 export interface WalletContextValue {
   ready: boolean
   authenticated: boolean
@@ -40,6 +44,10 @@ export interface WalletContextValue {
   account: Address | undefined
   /** Privy signer EOA (embedded or external wallet). */
   signerAddress: Address | undefined
+  smartAccountStatus: SmartAccountStatus
+  /** True while Alchemy smart account provisioning is in flight. */
+  isProvisioningSmartAccount: boolean
+  retrySmartAccount: () => void
   user: User | null
   walletClient: WalletClient | null
   smartWalletClient: SmartWalletClient | null
@@ -69,6 +77,8 @@ function WalletContextInner({ children }: { children: ReactNode }) {
   const { wallets, ready: walletsReady } = useWallets()
   const [walletClient, setWalletClient] = useState<WalletClient | null>(null)
   const [smartAccountAddress, setSmartAccountAddress] = useState<Address | undefined>()
+  const [smartAccountStatus, setSmartAccountStatus] = useState<SmartAccountStatus>('idle')
+  const [smartAccountRetryKey, setSmartAccountRetryKey] = useState(0)
   const [chain, setChain] = useState<Chain>(DEFAULT_CHAIN)
   const [isConnecting, setIsConnecting] = useState(false)
   const [error, setError] = useState<Error | null>(null)
@@ -130,19 +140,31 @@ function WalletContextInner({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (!bootstrapSmartWalletClient || !signerAddress) {
       setSmartAccountAddress(undefined)
+      setSmartAccountStatus('idle')
       return
     }
     let cancelled = false
+    setSmartAccountStatus('pending')
     void (async () => {
       try {
-        const smartAccount = await bootstrapSmartWalletClient.requestAccount({ signerAddress })
+        const smartAccount = await Promise.race([
+          bootstrapSmartWalletClient.requestAccount({ signerAddress }),
+          new Promise<never>((_, reject) => {
+            window.setTimeout(
+              () => reject(new Error('Smart account provisioning timed out')),
+              SMART_ACCOUNT_REQUEST_TIMEOUT_MS,
+            )
+          }),
+        ])
         if (!cancelled) {
           setSmartAccountAddress(smartAccount.address)
+          setSmartAccountStatus('ready')
           setError(null)
         }
       } catch (e) {
         if (!cancelled) {
           setSmartAccountAddress(undefined)
+          setSmartAccountStatus('error')
           setError(e instanceof Error ? e : new Error(String(e)))
         }
       }
@@ -150,7 +172,13 @@ function WalletContextInner({ children }: { children: ReactNode }) {
     return () => {
       cancelled = true
     }
-  }, [bootstrapSmartWalletClient, signerAddress])
+  }, [bootstrapSmartWalletClient, signerAddress, smartAccountRetryKey])
+
+  const retrySmartAccount = useCallback(() => {
+    setError(null)
+    setSmartAccountStatus('idle')
+    setSmartAccountRetryKey((key) => key + 1)
+  }, [])
 
   const smartWalletClient = useMemo<SmartWalletClient | null>(() => {
     if (!walletClient || !ALCHEMY_API_KEY || !smartAccountAddress) return null
@@ -185,8 +213,8 @@ function WalletContextInner({ children }: { children: ReactNode }) {
     [activeWallet],
   )
 
-  const walletReady =
-    ready && walletsReady && (!authenticated || !ALCHEMY_API_KEY || Boolean(smartAccountAddress))
+  const walletReady = ready && walletsReady
+  const isProvisioningSmartAccount = smartAccountStatus === 'pending'
 
   const value = useMemo(
     () => ({
@@ -198,6 +226,9 @@ function WalletContextInner({ children }: { children: ReactNode }) {
       wallet: activeWallet,
       account: smartAccountAddress,
       signerAddress,
+      smartAccountStatus,
+      isProvisioningSmartAccount,
+      retrySmartAccount,
       user,
       walletClient,
       smartWalletClient,
@@ -215,6 +246,9 @@ function WalletContextInner({ children }: { children: ReactNode }) {
       activeWallet,
       smartAccountAddress,
       signerAddress,
+      smartAccountStatus,
+      isProvisioningSmartAccount,
+      retrySmartAccount,
       user,
       walletClient,
       smartWalletClient,
@@ -250,6 +284,9 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       wallet: null,
       account: undefined,
       signerAddress: undefined,
+      smartAccountStatus: 'idle',
+      isProvisioningSmartAccount: false,
+      retrySmartAccount: () => {},
       user: null,
       walletClient: null,
       smartWalletClient: null,

--- a/src/routes/projects/index.tsx
+++ b/src/routes/projects/index.tsx
@@ -64,7 +64,7 @@ function ProjectsIndex() {
     connect,
   } = useWalletContext()
   const walletConnected = Boolean(authenticated && wallet)
-  // Wait for Privy to finish initializing before treating the user as disconnected.
+  // Wait for Privy init only — smart account provisioning runs in the background.
   const requireWalletForNewProject = walletConfigured && walletReady && !walletConnected
   const walletInitializing = walletConfigured && !walletReady
   const [editingProject, setEditingProject] = useState<Project | null>(null)

--- a/src/vendor/mipd-store.js
+++ b/src/vendor/mipd-store.js
@@ -1,0 +1,50 @@
+import { requestProviders } from 'mipd/dist/esm/utils.js'
+
+function isValidProviderDetail(providerDetail) {
+  return Boolean(providerDetail?.info?.uuid)
+}
+
+export function createStore() {
+  const listeners = new Set()
+  let providerDetails = []
+  const request = () =>
+    requestProviders((providerDetail) => {
+      if (!isValidProviderDetail(providerDetail)) return
+      if (providerDetails.some((existing) => existing?.info?.uuid === providerDetail.info.uuid)) {
+        return
+      }
+      providerDetails = [...providerDetails, providerDetail]
+      listeners.forEach((listener) => listener(providerDetails, { added: [providerDetail] }))
+    })
+  let unwatch = request()
+  return {
+    _listeners() {
+      return listeners
+    },
+    clear() {
+      listeners.forEach((listener) => listener([], { removed: [...providerDetails] }))
+      providerDetails = []
+    },
+    destroy() {
+      this.clear()
+      listeners.clear()
+      unwatch?.()
+    },
+    findProvider({ rdns }) {
+      return providerDetails.find((providerDetail) => providerDetail?.info?.rdns === rdns)
+    },
+    getProviders() {
+      return providerDetails
+    },
+    reset() {
+      this.clear()
+      unwatch?.()
+      unwatch = request()
+    },
+    subscribe(listener, { emitImmediately } = {}) {
+      listeners.add(listener)
+      if (emitImmediately) listener(providerDetails, { added: providerDetails })
+      return () => listeners.delete(listener)
+    },
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -254,6 +254,9 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),
+      'mipd/dist/esm/store.js': fileURLToPath(
+        new URL('./src/vendor/mipd-store.js', import.meta.url),
+      ),
     },
     // Keep every UI dependency on the same React dispatcher. This also prevents
     // an optimizer refresh from leaving Radix on a stale React module during HMR.


### PR DESCRIPTION
## Summary
- Decouple Privy init from Alchemy smart-account provisioning so the wallet button no longer spins forever when `requestAccount` fails or hangs
- Add a 30s provisioning timeout, retry UI, and signer-address fallback for the connected state
- Gate copy/receive/send/onramp actions on the smart account so users cannot copy the signer EOA during setup
- Add a null-safe mipd store shim to prevent EIP-6963 extension crashes

## Test plan
- [ ] Fresh visit (logged out): wallet shows "Connect wallet" after Privy init, not infinite loading
- [ ] Returning logged-in user: wallet address appears immediately; smart account loads in background
- [ ] Smart account failure: retry affordance appears instead of eternal spinner
- [ ] Copy address only available once smart account is provisioned
- [ ] With wallet browser extension: no mipd `Cannot read properties of null (reading 'info')` crash


Made with [Cursor](https://cursor.com)